### PR TITLE
Fix JS injection breaking on page reloads in 10.7

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
@@ -130,10 +130,10 @@ class WebViewFragment : Fragment() {
                 val url = request.url
                 val path = url.path?.toLowerCase(Locale.ROOT) ?: return null
                 return when {
-                    path.endsWith(Constants.APPLOADER_PATH) || path.endsWith(Constants.MAIN_BUNDLE_PATH) -> {
+                    path.endsWith(Constants.APPLOADER_PATH) || path.endsWith(Constants.ANY_BUNDLE_PATH) -> {
                         assetsVersion = when {
                             path.endsWith(Constants.APPLOADER_PATH) -> "10.6"
-                            path.endsWith(Constants.MAIN_BUNDLE_PATH) -> "10.7"
+                            path.endsWith(Constants.ANY_BUNDLE_PATH) -> "10.7"
                             // Unreachable path, add a sane value to be safe anyway
                             else -> "10.7"
                         }

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -10,7 +10,7 @@ object Constants {
 
     // Webapp constants
     const val APPLOADER_PATH = "scripts/apploader.js" // 10.6.4 <=
-    const val MAIN_BUNDLE_PATH = "/main.bundle.js" // 10.7 >=
+    const val ANY_BUNDLE_PATH = ".bundle.js" // 10.7 >=
     const val SELECT_SERVER_PATH = "selectserver.html"
     const val SESSION_CAPABILITIES_PATH = "sessions/capabilities/full"
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
@@ -7,6 +7,9 @@ import java.io.IOException
 
 const val JS_INJECTION_CODE = """
 !function() {
+    if (window.injectedAppJS) {
+        return;
+    }
     var scripts = [
         '/native/nativeshell.js',
         '/native/EventEmitter.js',
@@ -20,6 +23,7 @@ const val JS_INJECTION_CODE = """
         scriptElement.setAttribute('defer', '');
         document.body.appendChild(scriptElement);
     });
+    window.injectedAppJS = true;
 }();
 """
 


### PR DESCRIPTION
Instead of only injecting when the main.bundle.js is requested, it attempts to inject for every *.bundle.js that is requested, and ensures one-time execution by setting a flag in window.