### PR TITLE
Mirror subtitle profiles present in jellyfin-web to apphost.js 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@
  - [thornbill](https://github.com/thornbill)
  - [dkanada](https://github.com/dkanada)
  - [grafixeyehero](https://github.com/grafixeyehero)
+ - [vitorsemeano](https://github.com/vitorsemeano)
  
 # Emby Contributors
 

--- a/src/cordova/apphost.js
+++ b/src/cordova/apphost.js
@@ -25,8 +25,7 @@ define(['appStorage', 'browser'], function (appStorage, browser) {
 
             require(['browserdeviceprofile'], function (profileBuilder) {
 
-                var profile = profileBuilder({
-                });
+                var profile = profileBuilder();
 
                 profile.DirectPlayProfiles.push({
                     // TODO investigate ac3 support
@@ -39,75 +38,16 @@ define(['appStorage', 'browser'], function (appStorage, browser) {
                     return i.Type == 'Audio';
                 });
 
-                profile.SubtitleProfiles = [];
-                profile.SubtitleProfiles.push({
-                    Format: 'srt',
-                    Method: 'External'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'ssa',
-                    Method: 'External'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'ass',
-                    Method: 'External'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'srt',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'subrip',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'ass',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'ssa',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'dvb_teletext',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'dvb_subtitle',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'dvbsub',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'pgs',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'pgssub',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'dvdsub',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'vtt',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'sub',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'idx',
-                    Method: 'Embed'
-                });
-                profile.SubtitleProfiles.push({
-                    Format: 'smi',
-                    Method: 'Embed'
-                });
+                profile.SubtitleProfiles.push(
+                    {
+                        Format: 'ssa',
+                        Method: 'External'
+                    },
+                    {
+                        Format: 'ass',
+                        Method: 'External'
+                    }
+                );
 
                 profile.CodecProfiles.push({
                     Type: 'Video',


### PR DESCRIPTION
In the current state of the jellyfin-web repo, the subtitle profiles defined in the android app don't work as expected. Since the android app uses a webview (very similar to running inside chrome) to render a web server, one can assume the subtitle profiles set in the jellyfin-web repo will also work with the android app. 

For instance, if the profile is set for a given subtitle format, that impacts on the deliveryMethod used for that subtitle. When omitting that format, assumes a different behavior, giving a workable deliveryMethod to the client.

This can be related to the fact that, recently the default html5 player replaced a dedicated player in jellyfin-web.