### PR TITLE
Fix UI overlap by applying also horizontal insets

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -80,10 +80,14 @@ class MainActivity : AppCompatActivity(), WebViewController {
 
         // Handle window insets
         setStableLayoutFlags()
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { _, insets ->
             val layoutParams = webView.layoutParams as CoordinatorLayout.LayoutParams
-            layoutParams.updateMargins(top = insets.systemWindowInsetTop, bottom = insets.systemWindowInsetBottom)
-
+            layoutParams.updateMargins(
+                left = insets.systemWindowInsetLeft,
+                top = insets.systemWindowInsetTop,
+                right = insets.systemWindowInsetRight,
+                bottom = insets.systemWindowInsetBottom
+            )
             insets
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {


### PR DESCRIPTION
And remove warning about unused 'v' parameter in build, missing for some reason in #74?

**Before**:
![image](https://user-images.githubusercontent.com/25919231/92776778-308cc600-f365-11ea-8e93-885a40b73898.png)
![image](https://user-images.githubusercontent.com/25919231/92776807-3682a700-f365-11ea-9797-74b73bb6e045.png)


**After**:
![image](https://user-images.githubusercontent.com/25919231/92776850-413d3c00-f365-11ea-8dc1-f2310a7d8444.png)
![image](https://user-images.githubusercontent.com/25919231/92776867-44382c80-f365-11ea-9442-0645b4158b40.png)
