### PR TITLE
Workaround for coroutines crash

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/source/Result.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/Result.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.mobile.player.source
+
+class Result<T> private constructor(
+    val value: T?,
+    val error: Throwable?,
+) {
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun getOrNull(): T? = value
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun onSuccess(action: (T) -> Unit): Result<T> {
+        if (error == null) action(value as T)
+        return this
+    }
+
+    inline fun onFailure(action: (Throwable) -> Unit): Result<T> {
+        if (error != null) action(error)
+        return this
+    }
+
+    companion object {
+        fun <T> success(value: T) = Result(value, null)
+
+        fun <T> failure(error: Throwable) = Result<T>(null, error)
+    }
+}


### PR DESCRIPTION
suspending functions returning inline/value classes cause a crash in the coroutines library. When replacing the `kotlin.util.Result` class with a primitive custom alternative that isn't a value class, this crash doesn't happen anymore.

Fixes #397.