### PR TITLE
Change battery optimization dialog to snackbar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     implementation(Dependencies.UI.webkitX)
     implementation(Dependencies.UI.exoPlayer)
     implementation(Dependencies.UI.modernAndroidPreferences)
+    implementation(Dependencies.UI.material)
 
     // Network
     implementation(Dependencies.Network.okHttp)

--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -11,12 +11,10 @@ import android.os.Bundle
 import android.os.IBinder
 import android.view.OrientationEventListener
 import android.webkit.*
-import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.doOnNextLayout
-import androidx.core.view.updatePadding
+import androidx.core.view.*
 import androidx.lifecycle.lifecycleScope
 import androidx.webkit.WebResourceErrorCompat
 import androidx.webkit.WebViewClientCompat
@@ -50,7 +48,7 @@ class MainActivity : AppCompatActivity(), WebViewController {
     private val connectionHelper = ConnectionHelper(this)
     private val webappFunctionChannel: Channel<String> by inject(named(WEBAPP_FUNCTION_CHANNEL))
 
-    val rootView: FrameLayout by lazyView(R.id.root_view)
+    val rootView: CoordinatorLayout by lazyView(R.id.root_view)
     val webView: WebView by lazyView(R.id.web_view)
 
     var serviceBinder: RemotePlayerService.ServiceBinder? = null
@@ -70,7 +68,7 @@ class MainActivity : AppCompatActivity(), WebViewController {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_webapp)
+        setContentView(R.layout.activity_main)
 
         // Bind player service
         bindService(Intent(this, RemotePlayerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)
@@ -78,7 +76,9 @@ class MainActivity : AppCompatActivity(), WebViewController {
         // Handle window insets
         setStableLayoutFlags()
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
-            v.updatePadding(top = insets.systemWindowInsetTop, bottom = insets.systemWindowInsetBottom)
+            val layoutParams = webView.layoutParams as CoordinatorLayout.LayoutParams
+            layoutParams.updateMargins(top = insets.systemWindowInsetTop, bottom = insets.systemWindowInsetBottom)
+
             insets
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -13,11 +13,13 @@ import android.provider.Settings
 import android.provider.Settings.System.ACCELEROMETER_ROTATION
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.getSystemService
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import org.jellyfin.mobile.BuildConfig
 import org.jellyfin.mobile.MainActivity
 import org.jellyfin.mobile.R
+import timber.log.Timber
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -25,21 +27,22 @@ fun MainActivity.requestNoBatteryOptimizations() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         val powerManager: PowerManager = getSystemService(AppCompatActivity.POWER_SERVICE) as PowerManager
         if (!appPreferences.ignoreBatteryOptimizations && !powerManager.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID)) {
-            val builder: AlertDialog.Builder = AlertDialog.Builder(this)
-            builder.setTitle(getString(R.string.battery_optimizations_title))
-            builder.setMessage(getString(R.string.battery_optimizations_message))
-            builder.setNegativeButton(android.R.string.cancel) { _, _ ->
-                appPreferences.ignoreBatteryOptimizations = true
-            }
-            builder.setPositiveButton(android.R.string.ok) { _, _ ->
-                try {
-                    val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
-                    startActivity(intent)
-                } catch (e: Exception) {
-                    e.printStackTrace()
+            Snackbar.make(rootView, R.string.battery_optimizations_message, Snackbar.LENGTH_INDEFINITE).apply {
+                // Add action
+                setAction(android.R.string.ok) {
+                    try {
+                        val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                        startActivity(intent)
+                    } catch (e: Exception) {
+                        Timber.e(e)
+                    }
+
+                    // Ignore after the user interacted with the snackbar at least once
+                    appPreferences.ignoreBatteryOptimizations = true
                 }
+
+                show()
             }
-            builder.show()
         }
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/webapp/ConnectionHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/ConnectionHelper.kt
@@ -7,9 +7,9 @@ import android.view.inputmethod.InputMethodManager
 import android.webkit.WebView
 import android.widget.Button
 import android.widget.EditText
-import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.getSystemService
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
@@ -42,7 +42,7 @@ class ConnectionHelper(private val activity: MainActivity) : KoinComponent {
     private val appPreferences: AppPreferences get() = activity.appPreferences
     private val jellyfin: Jellyfin by inject()
     private val apiClient: ApiClient get() = activity.apiClient
-    private val rootView: FrameLayout get() = activity.rootView
+    private val rootView: CoordinatorLayout get() = activity.rootView
     private val webView: WebView get() = activity.webView
 
     private var cachedInstanceUrl: HttpUrl? = null

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_view"
     android:layout_width="match_parent"
@@ -11,4 +11,4 @@
         android:id="@+id/web_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="mobile_data_and_roaming">Datos móviles e itinerancia</string>
-    <string name="battery_optimizations_title">Desactivar la optimización de la batería</string>
     <string name="downloading">Descargando</string>
     <string name="mobile_data">Datos móviles</string>
     <string name="wifi_only">Solo WiFi</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="network_title">Позволен мрежови тип</string>
     <string name="battery_optimizations_message">Моля изключете оптимизациите на батерията при възпроизвеждане на медия, когато екрана е изключен.</string>
-    <string name="battery_optimizations_title">Изключване оптимизациите на батерията</string>
     <string name="network_message">Желаете ли да позволите изтеглянето да стартира през мобилните данни или мрежа в Роуминг\?</string>
     <string name="downloading">Изтегляне</string>
     <string name="mobile_data_and_roaming">Мобилни Данни и Роуминг</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">Chcete povolit stahování přes mobilní data či roaming\?</string>
     <string name="network_title">Povolené typy sítě</string>
     <string name="battery_optimizations_message">Systémovou správu baterie pro tuto aplikaci je nutné vypnout, pokud chcete přehrávat s vypnutou obrazovkou.</string>
-    <string name="battery_optimizations_title">Vypnout systémovou správu baterie</string>
     <string name="connection_error_invalid_format">Formát hostitele je neplatný</string>
     <string name="connect_button_text">Připojit</string>
     <string name="host_input_hint">Hostitel</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="battery_optimizations_title">Batterieoptimierungen deaktivieren</string>
     <string name="battery_optimizations_message">Bitte deaktiviere die Batterieoptimierungen damit Medien bei ausgeschaltetem Bildschirm abgespielt werden können.</string>
     <string name="network_title">Erlaubte Verbindungsmöglichkeiten</string>
     <string name="network_message">Download über Mobile Daten oder Roaming erlauben\?</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">¿Desea permitir que la descarga se ejecute a través de datos móviles o redes de itinerancia\?</string>
     <string name="network_title">Tipos de red permitidos</string>
     <string name="battery_optimizations_message">Deshabilite las optimizaciones de batería para la reproducción de medios mientras la pantalla está apagada.</string>
-    <string name="battery_optimizations_title">Deshabilitar optimizaciones de batería</string>
     <string name="connect_to_server_title">Conectar al servidor</string>
     <string name="connection_error_invalid_format">El host tiene un formato no válido</string>
     <string name="connect_button_text">Conectar</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="battery_optimizations_title">Desactivar la optimización de la batería</string>
     <string name="downloading">Descargando</string>
     <string name="mobile_data_and_roaming">Datos móviles e itinerancia</string>
     <string name="mobile_data">Datos móviles</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,7 +6,6 @@
     <string name="wifi_only">Solo WiFi</string>
     <string name="network_message">¿Desea permitir que la descarga se ejecute a través de datos móviles o redes móviles\?</string>
     <string name="network_title">Tipo de redes permitidas</string>
-    <string name="battery_optimizations_title">Deshabilita la optimización de la batería</string>
     <string name="battery_optimizations_message">Por favor deshabilita la optimización de la batería para la reproducción de medios mientras la pantalla está apagada.</string>
     <string name="connection_error_invalid_format">El host tiene un formato no válido</string>
     <string name="connect_button_text">Conectado</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -4,7 +4,6 @@
     <string name="network_message">Haluatko sallia latauksen mobiilidatalla tai roaming-verkoissa\?</string>
     <string name="network_title">Sallitut verkkotyypit</string>
     <string name="battery_optimizations_message">Ole hyvä ja poista akun käytön optimointi käytöstä median toistolle, kun näyttö on suljettuna.</string>
-    <string name="battery_optimizations_title">Poista akun käytön optimointi käytöstä</string>
     <string name="downloading">Lataus</string>
     <string name="mobile_data_and_roaming">Mobiilidata &amp; Roaming</string>
     <string name="mobile_data">Mobiilidata</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -7,7 +7,6 @@
     <string name="mobile_data">Données mobile</string>
     <string name="wifi_only">Wi-Fi uniquement</string>
     <string name="network_title">Types de réseaux autorisés</string>
-    <string name="battery_optimizations_title">Désactiver les optimisations de la batterie</string>
     <string name="connection_error_invalid_format">L\'hôte a un format invalide</string>
     <string name="connect_button_text">Se connecter</string>
     <string name="host_input_hint">Hôte</string>

--- a/app/src/main/res/values-he-rIL/strings.xml
+++ b/app/src/main/res/values-he-rIL/strings.xml
@@ -18,7 +18,6 @@
     <string name="network_message">האם אתה מאשר לבצע הורדה על גבי רשת הסלולר או נדידה \?</string>
     <string name="network_title">אפשרויות תקשורת מורשות</string>
     <string name="battery_optimizations_message">אנא כבה את מצב החסכון בסוללה להפעלה בזמן שהמסך כבוי.</string>
-    <string name="battery_optimizations_title">בטל חסכון בסוללה</string>
     <string name="connect_button_text">התחבר</string>
     <string name="connection_error_cannot_connect">החיבור לא הצליח.
 \nאנא בדוק את כתובת השרת ואת החיבור לרשת.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">Engedélyezed a letöltést mobil adatforgalom és roaming esetén\?</string>
     <string name="network_title">Engedélyezett hálózat típusok</string>
     <string name="battery_optimizations_message">Ahhoz, hogy a lejátszás kikapcsolt képernyő mellett is működhessen, kapcsold ki az akkumulátor optimalizálást.</string>
-    <string name="battery_optimizations_title">Akkumulátor optimalizálás letiltása</string>
     <string name="connection_error_invalid_format">A hoszt formátuma helytelen</string>
     <string name="connect_button_text">Kapcsolódás</string>
     <string name="host_input_hint">Hoszt</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -16,7 +16,6 @@
     <string name="mobile_data">Data Seluler</string>
     <string name="network_message">Apakah Anda ingin mengizinkan unduhan berjalan melalui data seluler atau jaringan roaming\?</string>
     <string name="battery_optimizations_message">Nonaktifkan pengoptimalan baterai untuk pemutaran media saat layar mati.</string>
-    <string name="battery_optimizations_title">Nonaktifkan Pengoptimalan Baterai</string>
     <string name="connection_error_invalid_format">Host memiliki format yang tidak valid</string>
     <string name="downloading">Mengunduh</string>
     <string name="playback_info_and_x_more">… Dan %d lainnya</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -6,7 +6,6 @@
     <string name="wifi_only">Solo WiFi</string>
     <string name="network_message">Consentire il download dei media quando utilizzi i dati mobili o sei in roaming\?</string>
     <string name="battery_optimizations_message">Disabilita le ottimizzazioni della battera per consentire la riproduzione in background quando lo schermo è spento.</string>
-    <string name="battery_optimizations_title">Disabilita ottimizzazione della batteria</string>
     <string name="network_title">Tipi di Rete Permessi</string>
     <string name="pref_enable_exoplayer_summary">Abilita il lettore ExoPlayer sperimentale che supporta numerosi formati video ed è più integrato nel Sistema Operativo</string>
     <string name="pref_enable_exoplayer_title">Abilita integrazione del video player</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -6,7 +6,6 @@
     <string name="mobile_data">모바일 데이터</string>
     <string name="network_message">모바일 데이터 혹은 로밍 네트워크를 사용하여 다운로드하는 것을 허용하겠습니까\?</string>
     <string name="network_title">허용된 네트워크 종류</string>
-    <string name="battery_optimizations_title">배터리 최적화 비활성화</string>
     <string name="connection_error_invalid_format">호스트가 올바르지 않은 포맷을 사용합니다</string>
     <string name="connect_button_text">연결</string>
     <string name="host_input_hint">호스트</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -7,5 +7,4 @@
     <string name="network_message">Ar norite leisti duomenų siuntimą per mobilius arba tarptinklinius tinklus\?</string>
     <string name="network_title">Leidžiamos Tinklo Rūšys</string>
     <string name="battery_optimizations_message">Prašome išjungti baterijos optimizavimą, tam kad medijos atkūrimas veiktų išjungus ekraną.</string>
-    <string name="battery_optimizations_title">Išjungti Batterijos Optimizavimą</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -7,5 +7,4 @@
     <string name="network_message">Vai tu vēlies atļaut lejupielādēt izmantojot mobilos vai viesabonēšanas tīklus\?</string>
     <string name="network_title">Atļautie Tīkla Veidi</string>
     <string name="battery_optimizations_message">Lūdzu atspējo baterijas optimizāciju lai atskaņotu saturu kamēr ekrāns ir izslēgts.</string>
-    <string name="battery_optimizations_title">Atspējo Baterijas Optimizāciju</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">Tillat nedlasting over mobildata eller roaming-nettverk\?</string>
     <string name="network_title">Tillatte nettverkstyper</string>
     <string name="battery_optimizations_message">Deaktiver batterioptimaliseringer for avspilling mens skjermen er av.</string>
-    <string name="battery_optimizations_title">Deaktiver batterioptimaliseringer</string>
     <string name="connection_error_invalid_format">Tjeneren har et ugyldig format</string>
     <string name="connect_button_text">Koble til</string>
     <string name="host_input_hint">Tjener</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -7,7 +7,6 @@
     <string name="mobile_data">Mobiele data</string>
     <string name="wifi_only">Alleen op WiFi</string>
     <string name="battery_optimizations_message">Zet batterijoptimalisatie uit om media te spelen wanneer het scherm uit is.</string>
-    <string name="battery_optimizations_title">Batterijoptimalisaties uitschakelen</string>
     <string name="connection_error_invalid_format">Host heeft een ongeldig formaat</string>
     <string name="host_input_hint">Host</string>
     <string name="connect_button_text">Verbind</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">Gostaria de habilitar o download através de dados móveis ou roaming\?</string>
     <string name="network_title">Tipos de Rede Permitidos</string>
     <string name="battery_optimizations_message">Por favor desative otimizações da bateria para possibilitar a reprodução de mídia com a tela desligada.</string>
-    <string name="battery_optimizations_title">Desativar Otimizações da Bateria</string>
     <string name="activity_name_settings">Configurações do Jellyfin</string>
     <string name="playback_info_and_x_more">…e %d mais</string>
     <string name="playback_info_transcoding">Transcodificação: %b</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -7,5 +7,4 @@
     <string name="network_message">Desejas permitir que o download seja executado em dados móveis ou redes de roaming\?</string>
     <string name="network_title">Tipos de rede permitidos</string>
     <string name="battery_optimizations_message">Por favor, desativa as otimizações de bateria para reprodução de media enquanto o ecrã está desligado.</string>
-    <string name="battery_optimizations_title">Desativar as otimizações de bateria</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">Doriți să permiteți descărcarea să ruleze pe date mobile sau rețele de roaming\?</string>
     <string name="network_title">Tipuri de rețea permise</string>
     <string name="battery_optimizations_message">Vă rugăm să dezactivați optimizările bateriei pentru redarea media cu ecranul stins.</string>
-    <string name="battery_optimizations_title">Dezactivați optimizările bateriei</string>
     <string name="connection_error_invalid_format">Gazda are un format invalid</string>
     <string name="connect_button_text">Conectare</string>
     <string name="host_input_hint">Gazdă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -7,7 +7,6 @@
     <string name="wifi_only">Только WiFi</string>
     <string name="network_message">Вы разрешаете осуществлять скачивание при использовании мобильным интернетом или в роуминге\?</string>
     <string name="network_title">Доступные типы сетей</string>
-    <string name="battery_optimizations_title">Выключить оптимизацию энергопотребления при работе от батареи</string>
     <string name="connect_to_server_title">Соединение</string>
     <string name="pref_category_video_player">Встроенный видео плеер</string>
     <string name="pref_category_music_player">Музыкальный проигрыватель</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">Chcete povoliť sťahovanie pomocou mobilných dát alebo roamingových sietí\?</string>
     <string name="network_title">Povoliť sieťové typy</string>
     <string name="battery_optimizations_message">Prosím, zakážte optimalizáciu batérie pre prehrávanie medií počas vypnutej obrazovky.</string>
-    <string name="battery_optimizations_title">Zakázať optimalizáciu batérie</string>
     <string name="connection_error_invalid_format">Formát hostiteľa je neplatný</string>
     <string name="connect_button_text">Pripojiť</string>
     <string name="host_input_hint">Hostiteľ</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -7,7 +7,6 @@
     <string name="network_message">Ali želite omogočiti prenos prek mobilnih podatkov ali v gostovanju\?</string>
     <string name="network_title">Dovoljene vrste omrežja</string>
     <string name="battery_optimizations_message">Prosimo onemogočite optimizacijo akumulatorja za predvajanje predstavnosti pri izklopljenem zaslonu.</string>
-    <string name="battery_optimizations_title">Onemogoči optimizacijo akumulatorja</string>
     <string name="connection_error_invalid_format">Napačen format naslova</string>
     <string name="connect_button_text">Poveži</string>
     <string name="host_input_hint">Naslov</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -14,7 +14,6 @@
     <string name="network_message">மொபைல் தரவு அல்லது ரோமிங் நெட்வொர்க்குகள் மூலம் பதிவிறக்கத்தை இயக்க அனுமதிக்க விரும்புகிறீர்களா\?</string>
     <string name="network_title">அனுமதிக்கப்பட்ட பிணைய வகைகள்</string>
     <string name="battery_optimizations_message">திரை முடக்கத்தில் இருக்கும்போது மீடியா பிளேபேக்கிற்கான பேட்டரி மேம்படுத்தல்களை முடக்கவும்.</string>
-    <string name="battery_optimizations_title">பேட்டரி உகப்பாக்கங்களை முடக்கு</string>
     <string name="connection_error_invalid_format">ஹோஸ்ட் தவறான வடிவத்தைக் கொண்டுள்ளது</string>
     <string name="connect_button_text">இணை</string>
     <string name="host_input_hint">ஹோஸ்ட்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -27,7 +27,6 @@
     <string name="network_message">คุณต้องการอนุญาตให้ดาวน์โหลดผ่านข้อมูลมือถือหรือเครือข่ายโรมมิ่งหรือไม่\?</string>
     <string name="network_title">ประเภทเครือข่ายที่อนุญาต</string>
     <string name="battery_optimizations_message">โปรดปิดการใช้งานการเพิ่มประสิทธิภาพแบตเตอรี่เพื่อเล่นสื่อในขณะที่หน้าจอปิดอยู่</string>
-    <string name="battery_optimizations_title">ปิดการใช้งานการเพิ่มประสิทธิภาพแบตเตอรี่</string>
     <string name="connect_button_text">เชื่อมต่อ</string>
     <string name="connection_error_cannot_connect">ไม่สามารถสร้างการเชื่อมต่อได้
 \nโปรดตรวจสอบชื่อโฮสต์และการเชื่อมต่อเครือข่ายของคุณ</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="battery_optimizations_title">Вимкнути оптимізацію акумулятора</string>
     <string name="downloading">Завантаження</string>
     <string name="mobile_data_and_roaming">Мобільні дані та роумінг</string>
     <string name="mobile_data">Мобільні дані</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="battery_optimizations_message">要在屏幕关闭时播放媒体，请禁用电池优化。</string>
-    <string name="battery_optimizations_title">禁用电池优化</string>
     <string name="mobile_data_and_roaming">移动数据和漫游</string>
     <string name="mobile_data">移动数据</string>
     <string name="wifi_only">仅使用WiFi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="connection_error_cannot_connect">Connection cannot be established.\nPlease check the hostname and your network connection.</string>
     <string name="connect_button_text">Connect</string>
 
-    <string name="battery_optimizations_title">Disable Battery Optimizations</string>
     <string name="battery_optimizations_message">Please disable battery optimizations for media playback while the screen is off.</string>
     <string name="network_title">Allowed Network Types</string>
     <string name="network_message">Do you want to allow the download to run over mobile data or roaming networks?</string>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -28,6 +28,7 @@ object Dependencies {
         const val webkitX = "1.2.0"
         const val coil = "0.11.0"
         const val modernAndroidPreferences = "1.0-RC2"
+        const val material = "1.2.1"
 
         // Cast
         const val mediaRouter = "1.1.0"
@@ -79,6 +80,7 @@ object Dependencies {
         val webkitX = androidx("webkit", Versions.webkitX)
         val exoPlayer = exoPlayer("ui")
         const val modernAndroidPreferences = "de.Maxr1998.android:modernpreferences:${Versions.modernAndroidPreferences}"
+        const val material = "com.google.android.material:material:${Versions.material}"
     }
 
     object Network {


### PR DESCRIPTION
It's really annoying for first-time users to get that annoying alert. The snackbar will always show when the app starts unless the "ok" button is pressed once or the optimization is applied.

I changed the main activity to a coordinatorlayout because the snackbar requires that for the dismiss swipe gesture. I had to change some additional things in the webview inset code thingy for it to work properly.

![image](https://user-images.githubusercontent.com/2305178/92302946-c6dd7800-ef70-11ea-869a-4d4c9694651c.png)

