### PR TITLE
Replace GH_TOKEN with JF_BOT_TOKEN

### DIFF
--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/merge-conflict-labeler.yaml
+++ b/.github/workflows/merge-conflict-labeler.yaml
@@ -14,4 +14,4 @@ jobs:
       - uses: eps1lon/actions-label-merge-conflict@v2.0.1
         with:
           dirtyLabel: merge conflict
-          repoToken: ${{ secrets.GH_TOKEN }}
+          repoToken: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
``GH_TOKEN`` seems to be used internally by GitHub and it's making some actions we're using in some repos fail ([Source](https://github.com/alex-page/github-project-automation-plus/issues/39))

*(PRs made from users of the org are always successful, but PRs that aren't don't work, like Dependabot PRs. This can be checked by looking at the history of server repos and Jellyfin Vue)*

The org-wide secret should be renamed to something else to avoid confusion and further replacements or messes in GH's side. This PR replaces ``GH_TOKEN`` with ``JF_BOT_TOKEN``, which should be pretty generic.