### PR TITLE
update docker RELEASE tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ npx cordova run android
 
 You can optionally use Docker to build the APK to avoid the above requirements.
 
-Replace release with the desired build flavor (production, libre, or development) and output with the directory you want the APKs sent on completion.
+Replace release with the desired build flavor (production, unminified, foss, or debug) and output with the directory you want the APKs sent on completion.
 
 ```sh
 docker build . -t "jellyfin-android"


### PR DESCRIPTION
Not sure if this is correct or not, following the warnings. This branch is based off https://github.com/jellyfin/jellyfin-android/pull/238 so it probably just needs to be rebased to fix the build issue. 

```
artiume@noder:~/test/jellyfin-android$ docker run --rm -e "RELEASE=development" -v "/home/artiume/test:/dist" "jellyfin-android"
+ RELEASE=development
+ case "${RELEASE}" in
+ echo error: release may only be production, unminified, foss, or debug
error: release may only be production, unminified, foss, or debug
+ exit 1
artiume@noder:~/test/jellyfin-android$ docker run --rm -e "RELEASE=debug" -v "/home/artiume/test:/dist" "jellyfin-android"
+ RELEASE=debug
+ case "${RELEASE}" in
+ RELEASE_SUFFIX=
+ NODE_ENV=development
+ RFLAG=--debug
+ RELEASE_OUTPUT_DIR=debug
+ export ANDROID_HOME=/usr/lib/android-sdk
+ ANDROID_HOME=/usr/lib/android-sdk
+ export NODE_ENV
+ pushd /repo
/repo /
+ npm cache verify
Cache verified and compressed (~/.npm/_cacache):
Content verified: 3 (7313135 bytes)
Index entries: 3
Finished in 0.159s
+ npm config set unsafe-perm true
+ npm ci
npm WARN prepare removing existing node_modules/ before installation
npm ERR! cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-04-25T02_23_31_028Z-debug.log
artiume@noder:~/test/jellyfin-android$
```