### PR TITLE
Fix ProGuard configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     implementation(Dependencies.UI.modernAndroidPreferences)
 
     // Network
-    implementation(Dependencies.Network.apiClient)
+    implementation(Dependencies.Network.apiclient)
     implementation(Dependencies.Network.okHttp)
     implementation(Dependencies.Network.coil)
     implementation(Dependencies.Network.exoPlayerHLS)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -26,7 +26,7 @@ object Dependencies {
         const val modernAndroidPreferences = "1.1.0-alpha3"
 
         // Network
-        const val apiClient = "0.7.2"
+        const val apiclient = "0.7.4"
         const val okHttp = "4.8.0"
         const val coil = "0.11.0"
 
@@ -80,7 +80,7 @@ object Dependencies {
     }
 
     object Network {
-        const val apiClient = "org.jellyfin.apiclient:android:${Versions.apiClient}"
+        const val apiclient = "org.jellyfin.apiclient:android:${Versions.apiclient}"
         const val okHttp = "com.squareup.okhttp3:okhttp:${Versions.okHttp}"
         const val coil = "io.coil-kt:coil-base:${Versions.coil}"
         val exoPlayerHLS = exoPlayer("hls")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 include(":app")
 
 pluginManagement {
@@ -11,8 +13,8 @@ pluginManagement {
 }
 
 // Load properties from local.properties
-val properties = java.util.Properties().apply {
-    val location = file("local.properties")
+val properties = Properties().apply {
+    val location = File("local.properties")
     if (location.exists())
         load(location.inputStream())
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,3 +9,23 @@ pluginManagement {
         }
     }
 }
+
+// Load properties from local.properties
+val properties = java.util.Properties().apply {
+    val location = file("local.properties")
+    if (location.exists())
+        load(location.inputStream())
+}
+
+// Get value for dependency substitution
+val enableDependencySubstitution = properties.getProperty("enable.dependency.substitution", "true").equals("true", true)
+
+// Replace apiclient dependency with local version
+val apiclientLocation = "../jellyfin-apiclient-java"
+if (File(apiclientLocation).exists() && enableDependencySubstitution) {
+    includeBuild(apiclientLocation) {
+        dependencySubstitution {
+            substitute(module("org.jellyfin.apiclient:android")).with(project(":android"))
+        }
+    }
+}


### PR DESCRIPTION
The dependency substitution code is from the Android TV app. Note that it's not possible to use buildSrc inside of Gradle settings files.

**Testing**

To the if this actually fixes the issues you can enable ProGuard in the debug builds (copy the code from the release flavor in the build.gradle.kts file)

Closes #116 (tested) 
Closes #119 (tested)