### PR TITLE
Update NPM packages used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1092,8 +1092,8 @@
       }
     },
     "cordova-plugin-chromecast": {
-      "version": "git+https://github.com/jellyfin/cordova-plugin-chromecast.git#783a8cda6c2b95e5963a4f51f9c2e4115be6e3db",
-      "from": "git+https://github.com/jellyfin/cordova-plugin-chromecast.git#v0.1.0"
+      "version": "git+https://github.com/jellyfin/cordova-plugin-chromecast.git#3ff77a570ad76e87106a94ac091e37944606faee",
+      "from": "git+https://github.com/jellyfin/cordova-plugin-chromecast.git#v0.1.1"
     },
     "cordova-plugin-whitelist": {
       "version": "1.3.4",
@@ -3350,7 +3350,7 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jellyfin-web": {
-      "version": "git+https://github.com/jellyfin/jellyfin-web.git#42c8ef6262fc59861d4b49234e5dffabe2759afb",
+      "version": "git+https://github.com/jellyfin/jellyfin-web.git#df82636845323f5e97dbab910cbb2a81a583bac5",
       "from": "git+https://github.com/jellyfin/jellyfin-web.git#master",
       "requires": {
         "hls.js": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cordova": "^9.0.0",
     "cordova-android": "^8.0.0",
     "cordova-plugin-androidx": "^1.0.1",
-    "cordova-plugin-chromecast": "git+https://github.com/jellyfin/cordova-plugin-chromecast.git#v0.1.0",
+    "cordova-plugin-chromecast": "git+https://github.com/jellyfin/cordova-plugin-chromecast.git#v0.1.1",
     "cordova-plugin-whitelist": "^1.3.3",
     "del": "^3.0.0",
     "gulp": "^4.0.0",


### PR DESCRIPTION
* Update jellyfin-web to latest master
* Updates jellyfin/cordova-plugin-chromecast to v0.1.1, which restores Chromecast for Android >7.1