### PR TITLE
Remove broken profile

### DIFF
--- a/src/NativeShell/www/apphost.js
+++ b/src/NativeShell/www/apphost.js
@@ -24,12 +24,6 @@ function getDeviceProfile(profileBuilder, item) {
         enableMkvProgressive: false
     });
 
-    profile.DirectPlayProfiles.push({
-        Container: "m4v,3gp,ts,mpegts,mov,xvid,vob,mkv,wmv,asf,ogm,ogv,m2v,avi,mpg,mpeg,mp4,webm,wtv",
-        Type: 'Video',
-        AudioCodec: 'aac,aac_latm,mp2,mp3,wma,dca,pcm,PCM_S16LE,PCM_S24LE,opus,flac'
-    });
-
     profile.CodecProfiles = profile.CodecProfiles.filter(function (i) {
         return i.Type == 'Audio';
     });


### PR DESCRIPTION
Most likely it was valid when the app came bundled with libvlc, but it is valid no more.

The way it was handled by server was the following:
1. Okay, profile has no `VideoCodec`, assign `null` (JSON behaviour)
2. Okay, we found a matching container and a matching audio codec, and we interpret `null` as "any video codec"
3. Playback with black screen (only audio) happens

Looking through the history I see this profile in the very first version of jellyfin-android, so I think it was there to address the fact that libvlc (which was used in the early days) could have played any video codec. This is no longer true.