### PR TITLE
Extended webview checks

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
@@ -46,6 +46,14 @@ class AppPreferences(context: Context) {
             }
         }
 
+    var ignoreWebViewChecks: Boolean
+        get() = sharedPreferences.getBoolean(Constants.PREF_IGNORE_WEBVIEW_CHECKS, false)
+        set(value) {
+            sharedPreferences.edit {
+                putBoolean(Constants.PREF_IGNORE_WEBVIEW_CHECKS, value)
+            }
+        }
+
     var downloadMethod: Int?
         get() = sharedPreferences.getInt(Constants.PREF_DOWNLOAD_METHOD, -1).takeIf { it >= 0 }
         set(value) {

--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : AppCompatActivity() {
         bindService(Intent(this, RemotePlayerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)
 
         // Check WebView support
-        if (!appPreferences.ignoreWebViewChecks && !isWebViewSupported()) {
+        if (!isWebViewSupported()) {
             AlertDialog.Builder(this).apply {
                 setTitle(R.string.dialog_web_view_not_supported)
                 setMessage(R.string.dialog_web_view_not_supported_message)

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -22,6 +22,7 @@ object Constants {
     const val PREF_USER_ID = "pref_user_id"
     const val PREF_INSTANCE_URL = "pref_instance_url"
     const val PREF_IGNORE_BATTERY_OPTIMIZATIONS = "pref_ignore_battery_optimizations"
+    const val PREF_IGNORE_WEBVIEW_CHECKS = "pref_ignore_webview_checks"
     const val PREF_DOWNLOAD_METHOD = "pref_download_method"
     const val PREF_MUSIC_NOTIFICATION_ALWAYS_DISMISSIBLE = "pref_music_notification_always_dismissible"
     const val PREF_VIDEO_PLAYER_TYPE = "pref_video_player_type"

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -9,7 +9,7 @@ object Constants {
     const val APP_INFO_VERSION: String = BuildConfig.VERSION_NAME
 
     // Webapp constants
-    const val MINIMUM_WEB_VIEW_VERSION = 88
+    const val MINIMUM_WEB_VIEW_VERSION = 80
     const val WEB_CONFIG_PATH = "config.json"
     const val CAST_SDK_PATH = "cast_sender.js"
     const val SESSION_CAPABILITIES_PATH = "sessions/capabilities/full"

--- a/app/src/main/java/org/jellyfin/mobile/utils/WebViewUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/WebViewUtils.kt
@@ -42,9 +42,14 @@ fun WebView.isOutdated(): Boolean =
     getWebViewMajorVersion() < Constants.MINIMUM_WEB_VIEW_VERSION
 
 private fun WebView.getWebViewMajorVersion(): Int {
-    return """.*Chrome/(\d+)\..*""".toRegex().matchEntire(getDefaultUserAgentString())?.let { match ->
+    val userAgent = getDefaultUserAgentString()
+    val version = """.*Chrome/(\d+)\..*""".toRegex().matchEntire(userAgent)?.let { match ->
         match.groupValues.getOrNull(1)?.toInt()
     } ?: 0
+
+    Timber.i("WebView user agent is $userAgent, detected version is $version")
+
+    return version
 }
 
 // Based on https://stackoverflow.com/a/29218966

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="dialog_web_view_outdated_message">The WebView implementation used by your device is outdated.\nPlease update it to a compatible version.</string>
     <string name="dialog_button_check_for_updates">Check for updates</string>
     <string name="dialog_button_close_app">Close app</string>
+    <string name="dialog_button_open_settings">Open settings</string>
+    <string name="toast_reopen_after_change">Please reopen the app after changes are made</string>
 
     <string name="connect_to_server_title">Connect to Server</string>
     <string name="host_input_hint">Host</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="dialog_button_check_for_updates">Check for updates</string>
     <string name="dialog_button_close_app">Close app</string>
     <string name="dialog_button_open_settings">Open settings</string>
+    <string name="dialog_button_ignore">Ignore</string>
     <string name="toast_reopen_after_change">Please reopen the app after changes are made</string>
 
     <string name="connect_to_server_title">Connect to Server</string>


### PR DESCRIPTION
Fixes #383

Adds an additional button to open the webview settings, it allows changing the used webview more easily. User needs to manually open the app again after changing it.
For the second alert (outdated webview) pressing on the background will cancel the dialog and never show it again. Adding an additional button was too much work because I'd need to make my own layout for it.

![image](https://user-images.githubusercontent.com/2305178/118325602-fc753080-b503-11eb-8490-4fae7d9d63e2.png)
![image](https://user-images.githubusercontent.com/2305178/118325552-ecf5e780-b503-11eb-84fa-e26d9298710e.png)
_note: this one actually says "open settings" instead of "settings" but I was too lazy to re-capture_