### PR TITLE
added support for user default aspect ratio

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/AppPreferences.kt
@@ -113,4 +113,8 @@ class AppPreferences(context: Context) {
     var externalPlayerApp: String
         get() = sharedPreferences.getString(Constants.PREF_EXTERNAL_PLAYER_APP, ExternalPlayerPackage.SYSTEM_DEFAULT)!!
         set(value) = sharedPreferences.edit { putString(Constants.PREF_EXTERNAL_PLAYER_APP, value) }
+
+    var defaultAspectRatio: String?
+        get() = sharedPreferences.getString(Constants.DEFAULT_ASPECT_RATIO, "auto")
+        set(value) = sharedPreferences.edit {putString(Constants.DEFAULT_ASPECT_RATIO, value)}
 }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -14,6 +14,7 @@ import org.jellyfin.mobile.AppPreferences
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.fragment.WebViewFragment
 import org.jellyfin.mobile.settings.SettingsFragment
+import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.Constants.EXTRA_ALBUM
 import org.jellyfin.mobile.utils.Constants.EXTRA_ARTIST
@@ -81,7 +82,8 @@ class NativeInterface(private val fragment: WebViewFragment) : KoinComponent {
                 window.setBackgroundDrawable(null)
             }
             //set default aspect ratio for Html Video Player
-            webappFunctionChannel.setDefaultAspectRatio(appPreferences.defaultAspectRatio as String)
+            if(appPreferences.videoPlayerType == VideoPlayerType.WEB_PLAYER)
+                webappFunctionChannel.setDefaultAspectRatio(appPreferences.defaultAspectRatio as String)
         }
         return true
     }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.webkit.JavascriptInterface
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import org.jellyfin.mobile.AppPreferences
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.fragment.WebViewFragment
 import org.jellyfin.mobile.settings.SettingsFragment
@@ -48,6 +49,7 @@ class NativeInterface(private val fragment: WebViewFragment) : KoinComponent {
     private val context: Context = fragment.requireContext()
     private val webappFunctionChannel: WebappFunctionChannel by inject()
     private val remoteVolumeProvider: RemoteVolumeProvider by inject()
+    private val appPreferences: AppPreferences by inject()
 
     @SuppressLint("HardwareIds")
     @JavascriptInterface
@@ -78,6 +80,8 @@ class NativeInterface(private val fragment: WebViewFragment) : KoinComponent {
                 enableFullscreen()
                 window.setBackgroundDrawable(null)
             }
+            //set default aspect ratio for Html Video Player
+            webappFunctionChannel.setDefaultAspectRatio(appPreferences.defaultAspectRatio as String)
         }
         return true
     }

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -140,6 +140,7 @@ class SettingsFragment : Fragment() {
         singleChoice(Constants.DEFAULT_ASPECT_RATIO, aspectRatios) {
             title = getString(R.string.default_aspect_ratio)
             initialSelection = appPreferences.defaultAspectRatio //auto by default
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.WEB_PLAYER
         }
 
         categoryHeader(PREF_CATEGORY_DOWNLOADS) {

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -129,6 +129,19 @@ class SettingsFragment : Fragment() {
             titleRes = R.string.external_player_app
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXTERNAL_PLAYER
         }
+
+        //Supported aspect ratios
+        val aspectRatios = listOf(
+            SelectionItem("auto", getString(R.string.aspect_ratio_auto), null),
+            SelectionItem("cover", getString(R.string.aspect_ratio_cover), null),
+            SelectionItem("fill", getString(R.string.aspect_ratio_fill), null)
+        )
+
+        singleChoice(Constants.DEFAULT_ASPECT_RATIO, aspectRatios) {
+            title = getString(R.string.default_aspect_ratio)
+            initialSelection = appPreferences.defaultAspectRatio //auto by default
+        }
+
         categoryHeader(PREF_CATEGORY_DOWNLOADS) {
             titleRes = R.string.pref_category_downloads
         }

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -141,4 +141,7 @@ object Constants {
 
     // Misc
     const val PERCENT_MAX = 100
+
+    //default aspect ratio
+    const val DEFAULT_ASPECT_RATIO = "default_aspect_ratio"
 }

--- a/app/src/main/java/org/jellyfin/mobile/webapp/WebappFunctionChannel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/WebappFunctionChannel.kt
@@ -18,6 +18,7 @@ class WebappFunctionChannel {
     fun setVolume(volume: Int) = call("$PLAYBACK_MANAGER.sendCommand({ Name: 'SetVolume', Arguments: { Volume: $volume } });")
     fun seekTo(pos: Long) = call("$PLAYBACK_MANAGER.seekMs($pos);")
     fun goBack() = call("$NAVIGATION_HELPER.goBack();")
+    fun setDefaultAspectRatio(aspect: String) = call("$PLAYBACK_MANAGER.sendCommand({ Name: 'SetAspectRatio', Arguments: { AspectRatio: `$aspect` } });")
 
     companion object {
         private const val NAVIGATION_HELPER = "window.NavigationHelper"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,4 +102,8 @@
 
     <string name="pref_category_downloads">Downloads</string>
     <string name="pref_download_location">Download location</string>
+    <string name="default_aspect_ratio">Default aspect ratio</string>
+    <string name="aspect_ratio_auto">Auto</string>
+    <string name="aspect_ratio_cover">Cover</string>
+    <string name="aspect_ratio_fill">Fill</string>
 </resources>


### PR DESCRIPTION
The user default aspect ratio is for html Html Video Player only. Allows user to specify a default aspect ratio in the setting fragment