### PR TITLE
Implement external player feature

### DIFF
--- a/app/src/main/assets/native/externalplayer.js
+++ b/app/src/main/assets/native/externalplayer.js
@@ -1,0 +1,167 @@
+define(['events', 'appSettings', 'playbackManager', 'toast'], function (events, appSettings, playbackManager, toast) {
+    "use strict";
+
+    return function () {
+        var self = this;
+
+        window.ExtPlayer = this;
+
+        self.name = 'External Player';
+        self.type = 'mediaplayer';
+        self.id = 'externalplayer';
+        self.subtitleStreamIndex = -1;
+        self.audioStreamIndex = -1;
+        self.cachedDeviceProfile = null;
+
+        // Prioritize first
+        self.priority = -2;
+        self.supportsProgress = false;
+        self.isLocalPlayer = true;
+        // Disable orientation lock
+        self.isExternalPlayer = true;
+        self._currentTime = 0;
+        self._paused = true;
+        self._volume = 100;
+        self._currentSrc = null;
+
+        self.canPlayMediaType = function (mediaType) {
+            return mediaType === 'Video';
+        };
+
+        self.canPlayItem = function (item, playOptions) {
+            var mediaSource = item.MediaSources[0] || false;
+            return appSettings.enableSystemExternalPlayers() && mediaSource && mediaSource.SupportsDirectStream;
+        };
+
+        self.supportsPlayMethod = function (playMethod, item) {
+            return playMethod === 'DirectStream';
+        };
+
+        self.currentSrc = function () {
+            return self._currentSrc;
+        };
+
+        self.play = function (options) {
+            return new Promise(function (resolve) {
+                self._currentTime = 0;
+                self._paused = false;
+                self._currentSrc = options.url;
+                window.ExternalPlayer.initPlayer(JSON.stringify(options));
+                resolve();
+            });
+        };
+
+        self.setSubtitleStreamIndex = function (index) {
+        };
+
+        self.setAudioStreamIndex = function (index) {
+        };
+
+        self.canSetAudioStreamIndex = function () {
+            return false;
+        };
+
+        self.setAudioStreamIndex = function (index) {
+        };
+
+        // Save this for when playback stops, because querying the time at that point might return 0
+        self.currentTime = function (val) {
+            return null;
+        };
+
+        self.duration = function (val) {
+            return null;
+        };
+
+        self.destroy = function () {
+        };
+
+        self.pause = function () {
+        };
+
+        self.unpause = function () {
+        };
+
+        self.paused = function () {
+            return self._paused;
+        };
+
+        self.stop = function (destroyPlayer) {
+            return new Promise(function (resolve) {
+                if (destroyPlayer) {
+                    self.destroy();
+                }
+                resolve();
+            });
+        };
+
+        self.volume = function (val) {
+            return self._volume;
+        };
+
+        self.setMute = function (mute) {
+        };
+
+        self.isMuted = function () {
+            return self._volume == 0;
+        };
+
+        self.notifyEnded = function () {
+            new Promise(function () {
+                let stopInfo = {
+                    src: self._currentSrc
+                };
+
+                events.trigger(self, 'stopped', [stopInfo]);
+                self._currentSrc = self._currentTime = null;
+            });
+        };
+
+        self.notifyTimeUpdate = function (currentTime) {
+            // if no time provided handle like playback completed
+            currentTime = currentTime || playbackManager.duration(self);
+            new Promise(function () {
+                currentTime = currentTime / 1000;
+                self._timeUpdated = self._currentTime != currentTime;
+                self._currentTime = currentTime;
+                events.trigger(self, 'timeupdate');
+            });
+        };
+
+        self.notifyCanceled = function (message) {
+            // required to not mark an item as seen / completed without time changes
+            var currentTime = self._currentTime || 0;
+            self.notifyTimeUpdate(currentTime + 1);
+            self.notifyTimeUpdate(currentTime - 1);
+            self.notifyEnded();
+            if (message) {
+                toast(message);
+            }
+        };
+
+        self.currentTime = function () {
+            return (self._currentTime || 0) * 1000;
+        };
+
+        self.changeSubtitleStream = function (index) {
+            // detach from the main ui thread
+            new Promise(function () {
+                var innerIndex = Number(index);
+                self.subtitleStreamIndex = innerIndex;
+            });
+        };
+
+        self.changeAudioStream = function (index) {
+            // detach from the main ui thread
+            new Promise(function () {
+                var innerIndex = Number(index);
+                self.audioStreamIndex = innerIndex;
+            });
+        }
+
+        self.getDeviceProfile = function () {
+            // using exoplayer implementation for now
+            return window.ExoPlayer.getDeviceProfile();
+        };
+    };
+});

--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -54,7 +54,7 @@ window.NativeShell = {
     },
 
     getPlugins() {
-        return ["native/exoplayer"];
+        return ["native/exoplayer", "native/externalplayer"];
     },
 
     execCast(action, args, callback) {

--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.mobile.bridge.Commands.triggerInputManagerAction
+import org.jellyfin.mobile.bridge.ExternalPlayer
 import org.jellyfin.mobile.bridge.NativeInterface
 import org.jellyfin.mobile.bridge.NativePlayer
 import org.jellyfin.mobile.cast.Chromecast
@@ -49,6 +50,7 @@ class MainActivity : AppCompatActivity(), WebViewController {
     val permissionRequestHelper: PermissionRequestHelper by inject()
     val chromecast = Chromecast()
     private val connectionHelper = ConnectionHelper(this)
+    private val externalPlayer = ExternalPlayer(this@MainActivity)
     private val webappFunctionChannel: Channel<String> by inject(named(WEBAPP_FUNCTION_CHANNEL))
 
     val rootView: CoordinatorLayout by lazyView(R.id.root_view)
@@ -181,6 +183,7 @@ class MainActivity : AppCompatActivity(), WebViewController {
         }
         addJavascriptInterface(NativeInterface(this@MainActivity), "NativeInterface")
         addJavascriptInterface(NativePlayer(this@MainActivity), "NativePlayer")
+        addJavascriptInterface(externalPlayer, "ExternalPlayer")
     }
 
     override fun loadUrl(url: String) {
@@ -189,6 +192,13 @@ class MainActivity : AppCompatActivity(), WebViewController {
 
     fun updateRemoteVolumeLevel(value: Int) {
         serviceBinder?.run { remoteVolumeProvider.currentVolume = value }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == Constants.HANDLE_EXTERNAL_PLAYER) {
+            externalPlayer.handleActivityResult(resultCode, data)
+        }
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -1,0 +1,165 @@
+package org.jellyfin.mobile.bridge
+
+import android.app.Activity
+import android.content.Intent
+import android.webkit.JavascriptInterface
+import org.jellyfin.mobile.MainActivity
+import org.jellyfin.mobile.R
+import org.jellyfin.mobile.player.source.JellyfinMediaSource
+import org.jellyfin.mobile.utils.Constants
+import org.json.JSONException
+import org.json.JSONObject
+import org.koin.core.KoinComponent
+import timber.log.Timber
+
+class ExternalPlayer(private val activity: MainActivity) : KoinComponent {
+
+    private var mediaSource: JellyfinMediaSource? = null
+    private var playerIntent: Intent? = null
+
+    @JavascriptInterface
+    fun initPlayer(args: String) {
+        try {
+            mediaSource = JellyfinMediaSource(JSONObject(args))
+            if (mediaSource?.playMethod.equals("DirectStream")) {
+                playerIntent = Intent(Intent.ACTION_VIEW).apply {
+                    setDataAndType(mediaSource?.uri, mediaSource?.mimeType)
+                    putExtra("title", mediaSource?.title)
+                    putExtra("position", mediaSource?.mediaStartMs)
+                    putExtra("return_result", true)
+                    putExtra("secure_uri", true)
+                }
+                activity.startActivityForResult(playerIntent, Constants.HANDLE_EXTERNAL_PLAYER)
+                Timber.d("Starting playback [id: ${mediaSource?.id}, title: ${mediaSource?.title}, playMethod: ${mediaSource?.playMethod}, mediaStartMs: ${mediaSource?.mediaStartMs}]")
+            } else {
+                Timber.d("Play Method '${mediaSource?.playMethod}' not tested, ignoring...")
+                notifyEvent(
+                    Constants.EVENT_CANCELED,
+                    "'${activity.getString(R.string.external_player_invalid_play_method)}'"
+                )
+            }
+        } catch (e: JSONException) {
+            Timber.e(e)
+        }
+    }
+
+    private fun notifyEvent(event: String, parameters: String = "") {
+        activity.loadUrl("javascript:window.ExtPlayer.notify$event($parameters)")
+    }
+
+    fun handleActivityResult(resultCode: Int, data: Intent?) {
+        when (data?.action) {
+            Constants.MX_PLAYER_RESULT_ACTION -> handleMXPlayer(resultCode, data)
+            Constants.VLC_PLAYER_RESULT_ACTION -> handleVLCPlayer(resultCode, data)
+            else -> {
+                if (data?.action != null && resultCode != Activity.RESULT_CANCELED) {
+                    Timber.d("Unknown action [resultCode: $resultCode, action: ${data.action}]")
+                    notifyEvent(
+                        Constants.EVENT_CANCELED,
+                        "'${activity.getString(R.string.external_player_not_supported_yet)}'"
+                    )
+                } else {
+                    Timber.d("Playback canceled [no player selected or player without action result]")
+                    notifyEvent(
+                        Constants.EVENT_CANCELED,
+                        "'${activity.getString(R.string.external_player_invalid_player)}'"
+                    )
+                }
+            }
+        }
+    }
+
+    // https://sites.google.com/site/mxvpen/api
+    private fun handleMXPlayer(resultCode: Int, data: Intent) {
+        val player = "MX Player"
+        when (resultCode) {
+            Activity.RESULT_OK -> {
+                when (val endBy = data.getStringExtra("end_by")) {
+                    "playback_completion" -> {
+                        Timber.d("Playback completed [player: $player]")
+                        notifyEvent(Constants.EVENT_TIME_UPDATE)
+                        notifyEvent(Constants.EVENT_ENDED)
+                    }
+                    "user" -> {
+                        val position = data.getIntExtra("position", 0)
+                        val duration = data.getIntExtra("duration", 0)
+                        if (position > 0) {
+                            Timber.d("Playback stopped [player: $player, position: $position, duration: $duration]")
+                            notifyEvent(
+                                Constants.EVENT_TIME_UPDATE,
+                                position.toString()
+                            )
+                            notifyEvent(Constants.EVENT_ENDED)
+                        } else {
+                            Timber.d("Invalid state [player: $player, position: $position, duration: $duration]")
+                            notifyEvent(
+                                Constants.EVENT_CANCELED,
+                                "'${activity.getString(R.string.external_player_unknown_error)}'"
+                            )
+                        }
+                    }
+                    else -> {
+                        Timber.d("Invalid state [player: $player, end_by: $endBy]")
+                        notifyEvent(
+                            Constants.EVENT_CANCELED,
+                            "'${activity.getString(R.string.external_player_unknown_error)}'"
+                        )
+                    }
+                }
+            }
+            Activity.RESULT_CANCELED -> {
+                Timber.d("Playback stopped by user [player: $player]")
+                notifyEvent(Constants.EVENT_CANCELED)
+            }
+            Activity.RESULT_FIRST_USER -> {
+                Timber.d("Playback stopped by unknown error [player: $player]")
+                notifyEvent(
+                    Constants.EVENT_CANCELED,
+                    "'${activity.getString(R.string.external_player_unknown_error)}'"
+                )
+            }
+            else -> {
+                Timber.d("Invalid state [player: $player, resultCode: $resultCode]")
+                notifyEvent(
+                    Constants.EVENT_CANCELED,
+                    "'${activity.getString(R.string.external_player_unknown_error)}'"
+                )
+            }
+        }
+    }
+
+    // https://wiki.videolan.org/Android_Player_Intents/
+    private fun handleVLCPlayer(resultCode: Int, data: Intent) {
+        val player = "VLC Player"
+        when (resultCode) {
+            Activity.RESULT_OK -> {
+                val extraPosition = data.getLongExtra("extra_position", 0L)
+                val extraDuration = data.getLongExtra("extra_duration", 0L)
+                if (extraPosition > 0L) {
+                    Timber.d("Playback stopped [player: $player, extra_position: $extraPosition, extra_duration: $extraDuration]")
+                    notifyEvent(Constants.EVENT_TIME_UPDATE, extraPosition.toString())
+                    notifyEvent(Constants.EVENT_ENDED)
+                } else {
+                    if (extraDuration == 0L && extraPosition == 0L) {
+                        Timber.d("Playback completed [player: $player]")
+                        notifyEvent(Constants.EVENT_TIME_UPDATE)
+                        notifyEvent(Constants.EVENT_ENDED)
+                    } else {
+                        Timber.d("Invalid state [player: $player, extra_position: $extraPosition, extra_duration: $extraDuration]")
+                        notifyEvent(
+                            Constants.EVENT_CANCELED,
+                            "'${activity.getString(R.string.external_player_unknown_error)}'"
+                        )
+                    }
+                }
+            }
+            else -> {
+                Timber.d("Playback failed [player: $player, resultCode: $resultCode]")
+                notifyEvent(
+                    Constants.EVENT_CANCELED,
+                    "'${activity.getString(R.string.external_player_unknown_error)}'"
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
@@ -12,6 +12,7 @@ class JellyfinMediaSource(item: JSONObject) {
     val title: String = item.optString("title")
     val artists: String? = item.optJSONObject("item")?.optJSONArray("Artists")?.asIterable()?.joinToString()
     val uri: Uri = Uri.parse(item.optString("url"))
+    val mimeType: String = item.optString("mimeType")
     val playMethod: String = item.optString("playMethod")
     val mediaStartMs: Long = item.optLong("playerStartPositionTicks") / Constants.TICKS_PER_MILLISECOND
     val mediaDurationTicks: Long

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -92,6 +92,18 @@ object Constants {
     // Video player intent extras
     const val EXTRA_MEDIA_SOURCE_ITEM = "org.jellyfin.mobile.MEDIA_SOURCE_ITEM"
 
+    // External player result code
+    const val HANDLE_EXTERNAL_PLAYER = 1
+
+    // External player result actions
+    const val MX_PLAYER_RESULT_ACTION = "com.mxtech.intent.result.VIEW"
+    const val VLC_PLAYER_RESULT_ACTION = "org.videolan.vlc.player.result"
+
+    // External player webapp events
+    const val EVENT_ENDED = "Ended"
+    const val EVENT_TIME_UPDATE = "TimeUpdate"
+    const val EVENT_CANCELED = "Canceled"
+
     // Orientation constants
     val ORIENTATION_PORTRAIT_RANGE = CombinedIntRange(340..360, 0..20)
     val ORIENTATION_LANDSCAPE_RANGE = CombinedIntRange(70..110, 250..290)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,9 @@
     <string name="pref_enable_exoplayer_title">Enable video player integration</string>
     <string name="pref_enable_exoplayer_summary">Enable the experimental ExoPlayer video player which supports more video formats and codecs, and is more integrated into the OS</string>
     <string name="pref_exoplayer_allow_background_audio">Allow playing audio in the background</string>
+
+    <string name="external_player_invalid_play_method">Invalid play method.</string>
+    <string name="external_player_not_supported_yet">Playback tracking not supported in selected external player yet. Contact developers to try to add support for it.</string>
+    <string name="external_player_invalid_player">No valid external player selected. Playback tracking disabled.</string>
+    <string name="external_player_unknown_error">Unknown error in external player. Playback tracking disabled.</string>
 </resources>


### PR DESCRIPTION
### Implement jellyfin-archive/jellyfin-android-original#67
Feel free to refactor the source code, the companion objects, Kotlin coroutines and english as well aren't my thing yet.

Supported players
- VLC Media Player
- MX Player

Notes
- Only works with DirectStream play method since a stream url is required.
- Uses ExoPlayer device profile since there is no way to get it from an external player.