### PR TITLE
Add desugaring to support java.time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,9 @@ android {
     buildFeatures {
         viewBinding = true
     }
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
     lintOptions {
         isAbortOnError = false
         sarifReport = true
@@ -153,6 +156,9 @@ dependencies {
     testImplementation(Dependencies.Health.mockk)
     androidTestImplementation(Dependencies.Health.androidXRunner)
     androidTestImplementation(Dependencies.Health.androidXEspresso)
+
+    // Desugaring
+    coreLibraryDesugaring(Dependencies.Health.androidDesugarLibs)
 }
 
 tasks {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -48,6 +48,7 @@ object Dependencies {
         const val mockk = "1.11.0"
         const val androidXRunner = "1.3.0"
         const val androidXEspresso = "3.3.0"
+        const val androidDesugarLibs = "1.1.5"
     }
 
     object Kotlin {
@@ -107,7 +108,7 @@ object Dependencies {
     }
 
     /**
-     * Includes logging, debugging, and testing
+     * Includes logging, debugging, testing and desugaring
      */
     object Health {
         const val timber = "com.jakewharton.timber:timber:${Versions.timber}"
@@ -122,6 +123,7 @@ object Dependencies {
         const val mockk = "io.mockk:mockk:${Versions.mockk}"
         const val androidXRunner = "androidx.test:runner:${Versions.androidXRunner}"
         const val androidXEspresso = "androidx.test.espresso:espresso-core:${Versions.androidXEspresso}"
+        const val androidDesugarLibs = "com.android.tools:desugar_jdk_libs:${Versions.androidDesugarLibs}"
     }
 
     // Helpers


### PR DESCRIPTION
Although the library already used desugaring it appears that it doesn't matter unless it is added to the app using it. We'll need to update the SDK's README later for that.

This fixes #373 and allows java.time to be used again.