### PR TITLE
Handle fragment destroy properly to prevent leaks

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/fragment/ConnectFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/ConnectFragment.kt
@@ -42,7 +42,8 @@ class ConnectFragment : Fragment() {
     private val appPreferences: AppPreferences by inject()
 
     // UI
-    private lateinit var connectServerBinding: FragmentConnectBinding
+    private var _connectServerBinding: FragmentConnectBinding? = null
+    private val connectServerBinding get() = _connectServerBinding!!
     private val serverSetupLayout: View get() = connectServerBinding.root
     private val hostInput: EditText get() = connectServerBinding.hostInput
     private val connectionErrorText: TextView get() = connectServerBinding.connectionErrorText
@@ -52,7 +53,7 @@ class ConnectFragment : Fragment() {
     private val serverList = ArrayList<DiscoveryServerInfo>(ServerDiscovery.DISCOVERY_MAX_SERVERS)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        connectServerBinding = FragmentConnectBinding.inflate(inflater, container, false)
+        _connectServerBinding = FragmentConnectBinding.inflate(inflater, container, false)
         return serverSetupLayout.apply { applyWindowInsetsAsMargins() }
     }
 
@@ -93,6 +94,11 @@ class ConnectFragment : Fragment() {
         }
 
         discoverServers()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _connectServerBinding = null
     }
 
     private fun connect(enteredUrl: String = hostInput.text.toString()) {

--- a/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
@@ -46,8 +46,9 @@ class WebViewFragment : Fragment() {
     private var connected = false
 
     // UI
-    lateinit var webView: WebView
-        private set
+    private var _webViewBinding: FragmentWebviewBinding? = null
+    private val webViewBinding get() = _webViewBinding!!
+    val webView: WebView get() = webViewBinding.root
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -60,7 +61,7 @@ class WebViewFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        webView = FragmentWebviewBinding.inflate(inflater, container, false).root
+        _webViewBinding = FragmentWebviewBinding.inflate(inflater, container, false)
         return webView.apply { applyWindowInsetsAsMargins() }
     }
 
@@ -102,6 +103,11 @@ class WebViewFragment : Fragment() {
                 webView.loadUrl("javascript:$function")
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _webViewBinding = null
     }
 
     @SuppressLint("SetJavaScriptEnabled")


### PR DESCRIPTION
From https://developer.android.com/topic/libraries/view-binding#fragments

> Note: Fragments outlive their views. Make sure you clean up any references to the binding class instance in the fragment's onDestroyView() method.