### PR TITLE
Improve ExoPlayer enabling

### DIFF
--- a/app/src/main/assets/native/exoplayer.js
+++ b/app/src/main/assets/native/exoplayer.js
@@ -47,7 +47,7 @@ define(['events', 'appSettings', 'loading', 'playbackManager'], function (events
         };
 
         self.canPlayItem = function (item, playOptions) {
-            return true;
+            return window.NativePlayer.isEnabled();
         };
 
         self.currentSrc = function () {

--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -32,7 +32,7 @@ window.NativeShell = {
     },
 
     getPlugins() {
-        return JSON.parse(window.NativeInterface.getPlugins());
+        return ["native/exoplayer"];
     },
 
     execCast(action, args, callback) {

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -49,12 +49,6 @@ class NativeInterface(private val activity: MainActivity) {
     }
 
     @JavascriptInterface
-    fun getPlugins(): String = JSONArray().apply {
-        if (activity.appPreferences.enableExoPlayer)
-            put("native/exoplayer")
-    }.toString()
-
-    @JavascriptInterface
     fun enableFullscreen(): Boolean {
         activity.runOnUiThread {
             activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
@@ -19,6 +19,9 @@ class NativePlayer(private val activity: MainActivity) {
     private val webappMessenger = Messenger(playerMessageHandler)
 
     @JavascriptInterface
+    fun isEnabled() = activity.appPreferences.enableExoPlayer
+
+    @JavascriptInterface
     fun getSupportedFormats() = ExoPlayerFormats.supportedCodecs.toJSONString()
 
     @JavascriptInterface

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsActivity.kt
@@ -1,17 +1,14 @@
 package org.jellyfin.mobile.settings
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import de.Maxr1998.modernpreferences.PreferencesAdapter
 import de.Maxr1998.modernpreferences.helpers.categoryHeader
 import de.Maxr1998.modernpreferences.helpers.checkBox
 import de.Maxr1998.modernpreferences.helpers.screen
-import de.Maxr1998.modernpreferences.preferences.TwoStatePreference
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.utils.Constants
-import org.jellyfin.mobile.utils.toast
 
 class SettingsActivity : AppCompatActivity() {
 
@@ -46,10 +43,6 @@ class SettingsActivity : AppCompatActivity() {
         checkBox(Constants.PREF_ENABLE_EXOPLAYER) {
             titleRes = R.string.pref_enable_exoplayer_title
             summaryRes = R.string.pref_enable_exoplayer_summary
-            checkedChangeListener = TwoStatePreference.OnCheckedChangeListener { _, _, _ ->
-                toast(R.string.toast_exo_player_restart_app, Toast.LENGTH_LONG)
-                true
-            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,5 +27,4 @@
     <string name="pref_category_video_player">Native video player</string>
     <string name="pref_enable_exoplayer_title">Enable video player integration</string>
     <string name="pref_enable_exoplayer_summary">Enable the experimental ExoPlayer video player which supports more video formats and codecs, and is more integrated into the OS</string>
-    <string name="toast_exo_player_restart_app">Restart app for changes to be applied</string>
 </resources>


### PR DESCRIPTION
No restart needed anymore. The plugin is now enabled by default and when item playback is requested we check if ExoPlayer is enabled or not.

Undoes #75 (Sorry @Maxr1998)