### PR TITLE
Build script refactoring

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,12 +3,12 @@ import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel
 import io.gitlab.arturbosch.detekt.Detekt
 
 plugins {
-    id("com.android.application")
-    kotlin("android")
-    kotlin("kapt")
-    id("kotlin-parcelize")
+    alias(libs.plugins.android.app)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.detekt)
-    id("de.mannodermaus.android-junit5")
+    alias(libs.plugins.android.junit5)
     alias(libs.plugins.dependencyupdates)
 }
 
@@ -150,7 +150,7 @@ dependencies {
 
     // Room
     implementation(libs.bundles.androidx.room)
-    kapt(libs.androidx.room.compiler)
+    ksp(libs.androidx.room.compiler)
 
     // Monitoring
     implementation(libs.timber)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,12 +37,6 @@ android {
         versionCode = getVersionCode(versionName!!)
         setProperty("archivesBaseName", "jellyfin-android-v$versionName")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments["room.schemaLocation"] = "$projectDir/schemas"
-                arguments["room.incremental"] = "true"
-            }
-        }
         vectorDrawables.useSupportLibrary = true
     }
 
@@ -102,6 +96,10 @@ android {
     }
 }
 
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+    arg("room.incremental", "true")
+}
 
 dependencies {
     val proprietaryImplementation by configurations

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,11 +27,12 @@ detekt {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
+
     defaultConfig {
         applicationId = "org.jellyfin.mobile"
         minSdk = 21
-        targetSdk = 30
+        targetSdk = 31
         versionName = project.getVersionName()
         versionCode = getVersionCode(versionName!!)
         setProperty("archivesBaseName", "jellyfin-android-v$versionName")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,8 @@
             android:name=".MainActivity"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden|uiMode"
             android:launchMode="singleTask"
-            android:supportsPictureInPicture="true">
+            android:supportsPictureInPicture="true"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/org/jellyfin/mobile/utils/PermissionRequestHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/PermissionRequestHelper.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.util.SparseArray
 import androidx.core.app.ActivityCompat
-import androidx.core.util.set
 import org.koin.android.ext.android.getKoin
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -17,7 +16,7 @@ class PermissionRequestHelper {
     fun getRequestCode() = requestCode.getAndIncrement()
 
     fun addCallback(requestCode: Int, callback: PermissionRequestCallback) {
-        permissionRequests[requestCode] = callback
+        permissionRequests.put(requestCode, callback)
     }
 
     fun handleRequestPermissionsResult(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        mavenCentral()
-        google()
-    }
-    dependencies {
-        val kotlinVersion: String by project
-        classpath("com.android.tools.build:gradle:7.0.2")
-        classpath(kotlin("gradle-plugin", kotlinVersion))
-        classpath("de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1")
-    }
-}
-
 allprojects {
     repositories {
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Kotlin version for this project
-kotlinVersion=1.5.31
 # Allow using snapshot releases of Jellyfin SDK. Possible values are:
 # - "default"
 # - "local" (local Maven repository)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 #
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2G -XX:MaxPermSize=512m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=512m
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 # Plugins
 android-plugin = "7.0.3"
-detekt = "1.18.1"
-dependencyupdates = "0.39.0"
 kotlin = "1.5.31"
 kotlin-ksp = "1.5.31-1.0.0"
+detekt = "1.18.1"
+android-junit5 = "1.8.0.0"
+dependencyupdates = "0.39.0"
 
 # KotlinX
 coroutines = "1.5.2"
@@ -52,16 +53,15 @@ kotest = "4.6.3"
 mockk = "1.12.0"
 androidx-test-runner = "1.4.0"
 androidx-test-espresso = "3.4.0"
-android-junit5 = "1.8.0.0"
 
 [plugins]
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-dependencyupdates = { id = "com.github.ben-manes.versions", version.ref = "dependencyupdates" }
 android-app = { id = "com.android.application", version.ref = "android-plugin" }
-android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android-junit5" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
+android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android-junit5" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dependencyupdates = { id = "com.github.ben-manes.versions", version.ref = "dependencyupdates" }
 
 [libraries]
 # KotlinX

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,10 @@
 [versions]
 # Plugins
+android-plugin = "7.0.3"
 detekt = "1.18.1"
 dependencyupdates = "0.39.0"
+kotlin = "1.5.31"
+kotlin-ksp = "1.5.31-1.0.0"
 
 # KotlinX
 coroutines = "1.5.2"
@@ -36,7 +39,7 @@ jellyfin-exoplayer-ffmpegextension = "2.15.1+1"
 playservices = "20.0.0"
 
 # Room
-androidx-room = "2.3.0"
+androidx-room = "2.4.0-beta01"
 
 # Monitoring
 timber = "5.0.1"
@@ -49,10 +52,16 @@ kotest = "4.6.3"
 mockk = "1.12.0"
 androidx-test-runner = "1.4.0"
 androidx-test-espresso = "3.4.0"
+android-junit5 = "1.8.0.0"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dependencyupdates = { id = "com.github.ben-manes.versions", version.ref = "dependencyupdates" }
+android-app = { id = "com.android.application", version.ref = "android-plugin" }
+android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android-junit5" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
 
 [libraries]
 # KotlinX

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,9 @@ enableFeaturePreview("VERSION_CATALOGS")
 include(":app")
 
 pluginManagement {
-    val kotlinVersion: String by settings
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.namespace?.startsWith("org.jetbrains.kotlin") == true)
-                useVersion(kotlinVersion)
-        }
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
     }
 }


### PR DESCRIPTION
- Update Android Gradle to 7.0.3
- Move all plugin configuration to version catalog
- Move Kotlin version to version catalog
- Switch from KAPT to KSP
  - Should improve build times since KSP doesn't do java stuff
  - Also hopefully fixes the occasional "cache is corrupt manually delete build dir to fix" issue
- Update Room to 2.4.0 beta - required for KSP 1.0.0 compatibility
- Use Android 12 when compiling
  - Also use it as target
  - Added `exported=true` in manifest for mainactivity (required by android 12)

I wanted to move the "all projects repositories" from build.gradle.kts to settings.gradle.kts using dependencyResolutionManagement but that wasn't possible because it uses buildsrc constants for the SDK stuff. So I didn't move that part, otherwise the root build.gradle.kts could become pretty much empty.
