### PR TITLE
Improve support for Jellyfin 10.8

### DIFF
--- a/app/src/main/assets/native/injectionScript.js
+++ b/app/src/main/assets/native/injectionScript.js
@@ -2,7 +2,7 @@
     const scripts = [
         '/native/nativeshell.js',
         '/native/EventEmitter.js',
-        document.currentScript.src.concat('?deferred=true&ts=', Date.now())
+        document.currentScript.src.split(/[?#]/)[0].concat('?deferred=true&ts=', Date.now())
     ];
     for (const script of scripts) {
         const scriptElement = document.createElement('script');

--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import org.jellyfin.mobile.cast.Chromecast
 import org.jellyfin.mobile.cast.IChromecast
 import org.jellyfin.mobile.fragment.ConnectFragment

--- a/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/fragment/WebViewFragment.kt
@@ -200,7 +200,13 @@ class WebViewFragment : Fragment(), NativePlayerHost {
                 val errorMessage = errorResponse.data?.run { bufferedReader().use(Reader::readText) }
                 Timber.e("Received WebView HTTP %d error: %s", errorResponse.statusCode, errorMessage)
 
-                if (request.url == Uri.parse(view.url)) onErrorReceived()
+                if (request.url == Uri.parse(view.url)) {
+                    if (errorResponse.statusCode == 404 && !request.url.toString().endsWith(Constants.FALLBACK_WEB_PATH)) {
+                        webView.loadUrl("${request.url}/${Constants.FALLBACK_WEB_PATH}")
+                        return
+                    }
+                    onErrorReceived()
+                }
             }
 
             override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceErrorCompat) {

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -12,7 +12,8 @@ object Constants {
 
     // Webapp constants
     const val MINIMUM_WEB_VIEW_VERSION = 80
-    val MAIN_BUNDLE_PATH_REGEX = Regex(""".*/main\.[^/\s]+\.bundle\.js""")
+    val MAIN_BUNDLE_PATH_REGEX = Regex(""".*/main(\.[^/\s]+|)\.bundle\.js""")
+    const val FALLBACK_WEB_PATH = "web/index.html"
     const val CAST_SDK_PATH = "cast_sender.js"
     const val SESSION_CAPABILITIES_PATH = "sessions/capabilities/full"
 


### PR DESCRIPTION
Optional change:

- Make a manual "redirect" attempt if the server responds with a 404 error

Required change:

- Tweak regex and injection script to support also Jellyfin 10.8 (I knew it would happen [again](https://github.com/jellyfin/jellyfin-android/pull/439#discussion_r654835168) ...)


Before 10.8
> https://demo.jellyfin.org/stable/web/main.0f183787a2f78055e856.bundle.js

Since 10.8
> https://demo.jellyfin.org/unstable/web/main.bundle.js?7a0f84ddb4c1919f988f

Feel free to drop the optional change if you want to wait for the upstream fix
