### PR TITLE
Set ExoPlayer as disabled by default

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
@@ -37,5 +37,5 @@ class AppPreferences(context: Context) {
         get() = sharedPreferences.getBoolean(Constants.PREF_MUSIC_NOTIFICATION_ALWAYS_DISMISSIBLE, false)
 
     val enableExoPlayer: Boolean
-        get() = sharedPreferences.getBoolean(Constants.PREF_ENABLE_EXOPLAYER, true)
+        get() = sharedPreferences.getBoolean(Constants.PREF_ENABLE_EXOPLAYER, false)
 }

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsActivity.kt
@@ -43,7 +43,6 @@ class SettingsActivity : AppCompatActivity() {
         checkBox(Constants.PREF_ENABLE_EXOPLAYER) {
             titleRes = R.string.pref_enable_exoplayer_title
             summaryRes = R.string.pref_enable_exoplayer_summary
-            defaultValue = true
         }
     }
 


### PR DESCRIPTION
Until there is full feature parity, ExoPlayer should not be enabled by default. Users can still enable it in the settings.