### PR TITLE
Add merge conflict labeler and gradle update and validate tasks

### DIFF
--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -1,0 +1,17 @@
+name: Gradle update
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'jellyfin/jellyfin-android'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository == 'jellyfin/jellyfin-android'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Validate Gradle Wrapper
+      - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradlew-validate.yaml
+++ b/.github/workflows/gradlew-validate.yaml
@@ -1,0 +1,18 @@
+name: Gradle validate
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '**/gradlе-wrapper.jar'
+
+jobs:
+  validate:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/gradlew-validate.yaml
+++ b/.github/workflows/gradlew-validate.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-ubuntu
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -1,4 +1,4 @@
-name: Merge conflicts labeler
+name: Merge conflict label
 
 on:
   schedule:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-ubuntu
     if: github.repository == 'jellyfin/jellyfin-android'
     steps:
       - uses: mschilde/auto-label-merge-conflicts@v2.0

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -1,0 +1,16 @@
+name: Merge conflicts labeler
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  push:
+
+jobs:
+  triage:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'jellyfin/jellyfin-android'
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@v2.0
+        with:
+          CONFLICT_LABEL_NAME: merge conflict
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of this comes from jellyfin/jellyfin-apiclient-java#163 with some slight improvements, the labeler comes from the ATV repo with some changes (added a schedule).