### PR TITLE
Update Core-ktx to 1.4.0-alpha01

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Dependencies {
         // Core
         const val koin = "2.1.6"
         const val appCompat = "1.1.0"
-        const val androidxCore = "1.3.0"
+        const val androidxCore = "1.4.0-alpha01"
         const val activity = "1.1.0"
         const val fragment = "1.2.5"
         const val exoPlayer = "2.11.7"


### PR DESCRIPTION
[Core-ktx Version 1.4.0-alpha01](https://developer.android.com/jetpack/androidx/releases/core#1.4.0-alpha01)

Relevant Bug Fixes

- Extracted v28+ calls into a separate static class, which fixes a NoClassDefFoundError error for View#OnUnhandledKeyEventListener when building an app bundle ([Id3419](https://android-review.googlesource.com/#/q/Id34194f77b9c7a2f0864e38d17ef6039733dee95))

See https://github.com/jellyfin/jellyfin-android/issues/172#issuecomment-706538410