### PR TITLE
Sign APKs with apksigner instead of via Gradle

### DIFF
--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -20,17 +20,30 @@ jobs:
       - name: Set JELLYFIN_VERSION
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
       - name: Assemble release APKs
-        env:
-          KEYSTORE: ${{ secrets.KEYSTORE }}
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew --no-daemon --info assembleRelease versionTxt
+      - name: Sign Libre APK
+        id: libreSign
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/apk/libre/release
+          signingKeyBase64: ${{ secrets.KEYSTORE }}
+          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+      - name: Sign Proprietary APK
+        uses: r0adkll/sign-android-release@v1
+        id: proprietarySign
+        with:
+          releaseDirectory: app/build/outputs/apk/proprietary/release
+          signingKeyBase64: ${{ secrets.KEYSTORE }}
+          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
       - name: Split APK release types
         run: |
           mkdir -p build/jellyfin-publish
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-release.apk build/jellyfin-publish/
-          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-release.apk build/jellyfin-publish/
+          mv ${{ steps.libreSign.outputs.signedReleaseFile }} build/jellyfin-publish/
+          mv ${{ steps.proprietarySign.outputs.signedReleaseFile }} build/jellyfin-publish/
           mv app/build/version.txt build/jellyfin-publish/
       - name: Upload release artifacts
         uses: alexellis/upload-assets@0.3.0

--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -31,8 +31,8 @@ jobs:
           alias: ${{ secrets.KEY_ALIAS }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
       - name: Sign Proprietary APK
-        uses: r0adkll/sign-android-release@v1
         id: proprietarySign
+        uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: app/build/outputs/apk/proprietary/release
           signingKeyBase64: ${{ secrets.KEYSTORE }}

--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -21,7 +21,7 @@ jobs:
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
       - name: Assemble release APKs
         run: ./gradlew --no-daemon --info assembleRelease versionTxt
-      - name: Sign Libre APK
+      - name: Sign libre APK
         id: libreSign
         uses: r0adkll/sign-android-release@v1
         with:
@@ -30,7 +30,7 @@ jobs:
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-      - name: Sign Proprietary APK
+      - name: Sign proprietary APK
         id: proprietarySign
         uses: r0adkll/sign-android-release@v1
         with:


### PR DESCRIPTION
### Description

This PR aims to fix our issues with the F-Droid build and our APKs signed via Gradle and not `apksigner` by reverting to using `apksigner`.
Big THANK YOU to @CarlosOlivo figuring this one out!

### Changes

* change apk signing from gradle to apksigner

### Issues

* should fix #414