### PR TITLE
Update Google Play Services to 20.1.0 to crash when using Chromecast on Android 12

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ androidx-media = "1.4.2"
 androidx-mediarouter = "1.2.5"
 exoplayer = "2.16.0"
 jellyfin-exoplayer-ffmpegextension = "2.16.0+1"
-playservices = "20.0.0"
+playservices = "20.1.0"
 
 # Room
 androidx-room = "2.4.0-beta01"


### PR DESCRIPTION
Fixes #573. Will be released as 2.4.2 when confirmed working.