### PR TITLE
Remove the ExoPlayer cast extension

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,7 +118,6 @@ dependencies {
 
     // Cast
     implementation(Dependencies.Cast.mediaRouter)
-    implementation(Dependencies.Cast.exoPlayerCastExtension)
     proprietaryImplementation(Dependencies.Cast.playServicesCast)
     proprietaryImplementation(Dependencies.Cast.playServicesCastFramework)
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -103,7 +103,6 @@ object Dependencies {
 
     object Cast {
         val mediaRouter = androidx("mediarouter", Versions.mediaRouter)
-        const val exoPlayerCastExtension = "com.google.android.exoplayer:extension-cast:${Versions.exoPlayer}"
         const val playServicesCast = "com.google.android.gms:play-services-cast:${Versions.playServicesCast}"
         const val playServicesCastFramework = "com.google.android.gms:play-services-cast-framework:${Versions.playServicesCast}"
     }


### PR DESCRIPTION
The easy way to fix #243.

Another approach is to make the dependency on the cast extension proprietary only but this would require some changes in the MediaService because it won't compile without the library.