### PR TITLE
Enable subtitle burn settings for web player

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -2,6 +2,7 @@ const features = [
     "filedownload",
     "displaylanguage",
     "subtitleappearancesettings",
+    "subtitleburnsettings",
     //'sharing',
     "exit",
     "htmlaudioautoplay",


### PR DESCRIPTION
Since NativeShell is defined, the feature must be added manually.

https://github.com/jellyfin/jellyfin-web/blob/5c09077a2f12ae44e7b7d356ea8d9f35862b0b60/src/components/apphost.js#L336-L342

https://github.com/jellyfin/jellyfin-web/blob/5c09077a2f12ae44e7b7d356ea8d9f35862b0b60/src/components/apphost.js#L258-L260

Closes #421