### PR TITLE
Keep ApiClient models enumerations members

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,6 +19,9 @@
     public *;
 }
 
+# Keep ApiClient models enumerations members
+-keepclassmembers enum org.jellyfin.apiclient.model.**.* { *; }
+
 # Keep file names/line numbers
 -keepattributes SourceFile,LineNumberTable
 


### PR DESCRIPTION
Closes #116 

See: https://stackoverflow.com/questions/15543607/assertionerror-in-gson-enumtypeadapter-when-using-proguard-obfuscation#comment112854882_30167048