### PR TITLE
Sign both proprietary and libre release apks

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -111,15 +111,14 @@ jobs:
           secureFile: 'keystore'
 
       - script: '$(find / -name apksigner -print -quit) sign --ks ${KEYSTORE_SECUREFILEPATH} --ks-pass pass:${PASSWORD} --out ${SYSTEM_ARTIFACTSDIRECTORY}/jellyfin-android-${JELLYFIN_VERSION}-libre-release.apk ${SYSTEM_ARTIFACTSDIRECTORY}/jellyfin-android-${JELLYFIN_VERSION}-libre-release-unsigned.apk'
-        displayName: 'Sign Release APK'
+        displayName: 'Sign Libre Release APK'
         env:
           PASSWORD: $(KeyStorePassword)
 
-      - task: DeleteFiles@1
-        displayName: 'Remove Unsigned APK'
-        inputs:
-          sourceFolder: '$(System.ArtifactsDirectory)'
-          contents: 'jellyfin-android-${JELLYFIN_VERSION}-libre-release-unsigned.apk'
+      - script: '$(find / -name apksigner -print -quit) sign --ks ${KEYSTORE_SECUREFILEPATH} --ks-pass pass:${PASSWORD} --out ${SYSTEM_ARTIFACTSDIRECTORY}/jellyfin-android-${JELLYFIN_VERSION}-proprietary-release.apk ${SYSTEM_ARTIFACTSDIRECTORY}/jellyfin-android-${JELLYFIN_VERSION}-proprietary-release-unsigned.apk'
+        displayName: 'Sign Proprietary Release APK'
+        env:
+          PASSWORD: $(KeyStorePassword)
 
       - task: GithubRelease@0
         displayName: 'GitHub Upload'


### PR DESCRIPTION
Basically copied the current sign task to make it work with both libre and proprietary. Removed the `DeleteFiles` task since it never worked (although it should've worked, weird)

Will cherrypick to release branch after merge to master.