### PR TITLE
Fix android wear multimedia notification play/pause button not working

### DIFF
--- a/src/NativeShell/src/RemotePlayerService.java
+++ b/src/NativeShell/src/RemotePlayerService.java
@@ -192,7 +192,7 @@ public class RemotePlayerService extends Service {
 
             PlaybackState.Builder stateBuilder = new PlaybackState.Builder();
             stateBuilder.setActiveQueueItemId(MediaSession.QueueItem.UNKNOWN_ID);
-            long actions = PlaybackState.ACTION_PLAY_PAUSE | PlaybackState.ACTION_STOP | PlaybackState.ACTION_SKIP_TO_NEXT | PlaybackState.ACTION_SKIP_TO_PREVIOUS | PlaybackState.ACTION_SEEK_TO | PlaybackState.ACTION_SET_RATING;
+            long actions = PlaybackState.ACTION_PLAY_PAUSE | PlaybackState.ACTION_STOP | PlaybackState.ACTION_SKIP_TO_NEXT | PlaybackState.ACTION_SKIP_TO_PREVIOUS | PlaybackState.ACTION_SEEK_TO | PlaybackState.ACTION_SET_RATING | PlaybackState.ACTION_PLAY | PlaybackState.ACTION_PAUSE;
             stateBuilder.setActions(actions);
 
             if (isPaused) {


### PR DESCRIPTION
added the playstate actions that android wear multimedia notification play/pause button sends to the list of accepted media buttons