### PR TITLE
fix incorrect rsync options

### DIFF
--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -50,8 +50,8 @@ jobs:
       - name: Upload to repo.jellyfin.org
         uses: burnett01/rsync-deployments@4.1
         with:
-          switches: -rltgoDzvO --delete --exclude='*' --include='**/*.apk' --include='*.txt'
-          path: build/jellyfin-publish/
+          switches: -vrptz
+          path: build/jellyfin-publish/**/
           remote_path: /srv/repository/releases/client/android/versions/v${{ env.JELLYFIN_VERSION }}
           remote_host: ${{ secrets.DEPLOY_HOST }}
           remote_user: ${{ secrets.DEPLOY_USER }}


### PR DESCRIPTION
### Description

With the deployment/release of the Android app we ran into a few issues with the new GitHub actions based workflow, most of which got already fixed but apparently I messed up the `rsync`options in my initial PR :man_facepalming:.
This PR aims to fix that and hopefully get the workflow 100% operational for the next release.

### Changes

* remove obsolete/release breaking `rsync` options

### Issues

* n/a?