### PR TITLE
Handle WebView error on unavailable instance

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
@@ -157,6 +157,8 @@ class WebViewFragment : Fragment() {
             override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceErrorCompat) {
                 val description = if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_RESOURCE_ERROR_GET_DESCRIPTION)) error.description else null
                 Timber.e("Received WebView error at %s: %s", request.url.toString(), description)
+                if (request.url.toString() == appPreferences.instanceUrl)
+                    runOnUiThread { onErrorReceived() }
             }
         }
         webChromeClient = WebChromeClient()


### PR DESCRIPTION
This assumes that if an error occurs when loading the url of the saved instance, it is not available. Which would redirect the user to the connection fragment instead of showing a WebView error. Similar to previous behavior in v2.0.0-rc.3

Note: This only handles the case when even cache loading fails, #44 still needs to be fixed.

See https://github.com/jellyfin/jellyfin-android/issues/44#issuecomment-689607259 #131 #173