### PR TITLE
Build improvements for wrapping infrastructure

### DIFF
--- a/build
+++ b/build
@@ -62,5 +62,5 @@ docker run --rm -e "RELEASE=${release}" -v "${package_temporary_dir}:/dist" "${i
 chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
   || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the APKs to the parent directory
-mkdir ../bin &>/dev/null || true
+mkdir -p ../bin &>/dev/null
 mv "${package_temporary_dir}"/apk/*.apk ../bin

--- a/build
+++ b/build
@@ -62,4 +62,5 @@ docker run --rm -e "RELEASE=${release}" -v "${package_temporary_dir}:/dist" "${i
 chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
   || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
 # Move the APKs to the parent directory
-mv "${package_temporary_dir}"/apk/*.apk ../
+mkdir ../bin &>/dev/null || true
+mv "${package_temporary_dir}"/apk/*.apk ../bin

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,8 @@
+---
+# We just wrap `build` so this is really it
+name: "jellyfin-android"
+version: "10.0.0"
+packages:
+  - production
+  - unminified
+  - debug


### PR DESCRIPTION
**Changes**
Makes some minor modifications to better support the wrapping `jellyfin-build` infrastructure. Specifically:
1. Put the output in `../bin` rather than `../`, which is cleaner, and easier to grab from.
1. Add a `build.yaml` configuration listing the available package types. `build` within the repo doesn't use this (yet).