### PR TITLE
Fix support for playlists in external player

### DIFF
--- a/app/src/main/assets/native-10.6/externalplayer.js
+++ b/app/src/main/assets/native-10.6/externalplayer.js
@@ -23,14 +23,14 @@ define(['appSettings', 'events', 'playbackManager'], function (appSettings, even
         self._paused = true;
         self._volume = 100;
         self._currentSrc = null;
+        self._isIntro = false;
 
         self.canPlayMediaType = function (mediaType) {
             return mediaType === 'Video';
         };
 
         self.canPlayItem = function (item, playOptions) {
-            var mediaSource = item.MediaSources && item.MediaSources[0];
-            return window.ExternalPlayer.isEnabled() && mediaSource && mediaSource.SupportsDirectStream;
+            return window.ExternalPlayer.isEnabled();
         };
 
         self.supportsPlayMethod = function (playMethod, item) {
@@ -46,6 +46,7 @@ define(['appSettings', 'events', 'playbackManager'], function (appSettings, even
                 self._currentTime = (options.playerStartPositionTicks || 0) / 10000;
                 self._paused = false;
                 self._currentSrc = options.url;
+                self._isIntro = options.item && options.item.ProviderIds && options.item.ProviderIds.hasOwnProperty("prerolls.video");
                 window.ExternalPlayer.initPlayer(JSON.stringify(options));
                 resolve();
             });
@@ -112,6 +113,7 @@ define(['appSettings', 'events', 'playbackManager'], function (appSettings, even
                     src: self._currentSrc
                 };
 
+                playbackManager._playNextAfterEnded = self._isIntro;
                 events.trigger(self, 'stopped', [stopInfo]);
                 self._currentSrc = self._currentTime = null;
             });

--- a/app/src/main/assets/native-10.7/ExternalPlayerPlugin.js
+++ b/app/src/main/assets/native-10.7/ExternalPlayerPlugin.js
@@ -24,6 +24,7 @@ export class ExternalPlayerPlugin {
         this._paused = true;
         this._volume = 100;
         this._currentSrc = null;
+        this._isIntro = false;
 
         this._externalPlayer = window['ExternalPlayer'];
     }
@@ -33,8 +34,7 @@ export class ExternalPlayerPlugin {
     }
 
     canPlayItem(item, playOptions) {
-        var mediaSource = item.MediaSources && item.MediaSources[0];
-        return this._externalPlayer.isEnabled() && mediaSource && mediaSource.SupportsDirectStream;
+        return this._externalPlayer.isEnabled();
     }
 
     supportsPlayMethod(playMethod, item) {
@@ -49,6 +49,7 @@ export class ExternalPlayerPlugin {
         this._currentTime = (options.playerStartPositionTicks || 0) / 10000;
         this._paused = false;
         this._currentSrc = options.url;
+        this._isIntro = options.item && options.item.ProviderIds && options.item.ProviderIds.hasOwnProperty("prerolls.video");
         this._externalPlayer.initPlayer(JSON.stringify(options));
     }
 
@@ -97,6 +98,7 @@ export class ExternalPlayerPlugin {
             src: this._currentSrc
         };
 
+        this.playbackManager._playNextAfterEnded = this._isIntro;
         this.events.trigger(this, 'stopped', [stopInfo]);
         this._currentSrc = this._currentTime = null;
     }


### PR DESCRIPTION
Only allow intros, a single item to play and stop as there is no way to stop a playlist from an external player.

Closes #265 