### PR TITLE
Update Activity-ktx to 1.2.0-alpha01

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Dependencies {
         const val koin = "2.1.6"
         const val appCompat = "1.1.0"
         const val androidxCore = "1.4.0-alpha01"
-        const val activity = "1.1.0"
+        const val activity = "1.2.0-alpha01"
         const val fragment = "1.2.5"
         const val exoPlayer = "2.12.0"
 


### PR DESCRIPTION
[Activity-ktx Version 1.2.0-alpha01](https://developer.android.com/jetpack/androidx/releases/activity#1.2.0-alpha01)

Bug Fixes

- Fixed a regression introduced in Activity 1.1.0 when running on older versions of the platform where onBackPressed() would cause an IllegalStateException due to a bug in the android.app.FragmentManager. ([b/146290338](https://issuetracker.google.com/issues/146290338))