### PR TITLE
Bump apiclient version to 0.7.7

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,7 +30,7 @@ object Dependencies {
         const val room = "2.2.5"
 
         // Network
-        const val apiclient = "0.7.6"
+        const val apiclient = "0.7.7"
         const val okHttp = "4.8.0"
         const val coil = "1.0.0-rc2"
 


### PR DESCRIPTION
Closes #172

https://github.com/jellyfin/jellyfin-apiclient-java/releases/tag/v0.7.7