### PR TITLE
Use specified video version in native player

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -13,9 +13,9 @@ import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.source.SingleSampleMediaSource
 import com.google.android.exoplayer2.source.hls.HlsMediaSource
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
-import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.PlayerException
 import org.jellyfin.mobile.player.PlayerViewModel
+import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.source.JellyfinMediaSource
 import org.jellyfin.mobile.player.source.MediaSourceResolver
 import org.jellyfin.mobile.utils.clearSelectionAndDisableRendererByType
@@ -53,7 +53,7 @@ class QueueManager(
      */
     suspend fun startPlayback(playOptions: PlayOptions): PlayerException? {
         if (playOptions != currentPlayOptions) {
-            val itemId = playOptions.run { mediaSourceId ?: ids[playOptions.startIndex]}
+            val itemId = playOptions.run { mediaSourceId ?: ids[playOptions.startIndex] }
             mediaSourceResolver.resolveMediaSource(
                 itemId = itemId,
                 deviceProfile = deviceProfile,

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -53,7 +53,7 @@ class QueueManager(
      */
     suspend fun startPlayback(playOptions: PlayOptions): PlayerException? {
         if (playOptions != currentPlayOptions) {
-            val itemId = playOptions.ids[playOptions.startIndex]
+            val itemId = playOptions.run { mediaSourceId ?: ids[playOptions.startIndex]}
             mediaSourceResolver.resolveMediaSource(
                 itemId = itemId,
                 deviceProfile = deviceProfile,


### PR DESCRIPTION
User can specify a version of a video they want to play, but previously the native player does not play the specified version and plays the default version instead.  Use the specified version from `playOptions` if available, similar to how it is handled in external player mode. 

Fixes #585.