### PR TITLE
fix odd release naming due to signing

### DIFF
--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -42,8 +42,8 @@ jobs:
       - name: Split APK release types
         run: |
           mkdir -p build/jellyfin-publish
-          mv ${{ steps.libreSign.outputs.signedReleaseFile }} build/jellyfin-publish/
-          mv ${{ steps.proprietarySign.outputs.signedReleaseFile }} build/jellyfin-publish/
+          mv ${{ steps.libreSign.outputs.signedReleaseFile }} build/jellyfin-publish/jellyfin-android-v${{ env.JELLYFIN_VERSION }}-libre.apk
+          mv ${{ steps.proprietarySign.outputs.signedReleaseFile }} build/jellyfin-publish/jellyfin-android-v${{ env.JELLYFIN_VERSION }}-proprietary.apk
           mv app/build/version.txt build/jellyfin-publish/
       - name: Upload release artifacts
         uses: alexellis/upload-assets@0.3.0

--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set JELLYFIN_VERSION
         run: echo "JELLYFIN_VERSION=$(echo ${GITHUB_REF#refs/tags/v} | tr / -)" >> $GITHUB_ENV
       - name: Assemble release APKs
-        run: ./gradlew --no-daemon --info assembleRelease versionTxt
+        run: ./gradlew --no-daemon --info assemble versionTxt
       - name: Sign libre APK
         id: libreSign
         uses: r0adkll/sign-android-release@v1
@@ -42,6 +42,10 @@ jobs:
       - name: Split APK release types
         run: |
           mkdir -p build/jellyfin-publish
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-debug.apk build/jellyfin-publish/
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-debug.apk build/jellyfin-publish/
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-libre-release-unsigned.apk build/jellyfin-publish/
+          mv app/build/outputs/apk/*/*/jellyfin-android-*-proprietary-release-unsigned.apk build/jellyfin-publish/
           mv ${{ steps.libreSign.outputs.signedReleaseFile }} build/jellyfin-publish/jellyfin-android-v${{ env.JELLYFIN_VERSION }}-libre.apk
           mv ${{ steps.proprietarySign.outputs.signedReleaseFile }} build/jellyfin-publish/jellyfin-android-v${{ env.JELLYFIN_VERSION }}-proprietary.apk
           mv app/build/version.txt build/jellyfin-publish/


### PR DESCRIPTION
### Description

what it says on the tin

### Changes

* fix odd release naming due to signing
* change to assemble both debug and release builds in publish workflow
* add unsigned and debug builds to publish pack

### Issues

* n/a?