### PR TITLE
Chromecast JS: Improve error logging.

### DIFF
--- a/app/src/main/assets/native/chrome.cast.js
+++ b/app/src/main/assets/native/chrome.cast.js
@@ -1431,7 +1431,12 @@ function handleError (err, callback) {
     }
 
     var error = new chrome.cast.Error(err, desc, {});
-    console.error('Encountered cast error', error);
+    try {
+        console.error('Encountered cast error', JSON.stringify(error));
+    } catch {
+        console.error('Encountered cast error', error);
+    }
+
     if (callback) {
         callback(error);
     }


### PR DESCRIPTION
I was investigating an issue I was having with casting ~(which has been fixed somewhere between the Playstore release and the tip of `master`)~ and found whenever the Chromecast js logged an error it was not stringified and thus would log `[object Object]`.

EDIT: Actually my issue is still present when using the gradle options to build, will raise an issue.

This PR addresses this by attempting to stringify the instance of `chrome.cast.Error`, if this fails or throws then the original behaviour will be used.

Before:
```
2021-03-21 01:25:37.543 7245-7245/org.jellyfin.mobile.debug I/chromium: [INFO:CONSOLE(1444)] "Encountered cast error [object Object]", source: https://www.gstatic.com/cv/js/sender/v1/cast_sender.js (1444)
```

After:
```
2021-03-21 00:42:35.321 28384-28384/org.jellyfin.mobile.debug I/chromium: [INFO:CONSOLE(1434)] "Encountered cast error {"code":"unknown","description":"status{statuscode=success, resolution=null} undefined","details":{}}", source: https://www.gstatic.com/cv/js/sender/v1/cast_sender.js (1434)
```