### PR TITLE
Update to SDK beta 8

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/controller/ApiController.kt
+++ b/app/src/main/java/org/jellyfin/mobile/controller/ApiController.kt
@@ -18,12 +18,6 @@ class ApiController(
     private val serverDao: ServerDao,
     private val userDao: UserDao,
 ) {
-    var currentUser: UUID? = null
-        private set
-
-    var currentDeviceId: String = baseDeviceInfo.id
-        private set
-
     /**
      * Migrate from preferences if necessary
      */
@@ -79,20 +73,15 @@ class ApiController(
     }
 
     private fun configureApiClientUser(userId: String, accessToken: String) {
-        currentUser = userId.toUUID()
-
-        // Append user id to device id to ensure uniqueness across sessions
-        currentDeviceId = baseDeviceInfo.id + currentUser.toString()
-        apiClient.deviceInfo = baseDeviceInfo.copy(id = currentDeviceId)
+        apiClient.userId = userId.toUUID()
         apiClient.accessToken = accessToken
+        // Append user id to device id to ensure uniqueness across sessions
+        apiClient.deviceInfo = baseDeviceInfo.copy(id = baseDeviceInfo.id + userId)
     }
 
     private fun resetApiClientUser() {
-        currentUser = null
-        currentDeviceId = baseDeviceInfo.id
-        apiClient.deviceInfo = baseDeviceInfo
+        apiClient.userId = null
         apiClient.accessToken = null
+        apiClient.deviceInfo = baseDeviceInfo
     }
-
-    fun requireUser(): UUID = requireNotNull(currentUser) { "Current user is null!" }
 }

--- a/app/src/main/java/org/jellyfin/mobile/media/MediaService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/media/MediaService.kt
@@ -42,14 +42,15 @@ import org.jellyfin.mobile.controller.ApiController
 import org.jellyfin.mobile.media.car.LibraryBrowser
 import org.jellyfin.mobile.media.car.LibraryPage
 import org.jellyfin.mobile.utils.toast
+import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 import com.google.android.exoplayer2.MediaItem as ExoPlayerMediaItem
 
 class MediaService : MediaBrowserServiceCompat() {
-
     private val apiController: ApiController by inject()
+    private val apiClient: ApiClient by inject()
     private val libraryBrowser: LibraryBrowser by inject()
 
     private val serviceScope = MainScope()
@@ -172,7 +173,12 @@ class MediaService : MediaBrowserServiceCompat() {
             loadingJob.join()
 
             val items = try {
-                if (apiController.currentUser != null) libraryBrowser.loadLibrary(parentId) else null
+                if (apiClient.userId != null) {
+                    libraryBrowser.loadLibrary(parentId)
+                } else {
+                    Timber.e("Missing userId in ApiClient")
+                    null
+                }
             } catch (e: ApiClientException) {
                 Timber.e(e)
                 null

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jellyfin.mobile.BuildConfig
 import org.jellyfin.mobile.PLAYER_EVENT_CHANNEL
-import org.jellyfin.mobile.controller.ApiController
 import org.jellyfin.mobile.player.source.JellyfinMediaSource
 import org.jellyfin.mobile.player.source.MediaQueueManager
 import org.jellyfin.mobile.utils.Constants
@@ -51,10 +50,8 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 import timber.log.Timber
-import java.util.*
 
 class PlayerViewModel(application: Application) : AndroidViewModel(application), KoinComponent, Player.Listener {
-    private val apiController by inject<ApiController>()
     private val playStateApi by inject<PlayStateApi>()
 
     private val lifecycleObserver = PlayerLifecycleObserver(this)
@@ -243,10 +240,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
 
                 // Mark video as watched if playback finished
                 if (hasFinished) {
-                    playStateApi.markPlayedItem(
-                        userId = apiController.requireUser(),
-                        itemId = mediaSource.itemId,
-                    )
+                    playStateApi.markPlayedItem(itemId = mediaSource.itemId)
                 }
             } catch (e: ApiClientException) {
                 Timber.e(e, "Failed to report playback stop")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -28,7 +28,7 @@ object Dependencies {
         const val room = "2.3.0"
 
         // Network
-        const val jellyfinSdk = "1.0.0-beta.7"
+        const val jellyfinSdk = "1.0.0-beta.8"
         const val jellyfinSdkSnapshot = "master-SNAPSHOT"
         const val okHttp = "4.9.1"
         const val coil = "1.1.1"


### PR DESCRIPTION
- Bump SDK to beta 8
- Remove ApiController.currentUser in favor of ApiClient.userId
- Remove ApiController.requireUser in favor of ApiClient.userId
- Remove ApiController.currentDeviceId in favor of ApiClient.deviceInfo.id
- Remove explicit userId parameter when not required (replaced with SDK autofill)