### PR TITLE
add stale issue check workflow

### DIFF
--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v4.1.0
         with:
-          repo-token: ${{ github.token }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}
           days-before-stale: 120
           days-before-pr-stale: -1
           days-before-close: 21

--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -1,4 +1,4 @@
-name: Issue Stale Check
+name: Issue stale check
 
 on:
   schedule:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/stale@v4.1.0
         with:

--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -1,0 +1,30 @@
+name: Issue Stale Check
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.1.0
+        with:
+          repo-token: ${{ github.token }}
+          days-before-stale: 120
+          days-before-pr-stale: -1
+          days-before-close: 21
+          days-before-pr-close: -1
+          exempt-issue-labels: enhancement,confirmed
+          stale-issue-label: stale
+          stale-issue-message: |-
+            This issue has gone 120 days without comment. To avoid abandoned issues, it will be closed in 21 days if there are no new comments.
+            
+            If you're the original submitter of this issue, please comment confirming if this issue still affects you in the latest release or master branch, or close the issue if it has been fixed. If you're another user also affected by this bug, please comment confirming so. Either action will remove the stale label.
+            
+            This bot exists to prevent issues from becoming stale and forgotten. Jellyfin is always moving forward, and bugs are often fixed as side effects of other changes. We therefore ask that bug report authors remain vigilant about their issues to ensure they are closed if fixed, or re-confirmed - perhaps with fresh logs or reproduction examples - regularly. If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).


### PR DESCRIPTION
### Description

This PR aims to add a GitHub Action workflow to monitor, label and close stale issues.
It uses the Jellyfin-Bot token to comment and close stale Issues.

> NOTE: It explicitly does not touch PRs

### Changes

* add a basic GitHub action workflow to monitor, label, and close stale issues within this repository

### Issues

* successor to the discontinued Stale-Bot config
