### PR TITLE
Disable PNG crunching for release variant as well

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,12 +32,14 @@ android {
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = true
+            aaptOptions.cruncherEnabled = false
+
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
         getByName("debug") {
             applicationIdSuffix = ".debug"
             isDebuggable = true
-            aaptOptions.cruncherEnabled = false // Disable png crunching
+            aaptOptions.cruncherEnabled = false
         }
     }
 


### PR DESCRIPTION
Possible fix for F-Droid reproducible builds