### PR TITLE
Improve session integration

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/api/ApiModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/api/ApiModule.kt
@@ -6,6 +6,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.KtorClient
 import org.jellyfin.sdk.api.operations.ArtistsApi
 import org.jellyfin.sdk.api.operations.GenresApi
+import org.jellyfin.sdk.api.operations.HlsSegmentApi
 import org.jellyfin.sdk.api.operations.ImageApi
 import org.jellyfin.sdk.api.operations.ItemsApi
 import org.jellyfin.sdk.api.operations.MediaInfoApi
@@ -49,4 +50,5 @@ val apiModule = module {
     single { UniversalAudioApi(get()) }
     single { MediaInfoApi(get()) }
     single { PlayStateApi(get()) }
+    single { HlsSegmentApi(get()) }
 }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -110,6 +110,7 @@ class ExternalPlayer(
                     itemId = source.itemId,
                     static = true,
                     mediaSourceId = source.id,
+                    playSessionId = source.playSessionId,
                 )
             }
             PlayMethod.DIRECT_STREAM -> {
@@ -118,6 +119,7 @@ class ExternalPlayer(
                     itemId = source.itemId,
                     container = container,
                     mediaSourceId = source.id,
+                    playSessionId = source.playSessionId,
                 )
             }
             PlayMethod.TRANSCODE -> {

--- a/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
@@ -13,6 +13,7 @@ class JellyfinMediaSource(
     val itemId: UUID,
     val item: BaseItemDto?,
     val sourceInfo: MediaSourceInfo,
+    val playSessionId: String,
     startTimeTicks: Long? = null,
     audioStreamIndex: Int? = null,
     subtitleStreamIndex: Int? = null,

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaQueueManager.kt
@@ -142,7 +142,9 @@ class MediaQueueManager(
                         val url = videosApi.getVideoStreamUrl(
                             itemId = source.itemId,
                             static = true,
+                            playSessionId = source.playSessionId,
                             mediaSourceId = source.id,
+                            deviceId = apiClient.deviceInfo.id,
                         )
 
                         url to get<ProgressiveMediaSource.Factory>()
@@ -161,7 +163,9 @@ class MediaQueueManager(
                 val url = videosApi.getVideoStreamByContainerUrl(
                     itemId = source.itemId,
                     container = container,
+                    playSessionId = source.playSessionId,
                     mediaSourceId = source.id,
+                    deviceId = apiClient.deviceInfo.id,
                 )
 
                 url to get<ProgressiveMediaSource.Factory>()

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -24,6 +24,7 @@ class MediaSourceResolver(
         subtitleStreamIndex: Int? = null,
     ): Result<JellyfinMediaSource> {
         // Load media source info
+        val playSessionId: String
         val mediaSourceInfo = try {
             val response by mediaInfoApi.getPostedPlaybackInfo(
                 itemId = itemId,
@@ -37,6 +38,8 @@ class MediaSourceResolver(
                     autoOpenLiveStream = true,
                 ),
             )
+
+            playSessionId = response.playSessionId ?: return Result.failure(PlayerException.UnsupportedContent())
 
             response.mediaSources?.let { sources ->
                 sources.find { source -> source.id?.toUUIDOrNull() == itemId } ?: sources.firstOrNull()
@@ -61,6 +64,7 @@ class MediaSourceResolver(
                 itemId = itemId,
                 item = item,
                 sourceInfo = mediaSourceInfo,
+                playSessionId = playSessionId,
                 startTimeTicks = startTimeTicks,
                 audioStreamIndex = audioStreamIndex,
                 subtitleStreamIndex = subtitleStreamIndex,

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -90,7 +90,7 @@ object Constants {
     // Video player constants
     const val LANGUAGE_UNDEFINED = "und"
     const val TICKS_PER_MILLISECOND = 10000
-    const val PLAYER_TIME_UPDATE_RATE = 1000L
+    const val PLAYER_TIME_UPDATE_RATE = 10000L
     const val DEFAULT_CONTROLS_TIMEOUT_MS = 2500
     const val GESTURE_EXCLUSION_AREA_TOP = 48
     const val DEFAULT_CENTER_OVERLAY_TIMEOUT_MS = 250


### PR DESCRIPTION
- Changed `PLAYER_TIME_UPDATE_RATE` from 1 second to 10 seconds
 Too much spam before, to the level of slowing down the server (at least in my case), also is the default in [jellyfin-web](https://github.com/jellyfin/jellyfin-web/blob/0dde17fbd7b8318269de53784543cb2981715dce/src/components/playback/playbackmanager.js#L2751-L2755) 
- Stop active encoding if transcoding when playbacks ends

---

Originally 2 sessions are created because jellyfin-web creates a [singleton](https://github.com/jellyfin/jellyfin-web/blob/2edf4661d5b19dcc59414ba3c157f2ff1ca71713/src/components/ServerConnections.js#L20-L39) per device (many users - one device), while jellyfin-sdk-kotlin proposes one user per [session](https://github.com/jellyfin/jellyfin-sdk-kotlin/blob/a1d7596c4ef3bf3cb69eaab9b7872d3b0e5d350a/jellyfin-model/src/main/kotlin/org/jellyfin/sdk/model/DeviceInfo.kt#L7-L10) (one user - one device)

In the case of jellyfin-web, as it is a Singleton, once NativeShell is [injected](https://github.com/jellyfin/jellyfin-android/blob/530e01f67590077b8d1e2fc558b390e92b293b44/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt#L54-L73) the deviceId should not change or it causes unexpected behaviors

So `jellyfin-web` and `jellyfin-sdk-kotlin` must come to an agreement on what to do in these cases.

---

Before

![rs0PFEElVk](https://user-images.githubusercontent.com/25919231/122661608-ad996700-d151-11eb-97c2-7255b6aae2fb.gif)

After

![6XhogObBHn](https://user-images.githubusercontent.com/25919231/122661652-1e408380-d152-11eb-866e-252c5bbffdcc.gif)