### PR TITLE
Properly open live streams before playback if necessary

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -34,6 +34,7 @@ class MediaSourceResolver(
                     audioStreamIndex = audioStreamIndex,
                     subtitleStreamIndex = subtitleStreamIndex,
                     maxStreamingBitrate = /* 1 GB/s */ 1_000_000_000,
+                    autoOpenLiveStream = true,
                 ),
             )
 


### PR DESCRIPTION
Previously the media source resolver did not check whether a media source required opening. Now, the media resolver appropriately opens the live stream for a media source, when required.

Even after the recent changes in fc05f2a5f104757438c77a861b098abc4da87fb0, the app still wouldn't open LiveTV for me using a HDHR Connect Duo. I took a peek at the web client, and realized that the app wasn't checking to see whether the media source had the requiresOpening flag set. Adding the code from my PR seems to resolve things for me.

_Note: my expertise is C and not Kotlin, so let me know if you have any feedback/recommendations. I'm not as fluent with the functional languages._