### PR TITLE
Add support for external player choice inside client settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,19 @@
         tools:node="remove" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage" />
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="*/*" />
+        </intent>
+        <package android:name="com.mxtech.videoplayer.ad" />
+        <package android:name="com.mxtech.videoplayer.pro" />
+        <package android:name="is.xyz.mpv" />
+        <package android:name="org.videolan.vlc" />
+    </queries>
 
     <application
         android:name=".JellyfinApplication"

--- a/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
@@ -3,6 +3,7 @@ package org.jellyfin.mobile
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import org.jellyfin.mobile.settings.ExternalPlayerPackage
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
 
@@ -46,4 +47,9 @@ class AppPreferences(context: Context) {
 
     val exoPlayerAllowBackgroundAudio: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO, false)
+
+    @ExternalPlayerPackage
+    var externalPlayerApp: String
+        get() = sharedPreferences.getString(Constants.PREF_EXTERNAL_PLAYER_APP, ExternalPlayerPackage.SYSTEM_DEFAULT)!!
+        set(value) = sharedPreferences.edit { putString(Constants.PREF_EXTERNAL_PLAYER_APP, value) }
 }

--- a/app/src/main/java/org/jellyfin/mobile/settings/ExternalPlayerPackage.java
+++ b/app/src/main/java/org/jellyfin/mobile/settings/ExternalPlayerPackage.java
@@ -1,0 +1,19 @@
+package org.jellyfin.mobile.settings;
+
+
+import androidx.annotation.StringDef;
+
+@StringDef({
+        ExternalPlayerPackage.MPV_PLAYER,
+        ExternalPlayerPackage.MX_PLAYER_FREE,
+        ExternalPlayerPackage.MX_PLAYER_PRO,
+        ExternalPlayerPackage.VLC_PLAYER,
+        ExternalPlayerPackage.SYSTEM_DEFAULT
+})
+public @interface ExternalPlayerPackage {
+    String MPV_PLAYER = "is.xyz.mpv";
+    String MX_PLAYER_FREE = "com.mxtech.videoplayer.ad";
+    String MX_PLAYER_PRO = "com.mxtech.videoplayer.pro";
+    String VLC_PLAYER = "org.videolan.vlc";
+    String SYSTEM_DEFAULT = "~system~";
+}

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -16,6 +16,7 @@ import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.applyWindowInsetsAsMargins
 import org.jellyfin.mobile.utils.requireMainActivity
 import org.jellyfin.mobile.utils.withThemedContext
+import org.jellyfin.mobile.utils.isPackageInstalled
 import org.koin.android.ext.android.inject
 
 class SettingsFragment : Fragment() {
@@ -24,6 +25,7 @@ class SettingsFragment : Fragment() {
     private val settingsAdapter: PreferencesAdapter by lazy { PreferencesAdapter(buildSettingsScreen()) }
     private lateinit var backgroundAudioPreference: Preference
     private lateinit var swipeGesturesPreference: Preference
+    private lateinit var externalPlayerChoicePreference: Preference
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val localInflater = inflater.withThemedContext(requireContext(), R.style.AppTheme_Settings)
@@ -65,6 +67,7 @@ class SettingsFragment : Fragment() {
             defaultOnSelectionChange { selection ->
                 swipeGesturesPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 backgroundAudioPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
+                externalPlayerChoicePreference.enabled = selection == VideoPlayerType.EXTERNAL_PLAYER
             }
         }
         swipeGesturesPreference = checkBox(Constants.PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES) {
@@ -75,6 +78,17 @@ class SettingsFragment : Fragment() {
         backgroundAudioPreference = checkBox(Constants.PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO) {
             titleRes = R.string.pref_exoplayer_allow_background_audio
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
+        }
+        val externalPlayerOptions = listOf(
+            SelectionItem(ExternalPlayerPackage.MPV_PLAYER, R.string.external_player_mpv, R.string.external_player_mpv_description),
+            SelectionItem(ExternalPlayerPackage.MX_PLAYER_FREE, R.string.external_player_mx_player_free, R.string.external_player_mx_player_free_description),
+            SelectionItem(ExternalPlayerPackage.MX_PLAYER_PRO, R.string.external_player_mx_player_pro, R.string.external_player_mx_player_pro_description),
+            SelectionItem(ExternalPlayerPackage.VLC_PLAYER, R.string.external_player_vlc_player, R.string.external_player_vlc_player_description),
+        ).filter { isPackageInstalled(it.key) }.plus(SelectionItem(ExternalPlayerPackage.SYSTEM_DEFAULT, R.string.external_player_system_default, R.string.external_player_system_default_description))
+        if (!isPackageInstalled(appPreferences.externalPlayerApp)) appPreferences.externalPlayerApp = ExternalPlayerPackage.SYSTEM_DEFAULT
+        externalPlayerChoicePreference = singleChoice(Constants.PREF_EXTERNAL_PLAYER_APP, externalPlayerOptions) {
+            titleRes = R.string.external_player_app
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXTERNAL_PLAYER
         }
     }
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -24,6 +24,7 @@ object Constants {
     const val PREF_VIDEO_PLAYER_TYPE = "pref_video_player_type"
     const val PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES = "pref_exoplayer_allow_swipe_gestures"
     const val PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO = "pref_exoplayer_allow_background_audio"
+    const val PREF_EXTERNAL_PLAYER_APP = "pref_external_player_app"
 
     // InputManager commands
     const val INPUT_MANAGER_COMMAND_PLAY_PAUSE = "playpause"

--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -4,6 +4,7 @@ import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.*
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.Uri
 import android.os.Build
@@ -13,6 +14,7 @@ import android.provider.Settings
 import android.provider.Settings.System.ACCELEROMETER_ROTATION
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.getSystemService
+import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
@@ -21,6 +23,7 @@ import org.jellyfin.mobile.BuildConfig
 import org.jellyfin.mobile.MainActivity
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.fragment.WebViewFragment
+import org.jellyfin.mobile.settings.ExternalPlayerPackage
 import org.koin.android.ext.android.get
 import timber.log.Timber
 import kotlin.coroutines.resume
@@ -114,6 +117,12 @@ private fun Context.downloadFile(request: DownloadManager.Request, @DownloadMeth
 }
 
 fun Activity.isAutoRotateOn() = Settings.System.getInt(contentResolver, ACCELEROMETER_ROTATION, 0) == 1
+
+fun Fragment.isPackageInstalled(@ExternalPlayerPackage packageName: String) = try {
+    packageName.isNotEmpty() && requireContext().packageManager.getApplicationInfo(packageName, 0).enabled
+} catch (e: PackageManager.NameNotFoundException) {
+    false
+}
 
 fun Context.createMediaNotificationChannel(notificationManager: NotificationManager) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,16 @@
     <string name="video_player_external_description">External video playback apps like MX Player and VLC</string>
     <string name="pref_exoplayer_allow_background_audio">Allow playing audio in the background in native player</string>
     <string name="pref_exoplayer_allow_brightness_volume_gesture">Allow brightness and volume gestures in native player</string>
+    
+    <string name="external_player_app">External player app</string>
+    <string name="external_player_mpv">MPV Player</string>
+    <string name="external_player_mpv_description">A simple, small and light-weight free (as in freedom) video player. It supports a wide variety of media file formats.</string>
+    <string name="external_player_mx_player_free">MX Player Free</string>
+    <string name="external_player_mx_player_free_description">Powerful video player with advanced hardware acceleration and subtitle support.</string>
+    <string name="external_player_mx_player_pro">MX Player Pro</string>
+    <string name="external_player_mx_player_pro_description">The paid version of MX Player which provides an uninterrupted video experience.</string>
+    <string name="external_player_vlc_player">VLC Player</string>
+    <string name="external_player_vlc_player_description">Free and open source cross-platform multimedia player that plays most multimedia files.</string>
+    <string name="external_player_system_default">System default</string>
+    <string name="external_player_system_default_description">Let the system handle the player choice, some players may not be fully compatible.</string>
 </resources>


### PR DESCRIPTION
System choice by default.
Useful to force playback on a specific player without depending on android settings.
For now it only shows a list of the players that support playback tracking as long as they are installed and enabled.