### PR TITLE
Use display language when available

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -158,6 +158,7 @@ class MainActivity : AppCompatActivity(), WebViewController {
                                     val token = server.getString("AccessToken")
                                     apiClient.ChangeServerLocation(address)
                                     apiClient.SetAuthenticationInfo(token, user)
+                                    initLocale()
                                 } catch (e: JSONException) {
                                     Timber.e(e, "Failed to extract apiclient credentials")
                                 }

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsActivity.kt
@@ -20,6 +20,7 @@ class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setTitle(R.string.activity_name_settings)
         setContentView(R.layout.activity_settings)
         setSupportActionBar(findViewById(R.id.toolbar))
         supportActionBar?.setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/org/jellyfin/mobile/utils/ApiExtensions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/ApiExtensions.kt
@@ -3,6 +3,7 @@ package org.jellyfin.mobile.utils
 import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.apiclient.interaction.EmptyResponse
 import org.jellyfin.apiclient.interaction.Response
+import org.jellyfin.apiclient.model.configuration.ServerConfiguration
 import org.jellyfin.apiclient.model.dto.UserItemDataDto
 import org.jellyfin.apiclient.model.session.PlaybackProgressInfo
 import org.jellyfin.apiclient.model.session.PlaybackStopInfo
@@ -19,6 +20,10 @@ val PRODUCT_NAME_SUPPORTED_SINCE: Pair<Int, Int> = 10 to 3
 // Can be removed/replaced once the api client supports coroutines natively
 suspend fun ApiClient.getPublicSystemInfo(): PublicSystemInfo? = suspendCoroutine { continuation ->
     GetPublicSystemInfoAsync(ContinuationResponse(continuation))
+}
+
+suspend fun ApiClient.getServerConfiguration(): ServerConfiguration? = suspendCoroutine { continuation ->
+    GetServerConfigurationAsync(ContinuationResponse(continuation))
 }
 
 suspend fun ApiClient.reportPlaybackProgress(progressInfo: PlaybackProgressInfo) = suspendCoroutine<Unit> { continuation ->

--- a/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
@@ -1,0 +1,53 @@
+package org.jellyfin.mobile.utils
+
+import android.app.Activity
+import android.content.res.Configuration
+import android.os.Build
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import org.jellyfin.mobile.MainActivity
+import timber.log.Timber
+import java.util.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+fun MainActivity.initLocale() = lifecycleScope.launch {
+    // Try to set locale via user settings
+    val userSettings = suspendCoroutine<String> { continuation ->
+        webView.evaluateJavascript("window.localStorage.getItem('${apiClient.currentUserId}-language')") { result ->
+            continuation.resume(result)
+        }
+    }
+    if (setLocale(userSettings.unescapeJson()))
+        return@launch
+
+    // Fallback to device locale
+    Timber.i("Couldn't acquire locale from config, keeping current")
+}
+
+private fun Activity.setLocale(localeString: String?): Boolean {
+    if (localeString.isNullOrEmpty() || localeString == "null")
+        return false
+
+    val localeSplit = localeString.split('-')
+    val locale = when (localeSplit.size) {
+        1 -> Locale(localeString, "")
+        2 -> Locale(localeSplit[0], localeSplit[1])
+        else -> return false
+    }
+
+    val configuration = resources.configuration
+    if (locale != configuration.primaryLocale) {
+        Locale.setDefault(locale)
+        configuration.setLocale(locale)
+        @Suppress("DEPRECATION")
+        resources.updateConfiguration(configuration, resources.displayMetrics)
+
+        Timber.i("Updated locale from web: '$locale'")
+    } // else: Locale is already applied
+    return true
+}
+
+@Suppress("DEPRECATION")
+private val Configuration.primaryLocale: Locale
+    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) locales[0] else locale


### PR DESCRIPTION
In the next order:
1. User settings
2. ~~Server settings~~
3. Android settings

For now, it's necessary to restart the application manually when the language is changed, as long as no [events](https://github.com/jellyfin/jellyfin-web/blob/c8b6b44b7bf79c5a14055c6262b85b5af9cd7554/src/scripts/globalize.js#L259) are handled.

Closes #83 