### PR TITLE
Fix exception "java.lang.ClassNotFoundException: Didn't find class "org.apache.http.ProtocolVersion" for API level 28 and greater

### DIFF
--- a/src/NativeShell/plugin.xml
+++ b/src/NativeShell/plugin.xml
@@ -30,7 +30,6 @@
     <source-file src="src/Constants.java" target-dir="src/org/jellyfin/mobile" />
     <framework src="src/build.gradle" custom="true" type="gradleReference" />
     <framework src="com.android.support:support-v4:27.1.1" />
-    <framework src="com.mcxiaoke.volley:library:1.0.19" />
     <framework src="com.squareup.okhttp3:okhttp:3.13.1" />
     <framework src="com.squareup.okhttp3:okhttp-urlconnection:3.13.1" />
     <resource-file src="res/drawable-hdpi/ic_notification.png" target="res/drawable-hdpi/ic_notification.png" />

--- a/src/NativeShell/src/build.gradle
+++ b/src/NativeShell/src/build.gradle
@@ -7,5 +7,5 @@ allprojects {
 }
 
 dependencies {
-    compile 'com.github.jellyfin:jellyfin-apiclient-java:1b76c9fd86'
+    implementation 'com.github.jellyfin:jellyfin-apiclient-java:master'
 }


### PR DESCRIPTION
This PR should address the exception "java.lang.ClassNotFoundException: Didn't find class "org.apache.http.ProtocolVersion"

This exception is associated with the usage of a deprecated library https://github.com/mcxiaoke/android-volley

Since this library is used for the jellyfin-apiclient-java dependency, and updated for the most recent volley version available (abou 2 days ago), i updated the dependency for the master version in build.gradle of NativeShell.

I also removed the old dependency in plugin.xml of NativeShell.

This was tested with a emulator with API level 28 (Pie). I also used the changes made in #105, so partially i also tested those changes and they are working as intended.