### PR TITLE
Drop AndroidX Webkit dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,7 +104,6 @@ dependencies {
     // UI
     implementation(Dependencies.UI.constraintLayout)
     implementation(Dependencies.UI.material)
-    implementation(Dependencies.UI.webkitX)
     implementation(Dependencies.UI.exoPlayer)
     implementation(Dependencies.UI.modernAndroidPreferences)
 

--- a/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
@@ -9,10 +9,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
-import android.webkit.WebView
+import android.webkit.*
 import androidx.activity.addCallback
 import androidx.core.view.ViewCompat
 import androidx.core.view.doOnNextLayout
@@ -20,9 +17,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.add
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.webkit.WebResourceErrorCompat
-import androidx.webkit.WebViewClientCompat
-import androidx.webkit.WebViewFeature
 import kotlinx.coroutines.launch
 import org.jellyfin.apiclient.interaction.ApiClient
 import org.jellyfin.mobile.MainActivity
@@ -128,7 +122,7 @@ class WebViewFragment : Fragment(), NativePlayerHost {
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun WebView.initialize() {
-        webViewClient = object : WebViewClientCompat() {
+        webViewClient = object : WebViewClient() {
             override fun shouldInterceptRequest(webView: WebView, request: WebResourceRequest): WebResourceResponse? {
                 val url = request.url
                 val path = url.path?.toLowerCase(Locale.ROOT) ?: return null
@@ -178,8 +172,8 @@ class WebViewFragment : Fragment(), NativePlayerHost {
                 if (request.url == Uri.parse(instanceUrl)) onErrorReceived()
             }
 
-            override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceErrorCompat) {
-                val description = if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_RESOURCE_ERROR_GET_DESCRIPTION)) error.description else null
+            override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+                val description = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) error.description else null
                 Timber.e("Received WebView error at %s: %s", request.url.toString(), description)
 
                 if (request.url.toString() == instanceUrl) onErrorReceived()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -22,7 +22,6 @@ object Dependencies {
         // UI
         const val constraintLayout = "2.0.4"
         const val material = "1.3.0"
-        const val webkitX = "1.4.0"
         const val modernAndroidPreferences = "1.1.0"
 
         // Room
@@ -84,7 +83,6 @@ object Dependencies {
     object UI {
         val constraintLayout = androidx("constraintlayout", Versions.constraintLayout)
         const val material = "com.google.android.material:material:${Versions.material}"
-        val webkitX = androidx("webkit", Versions.webkitX)
         val exoPlayer = exoPlayer("ui")
         const val modernAndroidPreferences = "de.Maxr1998.android:modernpreferences:${Versions.modernAndroidPreferences}"
     }


### PR DESCRIPTION
Related to #96

Apparently the AndroidX WebKit dependency has compatibility problems with certain old versions of WebView and the jellyfin-web combo, although I can't find the origin/source/reason in the Logcat, at least the WebView versions >= 74 don't throw this exception.

I also notice a slight performance improvement when using just the WebViewClient, maybe it's my imagination.

Also, it will eventually be removed when the switch is made to the native client, who agrees?

- AVD settings
Android 7.1.1 (API 25) x86_64
WebView com.android.chrome version 69.0.3497.100 (code 349710067)

- With androidx.webkit.WebViewClientCompat (Version 1.4.0)
![xCqdeavBLS](https://user-images.githubusercontent.com/25919231/107482622-8f897d80-6b45-11eb-8600-82eece07f16a.gif)
```
2021-02-09 11:49:38.500 10152-10152/org.jellyfin.mobile.debug E/RedScreenOfDeath: ══════════ Exception caught by Red Screen Of Death library ═════════
2021-02-09 11:49:38.500 10152-10152/org.jellyfin.mobile.debug E/RedScreenOfDeath: IllegalArgumentException
    java.lang.IllegalArgumentException: reasonPhrase can't be empty.
        at android.webkit.WebResourceResponse.setStatusCodeAndReasonPhrase(WebResourceResponse.java:138)
        at android.webkit.WebResourceResponse.<init>(WebResourceResponse.java:76)
        at xl.a(PG:292)
        at afG.handleMessage(PG:67)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6119)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
2021-02-09 11:49:38.500 10152-10152/org.jellyfin.mobile.debug E/RedScreenOfDeath: ════════════════════════════════════════════════════════════════════
```

- With android.webkit.WebViewClient
![WdXmB7x0jc](https://user-images.githubusercontent.com/25919231/107482686-a6c86b00-6b45-11eb-9690-7746fccb2f74.gif)
```
2021-02-10 00:15:21.085 7609-7609/org.jellyfin.mobile.debug E/WebViewFragment$initialize: Received WebView HTTP 400 error: null
```

Also closes #212