### PR TITLE
chore(CI): update JavaVersion used by GradleW tasks

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
           publishJUnitResults: true
           testResultsFiles: '**/TEST-*.xml'
           javaHomeOption: 'JDKVersion'
+          jdkVersionOption: 1.11
           sonarQubeRunAnalysis: false
 
   - job: Build
@@ -53,6 +54,7 @@ jobs:
           publishJUnitResults: false
           testResultsFiles: '**/TEST-*.xml'
           javaHomeOption: 'JDKVersion'
+          jdkVersionOption: 1.11
           sonarQubeRunAnalysis: false
 
       - task: Gradle@2
@@ -63,6 +65,7 @@ jobs:
           publishJUnitResults: false
           testResultsFiles: '**/TEST-*.xml'
           javaHomeOption: 'JDKVersion'
+          jdkVersionOption: 1.11
           sonarQubeRunAnalysis: false
 
       - task: CopyFiles@2


### PR DESCRIPTION
As CarlosOlivo discovered in the #175 azure CI run throws a warning for a JDK error in JDK 1.8.
I looked up how to "update"/select which JDK gets used by the [`Gradle@2`](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/gradle?view=azure-devops) task and this basic PR is the result :wink: 

**Changes**

* update JDK version used by the `Gradle@2` tasks to JDK 11

**Issues**

* N/A