### PR TITLE
change directory structure of workflow artifacts

### DIFF
--- a/.github/workflows/app-build.yaml
+++ b/.github/workflows/app-build.yaml
@@ -30,9 +30,9 @@ jobs:
         run: ./gradlew --no-daemon --info assembleDebug
       - name: Split APK release types
         run: |
-          mkdir -p build/jellyfin-publish;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-debug.apk build/jellyfin-publish/;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-debug.apk build/jellyfin-publish/;
+          mkdir -p build/jellyfin-publish
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-debug.apk build/jellyfin-publish/
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-debug.apk build/jellyfin-publish/
       - uses: actions/upload-artifact@v2
         with:
           name: build-artifacts

--- a/.github/workflows/app-build.yaml
+++ b/.github/workflows/app-build.yaml
@@ -30,9 +30,9 @@ jobs:
         run: ./gradlew --no-daemon --info assembleDebug
       - name: Split APK release types
         run: |
-          mkdir -p build/jellyfin-publish/release-libre build/jellyfin-publish/release-proprietary;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-debug.apk build/jellyfin-publish/release-libre/;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-debug.apk build/jellyfin-publish/release-proprietary/;
+          mkdir -p build/jellyfin-publish;
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-debug.apk build/jellyfin-publish/;
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-debug.apk build/jellyfin-publish/;
       - uses: actions/upload-artifact@v2
         with:
           name: build-artifacts

--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -28,24 +28,21 @@ jobs:
         run: ./gradlew --no-daemon --info assembleRelease versionTxt
       - name: Split APK release types
         run: |
-          mkdir -p build/jellyfin-publish/release-libre build/jellyfin-publish/release-proprietary;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-release.apk build/jellyfin-publish/release-libre/;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-release.apk build/jellyfin-publish/release-proprietary/;
+          mkdir -p build/jellyfin-publish;
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-release.apk build/jellyfin-publish/;
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-release.apk build/jellyfin-publish/;
           mv app/build/version.txt build/jellyfin-publish/;
       - name: Upload release artifacts
         uses: alexellis/upload-assets@0.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: |
-            ["build/jellyfin-publish/release-libre/*",
-            "build/jellyfin-publish/release-proprietary/*",
-            "build/jellyfin-publish/version.txt"]
+          asset_paths: '["build/jellyfin-publish/*"]'
       - name: Upload to repo.jellyfin.org
         uses: burnett01/rsync-deployments@4.1
         with:
           switches: -vrptz
-          path: build/jellyfin-publish/**/
+          path: build/jellyfin-publish/
           remote_path: /srv/repository/releases/client/android/versions/v${{ env.JELLYFIN_VERSION }}
           remote_host: ${{ secrets.DEPLOY_HOST }}
           remote_user: ${{ secrets.DEPLOY_USER }}

--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -28,10 +28,10 @@ jobs:
         run: ./gradlew --no-daemon --info assembleRelease versionTxt
       - name: Split APK release types
         run: |
-          mkdir -p build/jellyfin-publish;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-release.apk build/jellyfin-publish/;
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-release.apk build/jellyfin-publish/;
-          mv app/build/version.txt build/jellyfin-publish/;
+          mkdir -p build/jellyfin-publish
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-release.apk build/jellyfin-publish/
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-release.apk build/jellyfin-publish/
+          mv app/build/version.txt build/jellyfin-publish/
       - name: Upload release artifacts
         uses: alexellis/upload-assets@0.3.0
         env:


### PR DESCRIPTION
### Description

Observed with the latest release, the `version.txt` failed to be picked up during deploy.
This PR should fix that alongside simplify the folder structure used to hold the build artifacts.

Note: I omitted changing the `upload-assets` action for now until I or someone else has experience with a better alternative action.

### Changes

* change the artifact directory structure of the build and deploy workflow

### Issues

* n/a