### PR TITLE
Fix ExoPlayer crashing on track selection

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -180,7 +180,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
         }
         _player.value = SimpleExoPlayer.Builder(getApplication(), renderersFactory, extractorsFactory).apply {
             setTrackSelector(mediaQueueManager.trackSelector)
-            if (BuildConfig.DEBUG) setAnalyticsCollector(analyticsCollector)
+            setAnalyticsCollector(analyticsCollector)
         }.build().apply {
             addListener(this@PlayerViewModel)
             applyDefaultAudioAttributes(C.CONTENT_TYPE_MOVIE)


### PR DESCRIPTION
Without the `analyticsCollector` installed, any call using it would crash with a NPE. Thus, we enable it on release builds as well since the overhead should be minimal and the debugging information can be useful when users share their logs with us.