### PR TITLE
Fixes crash when entering incorrect Url

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/utils/ServerConnectionUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/ServerConnectionUtils.kt
@@ -12,6 +12,7 @@ import org.jellyfin.mobile.utils.Constants.SERVER_INFO_PATH
 import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
+import java.io.IOException
 
 suspend fun WebappActivity.checkServerUrlAndConnection(enteredUrl: String): HttpUrl? {
     val normalizedUrl = enteredUrl.run {
@@ -72,6 +73,7 @@ suspend fun fetchServerInfo(httpClient: OkHttpClient, url: HttpUrl): String? {
         try {
             request.execute().use { it.body?.string() }
         } catch (e: IOException) {
+            Timber.e(e, "Cannot connect to server")
             null
         }
     }


### PR DESCRIPTION
Start with a clean installation.
Enter an incorrect Url
Result Crash
Expected Message saying URL is invalid but no crash