### PR TITLE
Reduce Noto footprint

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -51,9 +51,9 @@ npm cache verify
 npm config set unsafe-perm true
 npm ci
 npx gulp
-npx cordova telemetry off
-cp -r jellyfin-noto/packaged/* node_modules/jellyfin-web/dist/assets/
+cp -r jellyfin-noto/packaged/* www/assets/
 rm -rf jellyfin-noto
+npx cordova telemetry off
 npx cordova prepare
 
 if [ "${RELEASE}" == 'foss' ]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -45,11 +45,15 @@ export NODE_ENV
 pushd "${SOURCE_DIR}"
 
 # Install dependencies
+## Fetch Jellyfin Noto packaged version
+git clone https://github.com/jellyfin/jellyfin-noto
 npm cache verify
 npm config set unsafe-perm true
 npm ci
 npx gulp
 npx cordova telemetry off
+cp -r jellyfin-noto/packaged/* node_modules/jellyfin-web/dist/assets/
+rm -rf jellyfin-noto
 npx cordova prepare
 
 if [ "${RELEASE}" == 'foss' ]


### PR DESCRIPTION
This PR is a followup of jellyfin/jellyfin#2871 and jellyfin/jellyfin-web#1087, so see them before for a better explanation.

This PR aims at using the **packaged** version of the new jellyfin-noto repo structure. for Android. This PR only makes sense after merging the web PR, because otherwise we would be bundling fonts two times in the apk file.

~~Problems~~
~~I'm new to Cordova development so I have no idea why this happens, but what I do simply doesn't work: in the resulting apk file, the files are not present in the ``assets/css`` directory of the web source. As long as this is solved, everything should be fine, so I need the help of the experienced people 😊.~~

*Fixed in latest commit! I was copying to the wrong location*

## Testing
As with my other PRs, checkout ``font-serve`` branch. Files won't be copied to the final apk file anyway.

