### PR TITLE
Fix possible exception when logging errors

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/WebappActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/WebappActivity.kt
@@ -115,7 +115,7 @@ class WebappActivity : AppCompatActivity(), WebViewController {
             }
 
             override fun onReceivedError(view: WebView, request: WebResourceRequest, errorResponse: WebResourceError) {
-                Timber.e("Received WebView error at ${request.url}: %s", errorResponse.descriptionOrNull)
+                Timber.e("Received WebView error at %s: %s", request.url.toString(), errorResponse.descriptionOrNull)
             }
         }
         webChromeClient = WebChromeClient()

--- a/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
@@ -43,5 +43,5 @@ fun Context.loadAsset(url: String): WebResourceResponse {
 
 val emptyResponse = WebResourceResponse("text/html", Charsets.UTF_8.toString(), "".byteInputStream())
 
-val WebResourceError.descriptionOrNull
-    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) description else null
+val WebResourceError.descriptionOrNull: String?
+    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) description.toString() else null


### PR DESCRIPTION
Logging a CharSequence as a String in Timber causes a crash.