### PR TITLE
Add missing import

### DIFF
--- a/src/NativeShell/src/RemotePlayerService.java
+++ b/src/NativeShell/src/RemotePlayerService.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.media.MediaMetadata;
 import android.media.Rating;
+import android.media.VolumeProvider;
 import android.media.session.MediaController;
 import android.media.session.MediaSession;
 import android.media.session.MediaSession.Callback;


### PR DESCRIPTION
Adds a missing import statement in the NativeShell plugin which caused the build to fail.