### PR TITLE
Miscellaneous casting fixes

### DIFF
--- a/app/src/main/assets/native-10.7/chrome.cast.js
+++ b/app/src/main/assets/native-10.7/chrome.cast.js
@@ -1378,6 +1378,7 @@ execute('setup', function (err, args) {
 });
 
 window.chrome.cast = chrome.cast;
+console.info('Applied custom cast interface to window');
 
 /**
  * Updates the current session with the incoming javaSession
@@ -1404,6 +1405,7 @@ function execute (action) {
         throw new Error('Not initialized. Must call chrome.cast.initialize first.');
     }
 
+    console.debug('execCast', action);
     window.NativeShell.execCast(action, args, callback);
 }
 
@@ -1429,6 +1431,7 @@ function handleError (err, callback) {
     }
 
     var error = new chrome.cast.Error(err, desc, {});
+    console.error('Encountered cast error', error);
     if (callback) {
         callback(error);
     }

--- a/app/src/main/assets/native-10.7/nativeshell.js
+++ b/app/src/main/assets/native-10.7/nativeshell.js
@@ -74,13 +74,13 @@ window.NativeShell = {
         return plugins;
     },
 
-    execCast(action, args, callback) {
+    async execCast(action, args, callback) {
         this.castCallbacks = this.castCallbacks || {};
         this.castCallbacks[action] = callback;
         window.NativeInterface.execCast(action, JSON.stringify(args));
     },
 
-    castCallback(action, keep, err, result) {
+    async castCallback(action, keep, err, result) {
         const callbacks = this.castCallbacks || {};
         const callback = callbacks[action];
         callback && callback(err || null, result);

--- a/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
@@ -130,10 +130,6 @@ class WebViewFragment : Fragment() {
                 val url = request.url
                 val path = url.path?.toLowerCase(Locale.ROOT) ?: return null
                 return when {
-                    path.endsWith(Constants.CAST_SDK_PATH) -> {
-                        // Load the chrome.cast.js library instead
-                        webView.context.loadAsset("native-${assetsVersion}/chrome.cast.js")
-                    }
                     path.endsWith(Constants.APPLOADER_PATH) || path.endsWith(Constants.ANY_BUNDLE_PATH) -> {
                         assetsVersion = when {
                             path.endsWith(Constants.APPLOADER_PATH) -> "10.6"
@@ -150,6 +146,10 @@ class WebViewFragment : Fragment() {
                         null // continue loading normally
                     }
                     path.contains("native") -> webView.context.loadAsset("native-${assetsVersion}/${url.lastPathSegment}")
+                    path.endsWith(Constants.CAST_SDK_PATH) -> {
+                        // Load the chrome.cast.js library instead
+                        webView.context.loadAsset("native-${assetsVersion}/chrome.cast.js")
+                    }
                     path.endsWith(Constants.SELECT_SERVER_PATH) -> {
                         runOnUiThread { onSelectServer() }
                         emptyResponse

--- a/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
@@ -130,6 +130,10 @@ class WebViewFragment : Fragment() {
                 val url = request.url
                 val path = url.path?.toLowerCase(Locale.ROOT) ?: return null
                 return when {
+                    path.endsWith(Constants.CAST_SDK_PATH) -> {
+                        // Load the chrome.cast.js library instead
+                        webView.context.loadAsset("native-${assetsVersion}/chrome.cast.js")
+                    }
                     path.endsWith(Constants.APPLOADER_PATH) || path.endsWith(Constants.ANY_BUNDLE_PATH) -> {
                         assetsVersion = when {
                             path.endsWith(Constants.APPLOADER_PATH) -> "10.6"

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -13,6 +13,7 @@ object Constants {
     const val ANY_BUNDLE_PATH = ".bundle.js" // 10.7 >=
     const val SELECT_SERVER_PATH = "selectserver.html"
     const val SESSION_CAPABILITIES_PATH = "sessions/capabilities/full"
+    const val CAST_SDK_PATH = "cast_sender.js"
 
     const val FRAGMENT_CONNECT_EXTRA_ERROR = "org.jellyfin.mobile.intent.extra.ERROR"
     const val FRAGMENT_WEB_VIEW_EXTRA_SERVER_ID = "org.jellyfin.mobile.intent.extra.SERVER_ID"

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -11,9 +11,9 @@ object Constants {
     // Webapp constants
     const val APPLOADER_PATH = "scripts/apploader.js" // 10.6.4 <=
     const val ANY_BUNDLE_PATH = ".bundle.js" // 10.7 >=
+    const val CAST_SDK_PATH = "cast_sender.js"
     const val SELECT_SERVER_PATH = "selectserver.html"
     const val SESSION_CAPABILITIES_PATH = "sessions/capabilities/full"
-    const val CAST_SDK_PATH = "cast_sender.js"
 
     const val FRAGMENT_CONNECT_EXTRA_ERROR = "org.jellyfin.mobile.intent.extra.ERROR"
     const val FRAGMENT_WEB_VIEW_EXTRA_SERVER_ID = "org.jellyfin.mobile.intent.extra.SERVER_ID"

--- a/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/WebAppUtils.kt
@@ -13,7 +13,6 @@ const val JS_INJECTION_CODE = """
     var scripts = [
         '/native/nativeshell.js',
         '/native/EventEmitter.js',
-        '/native/chrome.cast.js',
     ];
     scripts.forEach(function(src) {
         var scriptElement = document.createElement('script');


### PR DESCRIPTION
- Added a few logging statements
- Made the execCast and castCallback async so the JS engine will behave slightly different in the way everything is called
  - This fixes the unstable client never loading
- Change how the chrome cast plugin is loaded to MITM the google url instead
  - Because jellyfin-web does [some magic with that url](https://github.com/jellyfin/jellyfin-web/blob/eb1e501fad14b15ef3ea7d102c8caff46a4963ea/src/components/castSenderApi.js)