### PR TITLE
Allow unsafe-perm when running npm in docker

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -46,6 +46,7 @@ pushd "${SOURCE_DIR}"
 
 # Install dependencies
 npm cache verify
+npm config set unsafe-perm true
 npm install
 npx gulp
 npx cordova telemetry off


### PR DESCRIPTION
This fixes an issue where the `prepare` script in `jellyfin-web` is not run due to it running as root in docker.