### PR TITLE
Add repository condition to stale workflow

### DIFF
--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'jellyfin/jellyfin-android'
     steps:
       - name: Checkout repository

--- a/.github/workflows/gradlew-validate.yaml
+++ b/.github/workflows/gradlew-validate.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/repo-stale.yaml
+++ b/.github/workflows/repo-stale.yaml
@@ -2,7 +2,7 @@ name: Issue stale check
 
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '30 3 * * *'
   workflow_dispatch:
 
 permissions:
@@ -12,6 +12,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-20.04
+    if: github.repository == 'jellyfin/jellyfin-android'
     steps:
       - uses: actions/stale@v4.1.0
         with:


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Add repository condition to stale workflow
  - Now disabled for forks
- Change runs-on for gradle workflows (accidently used ubuntu-latest)
- Change cron schedule to trigger 30 minutes before the gradlew-update workflow
  - If both workflows trigger GitHub notifications the gradle update notification will be on the top
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
