### PR TITLE
Fix UI overlap by applying bottom insets

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity(), WebViewController {
         // Handle window insets
         setStableLayoutFlags()
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
-            v.updatePadding(top = insets.systemWindowInsets.top)
+            v.updatePadding(top = insets.systemWindowInsetTop, bottom = insets.systemWindowInsetBottom)
             insets
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {


### PR DESCRIPTION
I think for now, this is the best solution to the problem. Injecting custom CSS is much more complicated, and even with the nowplayingbar moved up, there are still UI problems that'd need to be adressed.

Fix #69.