### PR TITLE
Update application ID

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="com.mb.android" android-versionCode="20000854" id="com.emby.mobile" ios-CFBundleIdentifier="com.emby.mobile" version="2.8.54" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="20000854" id="org.jellyfin.mobile" version="2.8.54" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Jellyfin</name>
     <description>
     Jellyfin Mobile

--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<manifest android:hardwareAccelerated="true" android:versionCode="20000854" android:versionName="2.8.54" package="com.mb.android" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest android:hardwareAccelerated="true" android:versionCode="20000854" android:versionName="2.8.54" package="org.jellyfin.mobile" xmlns:android="http://schemas.android.com/apk/res/android">
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:resizeable="true" android:smallScreens="true" android:xlargeScreens="true" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/platforms/android/res/xml/config.xml
+++ b/platforms/android/res/xml/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="com.mb.android" android-versionCode="20000854" id="com.emby.mobile" ios-CFBundleIdentifier="com.emby.mobile" version="2.8.54" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="20000854" id="org.jellyfin.mobile" version="2.8.54" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <feature name="Chromecast">
         <param name="android-package" value="acidhax.cordova.chromecast.Chromecast" />
     </feature>

--- a/platforms/android/src/acidhax/cordova/chromecast/Chromecast.java
+++ b/platforms/android/src/acidhax/cordova/chromecast/Chromecast.java
@@ -10,13 +10,13 @@ import java.util.List;
 import java.util.ArrayList;
 
 import com.google.android.gms.cast.CastMediaControlIntent;
-import com.mb.android.MainActivity;
 import com.mb.android.logging.AppLogger;
 
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
+import org.jellyfin.mobile.MainActivity;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/platforms/android/src/com/mb/android/media/MediaRes.java
+++ b/platforms/android/src/com/mb/android/media/MediaRes.java
@@ -1,6 +1,6 @@
 package com.mb.android.media;
 
-import com.mb.android.R;
+import org.jellyfin.mobile.R;
 
 import mediabrowser.apiinteraction.android.mediabrowser.IMediaRes;
 

--- a/platforms/android/src/com/mb/android/media/MediaService.java
+++ b/platforms/android/src/com/mb/android/media/MediaService.java
@@ -2,9 +2,11 @@ package com.mb.android.media;
 
 import android.annotation.TargetApi;
 
-import com.mb.android.MainActivity;
 import com.mb.android.api.ApiClientBridge;
 import com.mb.android.logging.AppLogger;
+
+import org.jellyfin.mobile.MainActivity;
+
 import mediabrowser.apiinteraction.android.VolleyHttpClient;
 import mediabrowser.apiinteraction.android.mediabrowser.BaseMediaBrowserService;
 import mediabrowser.apiinteraction.android.mediabrowser.IMediaRes;

--- a/platforms/android/src/com/mb/android/media/PlaybackService.java
+++ b/platforms/android/src/com/mb/android/media/PlaybackService.java
@@ -40,13 +40,13 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.widget.Toast;
 
-import com.mb.android.BuildConfig;
-import com.mb.android.MainActivity;
-import com.mb.android.R;
 import com.mb.android.api.ApiClientBridge;
 import com.mb.android.logging.AppLogger;
 import com.mb.android.media.legacy.RemoteControlClientReceiver;
 
+import org.jellyfin.mobile.BuildConfig;
+import org.jellyfin.mobile.MainActivity;
+import org.jellyfin.mobile.R;
 import org.videolan.libvlc.IVLCVout;
 import org.videolan.libvlc.LibVLC;
 import org.videolan.libvlc.Media;

--- a/platforms/android/src/com/mb/android/media/RemotePlayerService.java
+++ b/platforms/android/src/com/mb/android/media/RemotePlayerService.java
@@ -20,10 +20,11 @@ import android.os.IBinder;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.util.Log;
 
-import com.mb.android.MainActivity;
-import com.mb.android.R;
 import com.mb.android.api.ApiClientBridge;
 import com.mb.android.logging.AppLogger;
+
+import org.jellyfin.mobile.MainActivity;
+import org.jellyfin.mobile.R;
 
 import mediabrowser.apiinteraction.Response;
 import mediabrowser.apiinteraction.android.VolleyHttpClient;

--- a/platforms/android/src/com/mb/android/media/Strings.java
+++ b/platforms/android/src/com/mb/android/media/Strings.java
@@ -1,6 +1,6 @@
 package com.mb.android.media;
 
-import com.mb.android.BuildConfig;
+import org.jellyfin.mobile.BuildConfig;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;

--- a/platforms/android/src/com/mb/android/media/VideoPlayerActivity.java
+++ b/platforms/android/src/com/mb/android/media/VideoPlayerActivity.java
@@ -65,12 +65,12 @@ import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.mb.android.BuildConfig;
-import com.mb.android.R;
 import com.mb.android.api.ApiClientBridge;
 import com.mb.android.logging.AppLogger;
 import com.mb.android.preferences.PreferencesActivity;
 
+import org.jellyfin.mobile.BuildConfig;
+import org.jellyfin.mobile.R;
 import org.videolan.libvlc.IVLCVout;
 import org.videolan.libvlc.LibVLC;
 import org.videolan.libvlc.Media;

--- a/platforms/android/src/com/mb/android/media/VlcEventHandler.java
+++ b/platforms/android/src/com/mb/android/media/VlcEventHandler.java
@@ -1,6 +1,6 @@
 package com.mb.android.media;
 
-import com.mb.android.MainActivity;
+import org.jellyfin.mobile.MainActivity;
 import org.videolan.libvlc.MediaPlayer;
 
 import mediabrowser.model.logging.ILogger;

--- a/platforms/android/src/com/mb/android/media/legacy/KitKatMediaService.java
+++ b/platforms/android/src/com/mb/android/media/legacy/KitKatMediaService.java
@@ -34,9 +34,6 @@ import android.util.Log;
 import android.widget.RemoteViews;
 import android.widget.Toast;
 
-import com.mb.android.BuildConfig;
-import com.mb.android.MainActivity;
-import com.mb.android.R;
 import com.mb.android.api.ApiClientBridge;
 import com.mb.android.logging.AppLogger;
 import com.mb.android.media.MediaWrapper;
@@ -47,6 +44,9 @@ import com.mb.android.media.VLCOptions;
 import com.mb.android.media.VlcEventHandler;
 import com.mb.android.media.WeakHandler;
 
+import org.jellyfin.mobile.BuildConfig;
+import org.jellyfin.mobile.MainActivity;
+import org.jellyfin.mobile.R;
 import org.videolan.libvlc.IVLCVout;
 import org.videolan.libvlc.LibVLC;
 import org.videolan.libvlc.Media;

--- a/platforms/android/src/com/mb/android/webviews/MySystemWebViewClient.java
+++ b/platforms/android/src/com/mb/android/webviews/MySystemWebViewClient.java
@@ -5,10 +5,9 @@ import android.net.http.SslError;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 
-import com.mb.android.MainActivity;
-
 import org.apache.cordova.engine.SystemWebViewClient;
 import org.apache.cordova.engine.SystemWebViewEngine;
+import org.jellyfin.mobile.MainActivity;
 
 import mediabrowser.apiinteraction.Response;
 

--- a/platforms/android/src/org/jellyfin/mobile/MainActivity.java
+++ b/platforms/android/src/org/jellyfin/mobile/MainActivity.java
@@ -17,7 +17,7 @@
        under the License.
  */
 
-package com.mb.android;
+package org.jellyfin.mobile;
 
 import android.Manifest;
 import android.app.Activity;


### PR DESCRIPTION
Part of the continuing effort of rebranding from Emby to Jellyfin #3.

This changes the app ID used for Android (and iOS if we can get it working) to `org.jellyfin.mobile`.