### PR TITLE
Switch uglify-es for terser

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,9 +2,9 @@ var gulp = require('gulp');
 var gulpif = require('gulp-if');
 var del = require('del');
 var dom = require('gulp-dom');
-var uglifyes = require('uglify-es');
+var terser = require('terser');
 var composer = require('gulp-uglify/composer');
-var uglify = composer(uglifyes, console);
+var minify = composer(terser, console);
 
 // Check the NODE_ENV environment variable
 var isDev = process.env.NODE_ENV === 'development';
@@ -94,7 +94,7 @@ function modifyIndex() {
 // Uglify cordova scripts
 function scripts() {
     return gulp.src(paths.scripts.src)
-        .pipe(gulpif(compress, uglify(uglifyOptions)))
+        .pipe(gulpif(compress, minify(uglifyOptions)))
         .pipe(gulp.dest(paths.scripts.dest));
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var del = require('del');
 var dom = require('gulp-dom');
 var terser = require('terser');
 var composer = require('gulp-uglify/composer');
-var minify = composer(terser, console);
+var tersify = composer(terser, console);
 
 // Check the NODE_ENV environment variable
 var isDev = process.env.NODE_ENV === 'development';
@@ -94,7 +94,7 @@ function modifyIndex() {
 // Uglify cordova scripts
 function scripts() {
     return gulp.src(paths.scripts.src)
-        .pipe(gulpif(compress, minify(uglifyOptions)))
+        .pipe(gulpif(compress, tersify(uglifyOptions)))
         .pipe(gulp.dest(paths.scripts.dest));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-android",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5212,6 +5212,22 @@
         "urix": "^0.1.0"
       }
     },
+    "source-map-support": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -5482,6 +5498,23 @@
         "through2": "^2.0.1"
       }
     },
+    "terser": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.4.tgz",
+      "integrity": "sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==",
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -5645,27 +5678,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "requires": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jellyfin-web": "git+https://github.com/jellyfin/jellyfin-web.git#a612fdf87c0d692447abb3a0016c62bd81468c8f",
     "org.jellyfin.mobile": "file:src/NativeShell",
     "request": "^2.88.0",
-    "uglify-es": "^3.3.9"
+    "terser": "^4.6.4"
   },
   "cordova": {
     "plugins": {


### PR DESCRIPTION
Switched [`ublify-es`](https://www.npmjs.com/package/uglify-es) for [`terser`](https://github.com/terser/terser) because `uglify-es` is [no longer maintained](https://github.com/terser/terser#why-choose-terser)