### PR TITLE
Fix device name again

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -47,7 +47,14 @@ class NativeInterface(private val fragment: WebViewFragment) : KoinComponent {
         val device = AndroidDevice.fromContext(context)
         JSONObject().apply {
             put("deviceId", device.deviceId)
-            put("deviceName", device.deviceName)
+            // normalize the name by removing special characters
+            // and making sure it's at least 1 character long
+            // otherwise the webui will fail to send it to the server
+            val name = device.deviceName
+                .replace("[^\\x20-\\x7E]".toRegex(), "")
+                .trim()
+                .padStart(1)
+            put("deviceName", name)
             put("appName", APP_INFO_NAME)
             put("appVersion", APP_INFO_VERSION)
         }.toString()


### PR DESCRIPTION
> I did some testing and came to the conclusion that this issue only happens in the mobile android client because the actual issue is the webui not being able to serialize the name. I therefor think we should remove the normalization from the apiclient and add it to the android app only (at the part we send it to the JS code).

Here it is. Uses the regex from @CarlosOlivo (thanks!) and I can confirm it fixes the issue because I added a weird name to my emulator.

Closes jellyfin/jellyfin-apiclient-java#140
Closes jellyfin/jellyfin-apiclient-java#141
Closes #230