### PR TITLE
Bump jf-web to 10.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-dom": "^1.0.0",
     "gulp-if": "^2.0.2",
     "gulp-uglify": "^3.0.2",
-    "jellyfin-web": "git+https://github.com/jellyfin/jellyfin-web.git#v10.5.2",
+    "jellyfin-web": "git+https://github.com/jellyfin/jellyfin-web.git#v10.5.4",
     "org.jellyfin.mobile": "file:src/NativeShell",
     "request": "^2.88.0",
     "terser": "^4.6.4"


### PR DESCRIPTION
It contains a few important bugfixes, including playback resuming (instead of always starting from the beginning) and `.ASS` subtitles renderer fix.

Fixes https://github.com/jellyfin/jellyfin-android/issues/258
