### PR TITLE
Apply explicit navigation bar color on API v28 and below

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
         <item name="colorPrimaryDark">@color/jellyfin_primary_dark</item>
         <item name="colorAccent">@color/jellyfin_accent</item>
         <item name="android:windowBackground">@color/theme_background</item>
-        <item name="android:navigationBarColor">@color/jellyfin_primary_dark</item>
+        <item name="android:navigationBarColor">@color/theme_background</item>
     </style>
 
     <style name="AppTheme" parent="AppTheme.V21" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
         <item name="colorPrimaryDark">@color/jellyfin_primary_dark</item>
         <item name="colorAccent">@color/jellyfin_accent</item>
         <item name="android:windowBackground">@color/theme_background</item>
+        <item name="android:navigationBarColor">@color/jellyfin_primary_dark</item>
     </style>
 
     <style name="AppTheme" parent="AppTheme.V21" />


### PR DESCRIPTION
Fix #581
I used `@color/jellyfin_primary_dark`, which is also used for the status bar.
I didn't find a solution to use the themes background color or transparency, which would look a bit nicer.
Perhaps someone with a physical Android 10+ smartphone can confirm/deny if the navigation bar displays content that is behind it. On a emulated device with API v30 it stil looks like the second screenshot in the above issue (no transparency).