### PR TITLE
Add subtitle profiles to external player profile

### DIFF
--- a/app/src/main/assets/native/ExternalPlayerPlugin.js
+++ b/app/src/main/assets/native/ExternalPlayerPlugin.js
@@ -144,7 +144,7 @@ export class ExternalPlayerPlugin {
             MusicStreamingTranscodingBitrate: 320000,
             DirectPlayProfiles: [{Type: 'Video'}, {Type: 'Audio'}],
             CodecProfiles: [],
-            SubtitleProfiles: [],
+            SubtitleProfiles: JSON.parse(this._externalPlayer.getSubtitleProfiles()),
             TranscodingProfiles: []
         };
     }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -32,6 +32,7 @@ import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.PlayMethod
 import org.json.JSONObject
+import org.json.JSONArray
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.component.inject
@@ -103,6 +104,15 @@ class ExternalPlayer(
                 }
             }
         }
+    }
+
+    @JavascriptInterface
+    fun getSubtitleProfiles(): String {
+        val subtitleProfiles = JSONArray()
+        externalPlayerProfile.subtitleProfiles?.forEach{
+            subtitleProfiles.put( JSONObject( "{Format: '${it.format}', Method: '${it.method}'}" ) )
+        }
+        return subtitleProfiles.toString()
     }
 
     private fun playMediaSource(playOptions: PlayOptions, source: JellyfinMediaSource) {

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -12,8 +12,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.R
+import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.player.PlayerException
 import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.source.ExternalSubtitleStream
@@ -31,8 +31,8 @@ import org.jellyfin.sdk.api.operations.VideosApi
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.PlayMethod
-import org.json.JSONObject
 import org.json.JSONArray
+import org.json.JSONObject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.component.inject
@@ -109,8 +109,13 @@ class ExternalPlayer(
     @JavascriptInterface
     fun getSubtitleProfiles(): String {
         val subtitleProfiles = JSONArray()
-        externalPlayerProfile.subtitleProfiles?.forEach{
-            subtitleProfiles.put( JSONObject( "{Format: '${it.format}', Method: '${it.method}'}" ) )
+        externalPlayerProfile.subtitleProfiles?.forEach { profile ->
+            subtitleProfiles.put(
+                JSONObject().apply {
+                    put("method", profile.method)
+                    put("format", profile.format)
+                }
+            )
         }
         return subtitleProfiles.toString()
     }


### PR DESCRIPTION
#566 marked all video as direct-playable in the external player profile stub, but the web client still thinks that the player is transcoding when there are subtitles since the player profile lacked the supported subtitle formats. Add the supported formats in the player profile. 

Fixes #565.