### PR TITLE
Added support for android client side logs to settings fragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,8 +7,10 @@ plugins {
     kotlin("android")
     kotlin("kapt")
     id("kotlin-parcelize")
+    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.detekt)
     id("de.mannodermaus.android-junit5")
+    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.dependencyupdates)
 }
 
@@ -27,11 +29,11 @@ detekt {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
     defaultConfig {
         applicationId = "org.jellyfin.mobile"
         minSdk = 21
-        targetSdk = 30
+        targetSdk = 31
         versionName = project.getVersionName()
         versionCode = getVersionCode(versionName!!)
         setProperty("archivesBaseName", "jellyfin-android-v$versionName")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
         tools:node="remove" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28"
         tools:ignore="ScopedStorage" />
 
     <queries>
@@ -43,7 +42,8 @@
             android:name=".MainActivity"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden|uiMode"
             android:launchMode="singleTask"
-            android:supportsPictureInPicture="true">
+            android:supportsPictureInPicture="true"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
@@ -2,15 +2,20 @@ package org.jellyfin.mobile
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import android.os.Environment
+import android.util.Log
 import android.view.WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import org.jellyfin.mobile.settings.ExternalPlayerPackage
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
 import java.io.File
+import kotlin.coroutines.coroutineContext
 
 class AppPreferences(context: Context) {
+    private val mContext = context
     private val sharedPreferences: SharedPreferences =
         context.getSharedPreferences("${context.packageName}_preferences", Context.MODE_PRIVATE)
 
@@ -81,6 +86,28 @@ class AppPreferences(context: Context) {
             sharedPreferences.edit {
                 if (File(value).parentFile?.isDirectory == true) {
                     putString(Constants.PREF_DOWNLOAD_LOCATION, value)
+                }
+            }
+        }
+
+    var logLocation: String
+        get() {
+            val defaultStorage = mContext.getExternalFilesDir(null)!!.absolutePath
+            val savedStorage = sharedPreferences.getString(Constants.PREF_LOG_LOCATION, null)
+
+            return if (savedStorage != null && File(savedStorage).parentFile?.isDirectory == true) {
+                // Saved location is still valid
+                savedStorage
+            } else {
+                // Reset download option if corrupt
+                sharedPreferences.edit { putString(Constants.PREF_LOG_LOCATION, null) }
+                defaultStorage
+            }
+        }
+        set(value) {
+            sharedPreferences.edit {
+                if (File(value).parentFile?.isDirectory == true) {
+                    putString(Constants.PREF_LOG_LOCATION, value)
                 }
             }
         }

--- a/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
@@ -2,17 +2,14 @@ package org.jellyfin.mobile
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.Build
 import android.os.Environment
-import android.util.Log
 import android.view.WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
-import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import org.jellyfin.mobile.settings.ExternalPlayerPackage
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
 import java.io.File
-import kotlin.coroutines.coroutineContext
+
 
 class AppPreferences(context: Context) {
     private val mContext = context

--- a/app/src/main/java/org/jellyfin/mobile/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/mobile/JellyfinApplication.kt
@@ -7,7 +7,6 @@ import org.jellyfin.mobile.api.apiModule
 import org.jellyfin.mobile.model.databaseModule
 import org.jellyfin.mobile.utils.JellyTree
 import org.jellyfin.mobile.utils.isWebViewSupported
-import org.jellyfin.sdk.BuildConfig
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.fragment.koin.fragmentFactory
 import org.koin.core.context.startKoin

--- a/app/src/main/java/org/jellyfin/mobile/JellyfinApplication.kt
+++ b/app/src/main/java/org/jellyfin/mobile/JellyfinApplication.kt
@@ -7,6 +7,7 @@ import org.jellyfin.mobile.api.apiModule
 import org.jellyfin.mobile.model.databaseModule
 import org.jellyfin.mobile.utils.JellyTree
 import org.jellyfin.mobile.utils.isWebViewSupported
+import org.jellyfin.sdk.BuildConfig
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.fragment.koin.fragmentFactory
 import org.koin.core.context.startKoin

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerLifecycleObserver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerLifecycleObserver.kt
@@ -1,18 +1,15 @@
 package org.jellyfin.mobile.player
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 
-class PlayerLifecycleObserver(private val viewModel: PlayerViewModel) : LifecycleObserver {
+class PlayerLifecycleObserver(private val viewModel: PlayerViewModel) : DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-    fun onCreate() {
+    override fun onCreate(owner: LifecycleOwner) {
         viewModel.setupPlayer()
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun onStop() {
+    override fun onStop(owner: LifecycleOwner) {
         if (!viewModel.notificationHelper.allowBackgroundAudio) {
             viewModel.pause()
         }

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -157,8 +157,8 @@ class SettingsFragment : Fragment() {
             initialSelection = appPreferences.logLocation
         }
 
-        pref("capture-log-button") {
-            title = "Capture log"
+        pref(Constants.PREF_CAPTURE_LOG) {
+            titleRes = R.string.pref_capture_log
             clickListener = Preference.OnClickListener { _, holder ->
                 requireContext().createLogs()
                 Toast.makeText(holder.itemView.context, "logcat has been captured", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import de.Maxr1998.modernpreferences.Preference
 import de.Maxr1998.modernpreferences.PreferencesAdapter
@@ -12,6 +13,7 @@ import de.Maxr1998.modernpreferences.helpers.categoryHeader
 import de.Maxr1998.modernpreferences.helpers.checkBox
 import de.Maxr1998.modernpreferences.helpers.defaultOnCheckedChange
 import de.Maxr1998.modernpreferences.helpers.defaultOnSelectionChange
+import de.Maxr1998.modernpreferences.helpers.pref
 import de.Maxr1998.modernpreferences.helpers.screen
 import de.Maxr1998.modernpreferences.helpers.singleChoice
 import de.Maxr1998.modernpreferences.preferences.CheckBoxPreference
@@ -20,15 +22,17 @@ import org.jellyfin.mobile.AppPreferences
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.databinding.FragmentSettingsBinding
 import org.jellyfin.mobile.utils.Constants
+import org.jellyfin.mobile.utils.LogDialog
 import org.jellyfin.mobile.utils.applyWindowInsetsAsMargins
+import org.jellyfin.mobile.utils.createLogs
 import org.jellyfin.mobile.utils.getDownloadsPaths
+import org.jellyfin.mobile.utils.getLogsPaths
 import org.jellyfin.mobile.utils.isPackageInstalled
 import org.jellyfin.mobile.utils.requireMainActivity
 import org.jellyfin.mobile.utils.withThemedContext
 import org.koin.android.ext.android.inject
 
 class SettingsFragment : Fragment() {
-
     private val appPreferences: AppPreferences by inject()
     private val settingsAdapter: PreferencesAdapter by lazy { PreferencesAdapter(buildSettingsScreen()) }
     private lateinit var swipeGesturesPreference: CheckBoxPreference
@@ -139,11 +143,39 @@ class SettingsFragment : Fragment() {
             titleRes = R.string.pref_download_location
             initialSelection = appPreferences.downloadLocation
         }
+
+        categoryHeader(PREF_CATEGORY_LOGS) {
+            titleRes = R.string.pref_category_logs
+        }
+
+        val logsDir: List<SelectionItem> = requireContext().getLogsPaths().map { path ->
+            SelectionItem(path, path, null)
+        }
+
+        singleChoice(Constants.PREF_LOG_LOCATION, logsDir) {
+            titleRes = R.string.pref_log_location
+            initialSelection = appPreferences.logLocation
+        }
+
+        pref("capture-log-button") {
+            title = "Capture log"
+            clickListener = Preference.OnClickListener { _, holder ->
+                requireContext().createLogs()
+                Toast.makeText(holder.itemView.context, "logcat has been captured", Toast.LENGTH_SHORT).show()
+                false
+            }
+        }
+
+        +LogDialog().apply {
+            title = "Clear logs"
+            iconRes = R.drawable.ic_info_24dp
+        }
     }
 
     companion object {
         const val PREF_CATEGORY_MUSIC_PLAYER = "pref_category_music"
         const val PREF_CATEGORY_VIDEO_PLAYER = "pref_category_video"
         const val PREF_CATEGORY_DOWNLOADS = "pref_category_downloads"
+        const val PREF_CATEGORY_LOGS = "pref_category_logs"
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -39,6 +39,7 @@ object Constants {
     const val PREF_EXTERNAL_PLAYER_APP = "pref_external_player_app"
     const val PREF_DOWNLOAD_LOCATION = "pref_download_location"
     const val PREF_LOG_LOCATION = "pref_log_location"
+    const val PREF_CAPTURE_LOG = "capture_log"
 
     // InputManager commands
     const val PLAYBACK_MANAGER_COMMAND_PLAY = "unpause"

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -2,6 +2,8 @@ package org.jellyfin.mobile.utils
 
 import android.media.session.PlaybackState
 import android.util.Rational
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import de.Maxr1998.modernpreferences.Preference
 import org.jellyfin.mobile.BuildConfig
 
 @Suppress("MagicNumber")
@@ -9,6 +11,7 @@ object Constants {
     // App Info
     const val APP_INFO_NAME = "Jellyfin Android"
     const val APP_INFO_VERSION: String = BuildConfig.VERSION_NAME
+    const val APP_LOGFILE_SCHEMA = "jellyfinLog"
 
     // Webapp constants
     const val MINIMUM_WEB_VIEW_VERSION = 80
@@ -37,6 +40,7 @@ object Constants {
     const val PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO = "pref_exoplayer_allow_background_audio"
     const val PREF_EXTERNAL_PLAYER_APP = "pref_external_player_app"
     const val PREF_DOWNLOAD_LOCATION = "pref_download_location"
+    const val PREF_LOG_LOCATION = "pref_log_location"
 
     // InputManager commands
     const val PLAYBACK_MANAGER_COMMAND_PLAY = "unpause"

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -2,8 +2,6 @@ package org.jellyfin.mobile.utils
 
 import android.media.session.PlaybackState
 import android.util.Rational
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import de.Maxr1998.modernpreferences.Preference
 import org.jellyfin.mobile.BuildConfig
 
 @Suppress("MagicNumber")

--- a/app/src/main/java/org/jellyfin/mobile/utils/LogDialog.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/LogDialog.kt
@@ -1,0 +1,17 @@
+package org.jellyfin.mobile.utils
+
+import android.app.Dialog
+import android.content.Context
+import de.Maxr1998.modernpreferences.preferences.DialogPreference
+
+class LogDialog : DialogPreference("delete-log-dialog") {
+    override fun createDialog(context: Context): Dialog =
+        Config.dialogBuilderFactory(context)
+            .setTitle("Clear logs")
+            .setMessage("Are you sure you want to clear the logs?")
+            .setNegativeButton(android.R.string.cancel, null)
+            .setPositiveButton(android.R.string.ok){ _, _ ->
+                context.deleteAllLogs()
+            }
+            .create()
+}

--- a/app/src/main/res/drawable-xxxhdpi/ic_info_24dp.xml
+++ b/app/src/main/res/drawable-xxxhdpi/ic_info_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11,17h2v-6h-2v6zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2L13,7h-2v2z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,4 +105,5 @@
 
     <string name="pref_category_logs">Logs</string>
     <string name="pref_log_location">Log location</string>
+    <string name="pref_capture_log">"Capture log"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,4 +102,7 @@
 
     <string name="pref_category_downloads">Downloads</string>
     <string name="pref_download_location">Download location</string>
+
+    <string name="pref_category_logs">Logs</string>
+    <string name="pref_log_location">Log location</string>
 </resources>

--- a/app/src/proprietary/java/org/jellyfin/mobile/cast/CastOptionsProvider.kt
+++ b/app/src/proprietary/java/org/jellyfin/mobile/cast/CastOptionsProvider.kt
@@ -7,7 +7,7 @@ import com.google.android.gms.cast.framework.SessionProvider
 
 class CastOptionsProvider : OptionsProvider {
     override fun getCastOptions(context: Context): CastOptions {
-        return CastOptions.Builder().setReceiverApplicationId(appId).build()
+        return CastOptions.Builder().setReceiverApplicationId(appId as String).build()
     }
 
     override fun getAdditionalSessionProviders(context: Context): List<SessionProvider>? {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ buildscript {
     }
     dependencies {
         val kotlinVersion: String by project
-        classpath("com.android.tools.build:gradle:7.0.2")
+        classpath("com.android.tools.build:gradle:7.0.4")
         classpath(kotlin("gradle-plugin", kotlinVersion))
-        classpath("de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1")
+        classpath("de.mannodermaus.gradle.plugins:android-junit5:1.8.0.0")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Kotlin version for this project
-kotlinVersion=1.5.31
+kotlinVersion=1.5.30
 # Allow using snapshot releases of Jellyfin SDK. Possible values are:
 # - "default"
 # - "local" (local Maven repository)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ androidx-lifecycle = "2.3.1"
 androidx-constraintlayout = "2.1.1"
 google-material = "1.4.0"
 androidx-webkit = "1.4.0"
-modernandroidpreferences = "2.1.0"
+modernandroidpreferences = "2.2.1"
 
 # Network
 jellyfin-sdk = "1.1.0"


### PR DESCRIPTION
Includes support for client side logs on android within the jellyfin setting, as well as some minor updates due to having to increase the target sdk  for 3rd party library support. Also addressed small code smells throughout. Includes two options, one for generating a logfile and another for deleting logs. 