### PR TITLE
Avoid double-debug in output APK file

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -18,7 +18,7 @@ case ${RELEASE} in
         RFLAG="--release"
     ;;
     'debug')
-        RELEASE_SUFFIX="debug_"
+        RELEASE_SUFFIX=""
         NODE_ENV="development"
         RFLAG=""
     ;;


### PR DESCRIPTION
Otherwise, it generates `jellyfin-android_debug_debug.apk`.