### PR TITLE
Add ffmpeg extension

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation(libs.androidx.media)
     implementation(libs.androidx.mediarouter)
     implementation(libs.bundles.exoplayer)
+    implementation(libs.jellyfin.exoplayer.ffmpegextension)
     @Suppress("UnstableApiUsage")
     proprietaryImplementation(libs.exoplayer.cast)
     @Suppress("UnstableApiUsage")

--- a/app/src/main/java/org/jellyfin/mobile/api/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/api/DeviceProfileBuilder.kt
@@ -262,22 +262,21 @@ class DeviceProfileBuilder {
         /**
          * List of PCM codecs supported by ExoPlayer by default
          */
-        private val PCM_CODECS = arrayOf("pcm_s8", "pcm_s16be", "pcm_s16le", "pcm_s24le", "pcm_s32le", "pcm_f32le")
+        private val PCM_CODECS = arrayOf("pcm_s8", "pcm_s16be", "pcm_s16le", "pcm_s24le", "pcm_s32le", "pcm_f32le", "pcm_alaw", "pcm_mulaw")
 
         /**
          * IMPORTANT: Must have same length as [SUPPORTED_CONTAINER_FORMATS],
          * as it maps the codecs to the containers with the same index!
          */
-        // TODO: add ffmpeg extension to support all (temporarily disabled) codecs
         private val AVAILABLE_AUDIO_CODECS = arrayOf(
             // mp4
-            arrayOf("mp1", "mp2", "mp3", "aac"),
+            arrayOf("mp1", "mp2", "mp3", "aac", "alac", "ac3"),
             // fmp4
-            emptyArray(),
+            arrayOf("mp3", "aac", "ac3", "eac3"),
             // webm
             arrayOf("vorbis", "opus"),
             // mkv
-            arrayOf(*PCM_CODECS, "mp1", "mp2", "mp3", "aac", "vorbis", "opus", "flac" /*, "ac3", "eac3", "dts"*/),
+            arrayOf(*PCM_CODECS, "mp1", "mp2", "mp3", "aac", "vorbis", "opus", "flac", "alac", "ac3", "eac3", "dts"),
             // mp3
             arrayOf("mp3"),
             // ogg
@@ -285,9 +284,9 @@ class DeviceProfileBuilder {
             // wav
             PCM_CODECS,
             // ts
-            arrayOf("mp1", "mp2", "mp3", "aac" /*, "ac3", "dts"*/),
+            arrayOf("mp1", "mp2", "mp3", "aac", "ac3", "dts"),
             // m2ts
-            arrayOf(*PCM_CODECS, "aac" /*, "ac3", "dts"*/),
+            arrayOf(*PCM_CODECS, "aac", "ac3", "dts"),
             // flv
             arrayOf("mp3", "aac"),
             // aac
@@ -302,7 +301,7 @@ class DeviceProfileBuilder {
          * List of audio codecs that will be added to the device profile regardless of [MediaCodecList] advertising them.
          * This is especially useful for codecs supported by decoders integrated to ExoPlayer or added through an extension.
          */
-        private val FORCED_AUDIO_CODECS = arrayOf(*PCM_CODECS)
+        private val FORCED_AUDIO_CODECS = arrayOf(*PCM_CODECS, "alac", "aac", "ac3", "eac3", "dts", "mlp", "truehd")
 
         private val EXO_EMBEDDED_SUBTITLES = arrayOf("srt", "subrip", "ttml")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerFragment.kt
@@ -247,14 +247,14 @@ class PlayerFragment : Fragment() {
      * @return true if the audio track was changed
      */
     fun onAudioTrackSelected(index: Int): Boolean {
-        return viewModel.mediaQueueManager.selectAudioTrack(index)
+        return viewModel.selectAudioTrack(index)
     }
 
     /**
      * @return true if the subtitle was changed
      */
     fun onSubtitleSelected(index: Int): Boolean {
-        return viewModel.mediaQueueManager.selectSubtitle(index)
+        return viewModel.selectSubtitle(index)
     }
 
     /**

--- a/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
@@ -11,6 +11,8 @@ import android.os.Build
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.analytics.AnalyticsCollector
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import org.jellyfin.mobile.player.source.JellyfinMediaSource
 import com.google.android.exoplayer2.audio.AudioAttributes as ExoPlayerAudioAttributes
 
@@ -77,16 +79,6 @@ inline fun ExoPlayer.AudioComponent.applyDefaultAudioAttributes(@C.AudioContentT
     setAudioAttributes(audioAttributes, true)
 }
 
-/**
- * Get the index of the first renderer with the specified [type]
- */
-fun ExoPlayer.getRendererIndexByType(type: Int): Int {
-    for (i in 0 until rendererCount) {
-        if (getRendererType(i) == type) return i
-    }
-    return -1
-}
-
 fun Player.seekToOffset(offsetMs: Long) {
     var positionMs = currentPosition + offsetMs
     val durationMs = duration
@@ -95,4 +87,8 @@ fun Player.seekToOffset(offsetMs: Long) {
     }
     positionMs = positionMs.coerceAtLeast(0)
     seekTo(positionMs)
+}
+
+fun Player.logTracks(analyticsCollector: AnalyticsCollector) {
+    analyticsCollector.onTracksChanged(currentTrackGroups, currentTrackSelections)
 }

--- a/app/src/main/java/org/jellyfin/mobile/utils/TrackSelectionUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/TrackSelectionUtils.kt
@@ -1,0 +1,67 @@
+package org.jellyfin.mobile.utils
+
+import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector
+
+
+/**
+ * Get the index of the first renderer of the specified [type] supporting the track with the specified [groupIndex].
+ *
+ * @param type One of the TRACK_TYPE_* constants defined in [C].
+ * @param groupIndex The index of the track group to which the track belongs.
+ */
+fun MappingTrackSelector.MappedTrackInfo.getBestRendererIndex(type: Int, groupIndex: Int): Int? {
+    if (groupIndex < 0) return null
+
+    for (i in 0 until rendererCount) {
+        if (getRendererType(i) != type || groupIndex >= getTrackGroups(i).length) continue
+        if (getTrackSupport(i, groupIndex, 0) == C.FORMAT_HANDLED) return i
+    }
+
+    // No perfect match found, try again with less strict requirements
+    for (i in 0 until rendererCount) {
+        if (getRendererType(i) != type || groupIndex >= getTrackGroups(i).length) continue
+        if (getTrackSupport(i, groupIndex, 0) == C.FORMAT_EXCEEDS_CAPABILITIES) return i
+    }
+
+    return null
+}
+
+/**
+ * Select the track of the specified [type] and [groupIndex] and enable it on the first supported renderer.
+ *
+ * @param type One of the TRACK_TYPE_* constants defined in [C].
+ * @param groupIndex The index of the track group to which the track belongs.
+ */
+fun DefaultTrackSelector.selectTrackByTypeAndGroup(type: Int, groupIndex: Int): Boolean {
+    with(currentMappedTrackInfo ?: return false) {
+        val parameters = buildUponParameters()
+        val rendererIndex = getBestRendererIndex(type, groupIndex) ?: return false
+        val selection = DefaultTrackSelector.SelectionOverride(groupIndex, 0)
+        parameters.clearSelectionOverrides(rendererIndex)
+        parameters.setSelectionOverride(rendererIndex, getTrackGroups(rendererIndex), selection)
+        parameters.setRendererDisabled(rendererIndex, false)
+        setParameters(parameters)
+    }
+    return true
+}
+
+/**
+ * Clear selection overrides for all renderers of the specified [type] and disable them.
+ *
+ * @param type One of the TRACK_TYPE_* constants defined in [C].
+ */
+fun DefaultTrackSelector.clearSelectionAndDisableRendererByType(type: Int): Boolean {
+    with(currentMappedTrackInfo ?: return false) {
+        val parameters = buildUponParameters()
+        for (i in 0 until rendererCount) {
+            if (getRendererType(i) == type) {
+                parameters.clearSelectionOverrides(i)
+                parameters.setRendererDisabled(i, true)
+            }
+        }
+        setParameters(parameters)
+    }
+    return true
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ allprojects {
             content {
                 includeVersionByRegex(JellyfinSdk.GROUP, ".*", JellyfinSdk.SNAPSHOT)
                 includeVersionByRegex(JellyfinSdk.GROUP, ".*", JellyfinSdk.SNAPSHOT_UNSTABLE)
+                includeVersionByRegex(JellyfinExoPlayer.GROUP, ".*", JellyfinExoPlayer.SNAPSHOT)
             }
         }
     }

--- a/buildSrc/src/main/kotlin/Jellyfin.kt
+++ b/buildSrc/src/main/kotlin/Jellyfin.kt
@@ -5,3 +5,8 @@ object JellyfinSdk {
     const val SNAPSHOT = "master-SNAPSHOT"
     const val SNAPSHOT_UNSTABLE = "openapi-unstable-SNAPSHOT"
 }
+
+object JellyfinExoPlayer {
+    const val GROUP = "org.jellyfin.exoplayer"
+    const val SNAPSHOT = "SNAPSHOT"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ coil = "1.3.1"
 androidx-media = "1.4.0"
 androidx-mediarouter = "1.2.4"
 exoplayer = "2.15.0"
+jellyfin-exoplayer-ffmpegextension = "2.15.0+2"
 playservices = "20.0.0"
 
 # Room
@@ -86,6 +87,7 @@ exoplayer-hls = { group = "com.google.android.exoplayer", name = "exoplayer-hls"
 exoplayer-cast = { group = "com.google.android.exoplayer", name = "extension-cast", version.ref = "exoplayer" }
 playservices-cast = { group = "com.google.android.gms", name = "play-services-cast", version.ref = "playservices" }
 playservices-castframework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "playservices" }
+jellyfin-exoplayer-ffmpegextension = { group = "org.jellyfin.exoplayer", name = "exoplayer-ffmpeg-extension", version.ref = "jellyfin-exoplayer-ffmpegextension" }
 
 # Room
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "androidx-room" }


### PR DESCRIPTION
- *A lot* of improvements related to #28. Adds support for multiple requested audio codecs like AC-3, E-AC-3, DTS, …
- Fix a bug where initial audio/subtitle track selections would be re-applied on ExoPlayer state changes.
- Refactor ExoPlayer event logging, current mapped track selections are logged on every manual audio/subtitle track change.
- Generally refactor track selection to be less complicated, more robust and easier to understand and debug.