### PR TITLE
Update Kotlin to 1.5.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,9 +77,6 @@ android {
     buildFeatures {
         viewBinding = true
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
     lintOptions {
         isAbortOnError = false
         sarifReport = true

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -25,7 +25,7 @@ object Dependencies {
         const val modernAndroidPreferences = "2.0"
 
         // Room
-        const val room = "2.2.6"
+        const val room = "2.3.0"
 
         // Network
         const val jellyfinSdk = "1.0.0-beta.4"

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Kotlin version for this project
-kotlinVersion=1.4.32
+kotlinVersion=1.5.0


### PR DESCRIPTION
- Remove now unnecessary jvmTarget from buildscript
- Update Room to 2.3.0 since earlier versions cause build errors with the new Kotlin release