### PR TITLE
Fix build reproducibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,7 @@ android {
                 arguments["room.incremental"] = "true"
             }
         }
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {


### PR DESCRIPTION
By enabling the ` vectorDrawables.useSupportLibrary` option the Android compiler will stop creating unnecessary png files.