### PR TITLE
Add workflow config for GitHub CI

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -12,11 +12,6 @@ trigger:
     include:
       - '*'
 
-pr:
-  branches:
-    include:
-      - '*'
-
 jobs:
   - job: Test
     displayName: 'Test'

--- a/.github/workflows/app-test.yaml
+++ b/.github/workflows/app-test.yaml
@@ -1,0 +1,30 @@
+name: Test App
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Setup Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run test and assemble tasks
+        run: ./gradlew --no-daemon --build-cache test

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 #
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx8192m
+org.gradle.jvmargs=-Xmx2G -XX:MaxPermSize=512m -XX:MaxMetaspaceSize=512m
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
Set up GitHub CI for testing and building the app. No signing or publishing configs for now, only builds and stores the (unsigned) APKs as artifacts.