### PR TITLE
Add --remote to fetch most recent master in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Jellyfin Mobile is an Android app built with Cordova.
    ```sh
    git clone https://github.com/jellyfin/jellyfin-android.git
    cd jellyfin-android
-   git submodule update --init --recursive
+   git submodule update --init --recursive --remote
    ```
 2. Install Cordova and other build dependencies via npm in the project directory.
    ```sh


### PR DESCRIPTION
This adds the missing --remote flag, in README, to fetch the most recent master version of jellyfin-web when building the app.