### PR TITLE
ci(update-action): update actions/setup-java to v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - ci
+      - github-actions
+    commit-message:
+      prefix: ci

--- a/.github/workflows/app-test.yaml
+++ b/.github/workflows/app-test.yaml
@@ -14,8 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Setup Gradle cache
         uses: actions/cache@v2


### PR DESCRIPTION
### Description

As mentioned on Matrix, `actions/setup-java` got updated to v2 and has possible breaking changes by defaulting to AzulJDK.
So this PR updates it to v2 while maintaining the previous behavior (by using AdoptOpenJDK).

### Changes

* update actions/setup-java to v2
* add dependabot for github-actions dependencies

### Issues

* n/a