### PR TITLE
Revert "Make ExoPlayer the default video player implementation"

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
@@ -89,7 +89,7 @@ class AppPreferences(context: Context) {
 
     @VideoPlayerType
     val videoPlayerType: String
-        get() = sharedPreferences.getString(Constants.PREF_VIDEO_PLAYER_TYPE, VideoPlayerType.EXO_PLAYER)!!
+        get() = sharedPreferences.getString(Constants.PREF_VIDEO_PLAYER_TYPE, VideoPlayerType.WEB_PLAYER)!!
 
     val exoPlayerAllowSwipeGestures: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES, true)

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -69,13 +69,13 @@ class SettingsFragment : Fragment() {
             titleRes = R.string.pref_category_video_player
         }
         val videoPlayerOptions = listOf(
-            SelectionItem(VideoPlayerType.EXO_PLAYER, R.string.video_player_native, R.string.video_player_native_description),
             SelectionItem(VideoPlayerType.WEB_PLAYER, R.string.video_player_web, R.string.video_player_web_description),
+            SelectionItem(VideoPlayerType.EXO_PLAYER, R.string.video_player_native, R.string.video_player_native_description),
             SelectionItem(VideoPlayerType.EXTERNAL_PLAYER, R.string.video_player_external, R.string.video_player_external_description),
         )
         singleChoice(Constants.PREF_VIDEO_PLAYER_TYPE, videoPlayerOptions) {
             titleRes = R.string.pref_video_player_type_title
-            initialSelection = VideoPlayerType.EXO_PLAYER
+            initialSelection = VideoPlayerType.WEB_PLAYER
             defaultOnSelectionChange { selection ->
                 swipeGesturesPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 backgroundAudioPreference.enabled = selection == VideoPlayerType.EXO_PLAYER


### PR DESCRIPTION
Reverts jellyfin/jellyfin-android#363

Native player is not ready for wide use yet so we're setting the default back to web.