### PR TITLE
Workaround for serviceWorker cache prevent injections

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -17,6 +17,7 @@ object Constants {
     val MAIN_BUNDLE_PATH_REGEX = Regex(""".*/main\.[^/\s]+\.bundle\.js""")
     const val CAST_SDK_PATH = "cast_sender.js"
     const val SESSION_CAPABILITIES_PATH = "sessions/capabilities/full"
+    const val SERVICE_WORKER_PATH = "serviceworker.js"
 
     const val FRAGMENT_CONNECT_EXTRA_ERROR = "org.jellyfin.mobile.intent.extra.ERROR"
     const val FRAGMENT_WEB_VIEW_EXTRA_SERVER = "org.jellyfin.mobile.intent.extra.SERVER"


### PR DESCRIPTION
Block Service Worker from caching that causes script injections to fail resulting in black screen or unable to connect on subsequent app restarts. 

Fixes #494