### PR TITLE
Android Auto: Sort playlists by name and return more by default

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/audio/car/LibraryBrowser.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/audio/car/LibraryBrowser.kt
@@ -336,12 +336,11 @@ class LibraryBrowser(
         val result by itemsApi.getItemsByUserId(
             parentId = libraryId,
             includeItemTypes = listOf("Playlist"),
-            sortBy = listOf("DatePlayed"),
-            sortOrder = listOf(SortOrder.DESCENDING),
+            sortBy = listOf(ItemFields.SORT_NAME.serialName),
             recursive = true,
             imageTypeLimit = 1,
             enableImageTypes = listOf(ImageType.PRIMARY),
-            limit = 20,
+            limit = 50,
         )
 
         return result.extractItems()?.browsable()


### PR DESCRIPTION
Closes #302 (first suggestion only, other two are duplicates).