### PR TITLE
Fix bad device profile

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -97,8 +97,8 @@ function getDeviceProfile(profileBuilder, item) {
         Container: "avi",
         Conditions: [
             {
-                Condition: "NotEqual",
-                Property: "CodecTag",
+                Condition: "NotEquals",
+                Property: "VideoCodecTag",
                 Value: "xvid"
             }
         ]


### PR DESCRIPTION
Caused JSON parsing errors in 10.7 >= and thus playback not working


this condition literally never worked because it used an non-existing operator and property lol