### PR TITLE
Rollback web to version used for 0.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-android",
-  "version": "0.9.0",
+  "version": "0.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -93,9 +93,9 @@
       }
     },
     "alameda": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/alameda/-/alameda-1.3.0.tgz",
-      "integrity": "sha512-DRhAXboxtfpHTawg5XRH9mJ3soyd5QocfD47BwgvbI5ryxCs+ga6yju2K0bvFRxINzRBnoJVlUIq/ndVBk6w1Q=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/alameda/-/alameda-1.4.0.tgz",
+      "integrity": "sha512-d6nIRyg4SD/zBupcfZ3lUis58l4H/3U7c1RBtFkcz/7u1dDIQwx26KUvKJ35esOVP6WsAjmRoP2VQ39kQZT/Gg=="
     },
     "android-versions": {
       "version": "1.4.0",
@@ -1394,14 +1394,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-0.5.4.tgz",
       "integrity": "sha1-32tX+7jhQRI+X2Gs84LWu3jAK84="
-    },
-    "dom7": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-2.1.3.tgz",
-      "integrity": "sha512-QTxHHDox+M6ZFz1zHPAHZKI3JOHY5iY4i9BK2uctlggxKQwRhO3q3HHFq1BKsT25Bm/ySSj70K6Wk/G4bs9rMQ==",
-      "requires": {
-        "ssr-window": "^1.0.1"
-      }
     },
     "domexception": {
       "version": "1.0.1",
@@ -2932,9 +2924,9 @@
       "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ=="
     },
     "howler": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/howler/-/howler-2.1.2.tgz",
-      "integrity": "sha512-oKrTFaVXsDRoB/jik7cEpWKTj7VieoiuzMYJ7E/EU5ayvmpRhumCv3YQ3823zi9VTJkSWAhbryHnlZAionGAJg=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.1.3.tgz",
+      "integrity": "sha512-PSGbOi1EYgw80C5UQbxtJM7TmzD+giJunIMBYyH3RVzHZx2fZLYBoes0SpVVHi/SFa1GoNtgXj/j6I7NOKYBxQ=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -3402,8 +3394,8 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jellyfin-web": {
-      "version": "git+https://github.com/jellyfin/jellyfin-web.git#6c56234171bd8c60aa45d91d2e5bc31c26b4cb5d",
-      "from": "git+https://github.com/jellyfin/jellyfin-web.git#master",
+      "version": "git+https://github.com/jellyfin/jellyfin-web.git#a612fdf87c0d692447abb3a0016c62bd81468c8f",
+      "from": "git+https://github.com/jellyfin/jellyfin-web.git#a612fdf87c0d692447abb3a0016c62bd81468c8f",
       "requires": {
         "alameda": "^1.3.0",
         "document-register-element": "^0.5.4",
@@ -3412,7 +3404,6 @@
         "howler": "^2.1.2",
         "jquery": "^3.4.1",
         "jstree": "^3.3.7",
-        "libass-wasm": "^2.1.1",
         "libjass": "^0.11.0",
         "native-promise-only": "^0.8.0-a",
         "requirejs": "^2.3.5",
@@ -3422,6 +3413,13 @@
         "swiper": "^3.4.2",
         "webcomponents.js": "^0.7.24",
         "whatwg-fetch": "^1.1.1"
+      },
+      "dependencies": {
+        "swiper": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/swiper/-/swiper-3.4.2.tgz",
+          "integrity": "sha1-Oda0ELGjmDPh9y07cpmd9fXjg5I="
+        }
       }
     },
     "jquery": {
@@ -3522,9 +3520,9 @@
       }
     },
     "jstree": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.8.tgz",
-      "integrity": "sha512-0/nhGxVLSGfGQyVg+q59ocqSEKWRDKHoA8wNrcOIvlzCCw19tzvcMNGJ19hf+U0b7fycABowkny7fQPcLgUwwA==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.9.tgz",
+      "integrity": "sha512-jRIbhg+BHrIs1Wm6oiJt3oKTVBE6sWS0PCp2/RlkIUqsLUPWUYgV3q8LfKoi1/E+YMzGtP6BuK4okk+0mwfmhQ==",
       "requires": {
         "jquery": ">=1.9.1"
       }
@@ -3588,11 +3586,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
-    },
-    "libass-wasm": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/libass-wasm/-/libass-wasm-2.1.1.tgz",
-      "integrity": "sha512-d45bHQ7tFVsLW3QstQDrDog2m+0D6Cja4GTrkGi70R9A5+aeLunPSUz3G4CVB+sKffNgiWjK4QI5NZLHQKZ9oQ=="
     },
     "libjass": {
       "version": "0.11.0",
@@ -5065,9 +5058,9 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "shaka-player": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-2.5.8.tgz",
-      "integrity": "sha512-IsyqXisimHZl9ITAZgGw6p2/E4004Vl3em+XQUk4zF1CjupVvL8kcs32a1iAXFYjNGrw+PMiPDULUpy2+Z/KPw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-2.5.9.tgz",
+      "integrity": "sha512-XavLBqxvIbvLOPfk7VKZu5fbMJyVko9bBfzxmMWdX5bvQwUSjU7ZhV8v2tHqXQYafpHml1hlGHzKkLs7idouNQ==",
       "requires": {
         "eme-encryption-scheme-polyfill": "^2.0.0"
       }
@@ -5198,9 +5191,9 @@
       }
     },
     "sortablejs": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.0.tgz",
-      "integrity": "sha512-+e0YakK1BxgEZpf9l9UiFaiQ8ZOBn1p/4qkkXr8QDVmYyCrUDTyDRRGm0AgW4E4cD0wtgxJ6yzIRkSPUwqhuhg=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
     },
     "source-map": {
       "version": "0.5.7",
@@ -5280,11 +5273,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
-    },
-    "ssr-window": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-1.0.1.tgz",
-      "integrity": "sha512-dgFqB+f00LJTEgb6UXhx0h+SrG50LJvti2yMKMqAgzfUmUXZrLSv2fjULF7AWGwK25EXu8+smLR3jYsJQChPsg=="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -5417,15 +5405,6 @@
       "requires": {
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
-      }
-    },
-    "swiper": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-4.5.1.tgz",
-      "integrity": "sha512-se6I7PWWu950NAMXXT+ENtF/6SVb8mPyO+bTfNxbQBILSeLqsYp3Ndap+YOA0EczOIUlea274PKejT6gKZDseA==",
-      "requires": {
-        "dom7": "^2.1.3",
-        "ssr-window": "^1.0.1"
       }
     },
     "symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-dom": "^1.0.0",
     "gulp-if": "^2.0.2",
     "gulp-uglify": "^3.0.2",
-    "jellyfin-web": "git+https://github.com/jellyfin/jellyfin-web.git#master",
+    "jellyfin-web": "git+https://github.com/jellyfin/jellyfin-web.git#a612fdf87c0d692447abb3a0016c62bd81468c8f",
     "org.jellyfin.mobile": "file:src/NativeShell",
     "request": "^2.88.0",
     "uglify-es": "^3.3.9"


### PR DESCRIPTION
Rollback web to the version used for the previous release since the build from master seems to be introducing several issues. The best I can tell, [this](https://github.com/jellyfin/jellyfin-web/commit/a612fdf87c0d692447abb3a0016c62bd81468c8f) is the last commit in web prior to the 0.9.7 release.

![woah](https://user-images.githubusercontent.com/3450688/74708620-f605e500-51ea-11ea-8ba1-4847177223c6.gif)
