### PR TITLE
Treat recommended server without system info as unable to connect

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/fragment/ConnectFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/ConnectFragment.kt
@@ -167,7 +167,7 @@ class ConnectFragment : Fragment() {
         val recommendedServer = jellyfin.discovery.getRecommendedServer(candidates, false)
 
         // No server found that replied
-        if (recommendedServer == null) {
+        if (recommendedServer?.systemInfo == null) {
             Timber.i("No recommended server found")
 
             // TODO add candidates to error


### PR DESCRIPTION
The SDK can sometimes give false positives.

Partial fix for #366 