### PR TITLE
Set appMode for webui

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
@@ -7,11 +7,14 @@ import java.io.IOException
 
 const val JS_INJECTION_CODE = """
 !function() {
+    window['appMode'] = 'android';
+    
     var scripts = [
         '/native/nativeshell.js',
         '/native/EventEmitter.js',
         '/native/chrome.cast.js',
     ];
+    
     scripts.forEach(function(src) {
         var scriptElement = document.createElement('script');
         scriptElement.type = 'text/javascript';


### PR DESCRIPTION
The webui needs the `appMode` property set to either `cordova` or `android` for some behavior. We didn't do that.

Relevant code in web: https://github.com/jellyfin/jellyfin-web/blob/692d404285c19e1700a74fec23b4804273d12ac3/src/components/castSenderApi.js#L3

As you can see, if the app mode is not set it will always load the cast_sender JavaScript from Google, this JS would then overwrite our own injected code. By setting the appMode it doesn't do that.

It doesn't fix most chromecast issues though.