### PR TITLE
Modify gulpfile for upcoming web changes

### DIFF
--- a/build
+++ b/build
@@ -27,23 +27,8 @@ else
     release="production"
 fi
 
-# Initialize the submodule jellyfin-web
-git submodule update --init --remote
-
-# Check out the proper jellyfin-web branch or update submodule
-if [[ ${1} == '--web-branch' || ${1} == '-b' ]]; then
-    if [[ -n ${2} ]]; then
-        pushd src/jellyfin-web
-        git fetch --all
-        git checkout ${2} || usage
-        popd
-        shift 2
-    else
-        usage
-    fi
-fi
-
 set -o xtrace
+
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"
 
@@ -56,11 +41,13 @@ trap cleanup EXIT INT
 
 # Set up the build environment docker image
 docker build . -t "${image_name}" -f ./${dockerfile}
+
 # Build the APKs and copy out to ${package_temporary_dir}
 docker run --rm -e "RELEASE=${release}" -v "${package_temporary_dir}:/dist" "${image_name}"
+
 # Correct ownership on the APKs (as current user, then as root if that fails)
-chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null \
-  || sudo chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
+chown -R "${current_user}" "${package_temporary_dir}" &>/dev/null
+
 # Move the APKs to the parent directory
 mkdir -p ../bin &>/dev/null
 mv "${package_temporary_dir}"/apk/*.apk ../bin

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,29 +1,11 @@
-var gulp = require('gulp');
-var gulpif = require('gulp-if');
-var cleanCSS = require('gulp-clean-css');
 var del = require('del');
-var dom = require('gulp-dom');
-var uglifyes = require('uglify-es');
-var composer = require('gulp-uglify/composer');
-var uglify = composer(uglifyes, console);
+var gulp = require('gulp');
 
 // Check the NODE_ENV environment variable
 var isDev = process.env.NODE_ENV === 'development';
 
-// Skip minification for development builds or minified files
-var compress = !isDev && [
-    '**/*',
-    '!**/*min.*',
-    '!**/*hls.js',
-    // Temporarily exclude apiclient until updated
-    '!bower_components/emby-apiclient/**/*.js'
-];
-
-var uglifyOptions = {
-    compress: {
-        drop_console: true
-    }
-};
+// Web client to bundle with cordova
+var webSource = isDev ? '../jellyfin-web/dist' : 'src/jellyfin-web';
 
 var cleanOptions = {
     // Do not rebase relative urls
@@ -32,31 +14,13 @@ var cleanOptions = {
 };
 
 var paths = {
-    assets: {
-        src: [
-            'src/jellyfin-web/src/**/*',
-            '!src/jellyfin-web/src/**/*.{js,css}',
-            '!src/jellyfin-web/src/index.html'
-        ],
+    web: {
+        src: webSource + '/**/*',
         dest: 'www/'
     },
-    index: {
-        src: 'src/jellyfin-web/src/index.html',
-        dest: 'www/'
-    },
-    scripts: {
-        cordova: {
-            src: 'src/cordova/**/*.js',
-            dest: 'www/cordova/'
-        },
-        dashboard: {
-            src: 'src/jellyfin-web/src/**/*.js',
-            dest: 'www/'
-        }
-    },
-    styles: {
-        src: 'src/jellyfin-web/src/**/*.css',
-        dest: 'www/'
+    plugins: {
+        src: 'src/cordova/**/*.js',
+        dest: 'www/cordova/'
     }
 };
 
@@ -68,81 +32,25 @@ function clean() {
     ]);
 }
 
-// Copy unmodified assets
-function copy() {
-    return gulp.src(paths.assets.src)
-        .pipe(gulp.dest(paths.assets.dest));
+// Copy web client
+function copyWeb() {
+    return gulp.src(paths.web.src)
+        .pipe(gulp.dest(paths.web.dest));
 }
 
-// Add required tags to index.html
-function modifyIndex() {
-    return gulp.src(paths.index.src)
-        .pipe(dom(function() {
-            // inject CSP meta tag
-            var meta = this.createElement('meta');
-            meta.setAttribute('http-equiv', 'Content-Security-Policy');
-            meta.setAttribute('content', 'default-src * \'self\' \'unsafe-inline\' \'unsafe-eval\' data: gap: file: filesystem: ws: wss:;');
-            this.head.appendChild(meta);
-
-            // inject appMode script
-            var appMode = this.createElement('script');
-            appMode.text = 'window.appMode=\'android\';';
-            this.body.appendChild(appMode);
-
-            // inject cordova.js
-            var cordova = this.createElement('script');
-            cordova.setAttribute('src', 'cordova.js');
-            cordova.setAttribute('defer', '');
-            this.body.appendChild(cordova);
-
-            // inject apploader.js
-            var apploader = this.createElement('script');
-            apploader.setAttribute('src', 'scripts/apploader.js');
-            apploader.setAttribute('defer', '');
-            this.body.appendChild(apploader);
-
-            return this;
-        }))
-        .pipe(gulp.dest(paths.index.dest))
+// Copy web plugins
+function copyPlugins() {
+    return gulp.src(paths.plugins.src)
+        .pipe(gulp.dest(paths.plugins.dest));
 }
-
-// Uglify cordova scripts
-function cordovaScripts() {
-    return gulp.src(paths.scripts.cordova.src)
-        .pipe(gulpif(compress, uglify(uglifyOptions)))
-        .pipe(gulp.dest(paths.scripts.cordova.dest));
-}
-cordovaScripts.displayName = 'scripts:cordova';
-
-// Uglify dashboard-ui scripts
-function dashboardScripts() {
-    return gulp.src(paths.scripts.dashboard.src)
-        .pipe(gulpif(compress, uglify(uglifyOptions)))
-        .pipe(gulp.dest(paths.scripts.dashboard.dest));
-}
-dashboardScripts.displayName = 'scripts:dashboard';
-
-// Uglify scripts
-var scripts = gulp.parallel(cordovaScripts, dashboardScripts);
-
-// Uglify stylesheets
-function styles() {
-    return gulp.src(paths.styles.src)
-        .pipe(gulpif(compress, cleanCSS(cleanOptions)))
-        .pipe(gulp.dest(paths.styles.dest));
-}
-
-// Default build task
-var build = gulp.series(
-    clean,
-    gulp.parallel(copy, modifyIndex, scripts, styles)
-);
 
 // Export tasks so they can be run individually
 exports.clean = clean;
-exports.copy = copy;
-exports.modifyIndex = modifyIndex;
-exports.scripts = scripts;
-exports.styles = styles;
+exports.copyWeb = copyWeb;
+exports.copyPlugins = copyPlugins;
+
+// Default build task
+var build = gulp.series(clean, copyWeb, copyPlugins);
+
 // Export default task
 exports.default = build;

--- a/package.json
+++ b/package.json
@@ -6,12 +6,8 @@
     "type": "git",
     "url": "https://github.com/jellyfin/jellyfin-android.git"
   },
-  "scripts": {
-    "postinstall": "gulp"
-  },
   "license": "GPL-2.0-only",
   "dependencies": {
-    "acorn": "^6.1.1",
     "cordova": "^9.0.0",
     "cordova-android": "^8.0.0",
     "cordova-plugin-androidx": "^1.0.1",
@@ -19,13 +15,7 @@
     "cordova-plugin-whitelist": "^1.3.3",
     "del": "^3.0.0",
     "gulp": "^4.0.0",
-    "gulp-clean-css": "^4.0.0",
-    "gulp-dom": "^1.0.0",
-    "gulp-if": "^2.0.2",
-    "gulp-uglify": "^3.0.2",
-    "org.jellyfin.mobile": "file:src/NativeShell",
-    "request": "^2.88.0",
-    "uglify-es": "^3.3.9"
+    "org.jellyfin.mobile": "file:src/NativeShell"
   },
   "cordova": {
     "plugins": {


### PR DESCRIPTION
@thornbill I was thinking something like this for the new build process. I am still stuck trying to figure out an alternate method to pull the web source both here and in the server when people don't want to clone the web repo locally. I really wish we didn't have to manually copy files all over the place here, can you think of a way to avoid that?

Ideally we would move `modifyIndex` to the web build and use a flag to change `appMode` for different flavors. We would roll the android changes, server changes, and standalone changes into a gulpfile there and remove all custom handling here and in the server.