### PR TITLE
Remove csp rule for default video player poster

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,7 +66,7 @@ function modifyIndex() {
             // inject CSP meta tag
             var meta = this.createElement('meta');
             meta.setAttribute('http-equiv', 'Content-Security-Policy');
-            meta.setAttribute('content', 'default-src * \'self\' \'unsafe-inline\' \'unsafe-eval\' blob: data: gap: file: filesystem: ws: wss:; img-src * android-webview-video-poster:;');
+            meta.setAttribute('content', 'default-src * \'self\' \'unsafe-inline\' \'unsafe-eval\' blob: data: gap: file: filesystem: ws: wss:;');
             this.head.appendChild(meta);
 
             // inject appMode script


### PR DESCRIPTION
I confirmed this did not break live tv for me while it does remove the default poster.