### PR TITLE
default layout 'mobile' since this app is for android devices

### DIFF
--- a/src/cordova/apphost.js
+++ b/src/cordova/apphost.js
@@ -227,7 +227,7 @@ define(['appStorage', 'browser'], function (appStorage, browser) {
         moreIcon: 'dots-vert',
         getSyncProfile: getDeviceProfile,
         getDefaultLayout: function() {
-            // FIXME: Needs Implementation!
+            return 'mobile';
         },
         getDeviceProfile: function() {
             return getDeviceProfile();


### PR DESCRIPTION
This should fix the layout being default to tv for some resolutions (tablets).

Since this app in meant to be run on android smartphones and tablets, its seems fit to assume the layout is of type mobile.