### PR TITLE
Docker enhancements

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 # Handle the release type
 RELEASE="${RELEASE:-debug}"
-case ${RELEASE} in
+case "${RELEASE}" in
     'production')
         RELEASE_SUFFIX=""
         NODE_ENV="production"
@@ -35,11 +35,11 @@ case ${RELEASE} in
 esac
 
 # Export environment variables
-export ANDROID_HOME=${ANDROID_DIR}
+export ANDROID_HOME="${ANDROID_DIR}"
 export NODE_ENV
 
 # Move to source directory
-pushd ${SOURCE_DIR}
+pushd "${SOURCE_DIR}"
 
 # Install dependencies
 npm cache verify
@@ -48,14 +48,14 @@ npx gulp
 npx cordova telemetry off
 npx cordova prepare
 
-if [ ${RELEASE} == 'foss' ]
+if [ "${RELEASE}" == 'foss' ]
 then
     npx cordova plugin rm cordova-plugin-chromecast
 fi
 
 # Build APK
-npx cordova build android ${RFLAG}
+npx cordova build android "${RFLAG}"
 
 # Move the artifacts out
-mkdir -p ${ARTIFACT_DIR}/apk
+mkdir -p "${ARTIFACT_DIR}/apk"
 mmv "${SOURCE_DIR}/platforms/android/app/build/outputs/apk/${RELEASE_OUTPUT_DIR}/app-*.apk" "${ARTIFACT_DIR}/apk/jellyfin-android_${RELEASE_SUFFIX}#1.apk"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -6,6 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Handle the release type
+RELEASE="${RELEASE:-debug}"
 case ${RELEASE} in
     'production')
         RELEASE_SUFFIX=""

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -32,6 +32,9 @@ case "${RELEASE}" in
         RFLAG="--debug"
         RELEASE_OUTPUT_DIR="debug"
     ;;
+    *)
+        echo error: release may only be production, unminified, foss, or debug >&2
+        exit 1
 esac
 
 # Export environment variables

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -29,7 +29,7 @@ case ${RELEASE} in
     'debug')
         RELEASE_SUFFIX=""
         NODE_ENV="development"
-        RFLAG=""
+        RFLAG="--debug"
         RELEASE_OUTPUT_DIR="debug"
     ;;
 esac

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -45,6 +45,7 @@ pushd ${SOURCE_DIR}
 npm cache verify
 npm install
 npx gulp
+npx cordova telemetry off
 npx cordova prepare
 
 if [ ${RELEASE} == 'foss' ]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -61,4 +61,5 @@ npx cordova build android "${RFLAG}"
 
 # Move the artifacts out
 mkdir -p "${ARTIFACT_DIR}/apk"
-mmv "${SOURCE_DIR}/platforms/android/app/build/outputs/apk/${RELEASE_OUTPUT_DIR}/app-*.apk" "${ARTIFACT_DIR}/apk/jellyfin-android_${RELEASE_SUFFIX}#1.apk"
+mmv "${SOURCE_DIR}/platforms/android/app/build/outputs/apk/${RELEASE_OUTPUT_DIR}/app-*.apk" \
+    "${ARTIFACT_DIR}/apk/jellyfin-android_${RELEASE_SUFFIX}#1.apk"


### PR DESCRIPTION
These should make running the container easier for someone. Defaults the build to debug and provides an error if an unknown `RELEASE` value is used.

Also:
* disable Cordova telemetry and thus telemetry prompt
* variable quoting
* split `mmv` command to two lines to make it easier to read in a narrow terminal (previously 154 chars wide)