### PR TITLE
Remove redundant Android versionCode

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,8 +2,7 @@
 <widget xmlns="http://www.w3.org/ns/widgets"
     xmlns:cdv="http://cordova.apache.org/ns/1.0"
     id="org.jellyfin.mobile"
-    version="2.8.54"
-    android-versionCode="20000854">
+    version="2.8.54">
     <name>Jellyfin</name>
     <description>
     Jellyfin Mobile

--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<manifest android:hardwareAccelerated="true" android:versionCode="20000854" android:versionName="2.8.54" package="org.jellyfin.mobile" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest android:hardwareAccelerated="true" android:versionCode="20854" android:versionName="2.8.54" package="org.jellyfin.mobile" xmlns:android="http://schemas.android.com/apk/res/android">
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:resizeable="true" android:smallScreens="true" android:xlargeScreens="true" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/platforms/android/res/xml/config.xml
+++ b/platforms/android/res/xml/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="20000854" id="org.jellyfin.mobile" version="2.8.54" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.jellyfin.mobile" version="2.8.54" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <feature name="Chromecast">
         <param name="android-package" value="acidhax.cordova.chromecast.Chromecast" />
     </feature>


### PR DESCRIPTION
This versionCode is redundant since it is the same as version. This would be useful if we were targeting multiple platforms and had an Android specific version number.