### PR TITLE
Fix inconsistent behaviour of the previous button

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerMediaSessionCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerMediaSessionCallback.kt
@@ -24,7 +24,7 @@ class PlayerMediaSessionCallback(private val viewModel: PlayerViewModel) : Media
     }
 
     override fun onSkipToPrevious() {
-        viewModel.skipToPrevious(force = true)
+        viewModel.skipToPrevious()
     }
 
     override fun onSkipToNext() {

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerNotificationHelper.kt
@@ -161,7 +161,7 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
                 Constants.ACTION_PAUSE -> viewModel.pause()
                 Constants.ACTION_REWIND -> viewModel.rewind()
                 Constants.ACTION_FAST_FORWARD -> viewModel.fastForward()
-                Constants.ACTION_PREVIOUS -> viewModel.skipToPrevious(force = true)
+                Constants.ACTION_PREVIOUS -> viewModel.skipToPrevious()
                 Constants.ACTION_NEXT -> viewModel.skipToNext()
                 Constants.ACTION_STOP -> viewModel.stop()
             }

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -329,18 +329,16 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
         playerOrNull?.seekToOffset(displayPreferences.skipForwardLength)
     }
 
-    fun skipToPrevious(force: Boolean = false) {
+    fun skipToPrevious() {
         val player = playerOrNull ?: return
         when {
             // Skip to previous element
-            force || player.currentPosition <= Constants.MAX_SKIP_TO_PREV_MS -> {
-                viewModelScope.launch {
-                    pause()
-                    if (!mediaQueueManager.previous()) {
-                        // Skip to previous failed, go to start of video anyway
-                        playerOrNull?.seekTo(0)
-                        play()
-                    }
+            player.currentPosition <= Constants.MAX_SKIP_TO_PREV_MS -> viewModelScope.launch {
+                pause()
+                if (!mediaQueueManager.previous()) {
+                    // Skip to previous failed, go to start of video anyway
+                    playerOrNull?.seekTo(0)
+                    play()
                 }
             }
             // Rewind to start of track if not at the start already


### PR DESCRIPTION
in the player control UI, the previous button only skips to the previous
track if the current position is smaller than
`Constants.MAX_SKIP_TO_PREV_MS`. however, the previous button in the
notification does not respect the current playback progress. this is
inconsistent and confusing behaviour.
this patch makes the previous button in the notification behave the same
as the previous button in the player control UI.
this makes the behaviour more consistent and also now the same as many
other popular media players, such as VLC, Spotify, etc.