### PR TITLE
Only change server location when different

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/viewmodel/MainViewModel.kt
@@ -22,7 +22,9 @@ class MainViewModel(
     init {
         viewModelScope.launch {
             serverState.collect { state ->
-                apiClient.ChangeServerLocation(state.server?.hostname?.trimEnd('/'))
+                val serverAddress = state.server?.hostname?.trimEnd('/')
+                if (apiClient.serverAddress != serverAddress)
+                    apiClient.ChangeServerLocation(serverAddress)
             }
         }
 


### PR DESCRIPTION
Prevents possible race conditions/crashes when using Android Auto simultaneously to the web client, caused by the server location change invalidating login credentials.