### PR TITLE
Fallback to prefer extension renderers if decoder fails

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaQueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaQueueManager.kt
@@ -70,6 +70,10 @@ class MediaQueueManager(
         return null
     }
 
+    fun tryRestartPlayback() {
+        _mediaQueue.value?.play()
+    }
+
     @CheckResult
     private fun createQueueItem(jellyfinMediaSource: JellyfinMediaSource, previous: QueueItem, next: QueueItem): QueueItem.Loaded {
         val exoMediaSource = prepareStreams(jellyfinMediaSource)


### PR DESCRIPTION
Necessary to support e.g. AAC-LTP on some devices, without unnecessarily impacting battery life for codecs supported by the hardware.