### PR TITLE
ExoPlayer: Use cronet where available

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation(libs.androidx.mediarouter)
     implementation(libs.bundles.exoplayer)
     implementation(libs.jellyfin.exoplayer.ffmpegextension)
+    implementation(libs.exoplayer.cronet)
     @Suppress("UnstableApiUsage")
     proprietaryImplementation(libs.exoplayer.cast)
     @Suppress("UnstableApiUsage")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,13 +136,15 @@ dependencies {
     }
     implementation(libs.okhttp)
     implementation(libs.coil)
+    implementation(libs.cronetembedded)
+    implementation(libs.cronetokhttp)
 
     // Media
     implementation(libs.androidx.media)
     implementation(libs.androidx.mediarouter)
     implementation(libs.bundles.exoplayer)
     implementation(libs.jellyfin.exoplayer.ffmpegextension)
-    implementation(libs.exoplayer.cronet)
+    implementation(libs.exoplayer.okhttp)
     @Suppress("UnstableApiUsage")
     proprietaryImplementation(libs.exoplayer.cast)
     @Suppress("UnstableApiUsage")

--- a/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
@@ -12,9 +12,13 @@ import com.google.android.exoplayer2.source.hls.HlsMediaSource
 import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.DefaultDataSource
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
+import com.google.android.exoplayer2.ext.cronet.CronetDataSource
 import com.google.android.exoplayer2.util.Util
+import com.google.android.gms.net.CronetProviderInstaller
 import kotlinx.coroutines.channels.Channel
 import okhttp3.OkHttpClient
+import org.chromium.net.CronetEngine
+import org.chromium.net.CronetProvider
 import org.jellyfin.mobile.MainViewModel
 import org.jellyfin.mobile.bridge.ExternalPlayer
 import org.jellyfin.mobile.player.audio.car.LibraryBrowser
@@ -34,6 +38,7 @@ import org.koin.androidx.fragment.dsl.fragment
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import java.util.concurrent.Executors
 
 const val PLAYER_EVENT_CHANNEL = "PlayerEventChannel"
 private const val TS_SEARCH_PACKETS = 1800
@@ -67,7 +72,23 @@ val applicationModule = module {
     // ExoPlayer factories
     single<DataSource.Factory> {
         val context: Context = get()
-        val baseDataSourceFactory = DefaultHttpDataSource.Factory().setUserAgent(Util.getUserAgent(context, Constants.APP_INFO_NAME))
+
+        val provider = CronetProvider.getAllProviders(context).firstOrNull { provider: CronetProvider ->
+            (provider.name == CronetProviderInstaller.PROVIDER_NAME) && provider.isEnabled
+        }
+
+        val baseDataSourceFactory = if (provider != null) {
+            val cronetEngine = provider.createBuilder()
+                .enableHttp2(true)
+                .enableQuic(true)
+                .enableBrotli(true)
+                .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_IN_MEMORY, 16 * 1024 * 1024)
+                .build()
+            CronetDataSource.Factory(cronetEngine, Executors.newCachedThreadPool()).setUserAgent(Util.getUserAgent(context, Constants.APP_INFO_NAME))
+        } else {
+            DefaultHttpDataSource.Factory().setUserAgent(Util.getUserAgent(context, Constants.APP_INFO_NAME))
+        }
+
         DefaultDataSource.Factory(context, baseDataSourceFactory)
     }
     single<MediaSourceFactory> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ exoplayer-ui = { group = "com.google.android.exoplayer", name = "exoplayer-ui", 
 exoplayer-mediaSession = { group = "com.google.android.exoplayer", name = "extension-mediasession", version.ref = "exoplayer" }
 exoplayer-hls = { group = "com.google.android.exoplayer", name = "exoplayer-hls", version.ref = "exoplayer" }
 exoplayer-cast = { group = "com.google.android.exoplayer", name = "extension-cast", version.ref = "exoplayer" }
+exoplayer-cronet = { group = "com.google.android.exoplayer", name = "extension-cronet", version.ref = "exoplayer" }
 playservices-cast = { group = "com.google.android.gms", name = "play-services-cast", version.ref = "playservices" }
 playservices-castframework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "playservices" }
 jellyfin-exoplayer-ffmpegextension = { group = "org.jellyfin.exoplayer", name = "exoplayer-ffmpeg-extension", version.ref = "jellyfin-exoplayer-ffmpegextension" }
@@ -144,6 +145,7 @@ exoplayer = [
     "exoplayer-ui",
     "exoplayer-mediaSession",
     "exoplayer-hls",
+    "exoplayer-cronet",
 ]
 playservices = [
     "playservices-cast",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,8 @@ modernandroidpreferences = "2.3.1"
 jellyfin-sdk = "1.2.0"
 okhttp = "4.10.0"
 coil = "2.1.0"
+cronetembedded = "102.5005.125"
+cronetokhttp = "0.1.0"
 
 # Media
 androidx-media = "1.6.0"
@@ -93,6 +95,8 @@ modernandroidpreferences = { group = "de.maxr1998", name = "modernandroidprefere
 jellyfin-sdk = { group = "org.jellyfin.sdk", name = "jellyfin-core", version.ref = "jellyfin-sdk" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 coil = { group = "io.coil-kt", name = "coil-base", version.ref = "coil" }
+cronetembedded = { group = "org.chromium.net", name = "cronet-embedded", version.ref = "cronetembedded" }
+cronetokhttp = { group = "com.google.net.cronet", name = "cronet-okhttp", version.ref = "cronetokhttp"}
 
 # Media
 androidx-media = { group = "androidx.media", name = "media", version.ref = "androidx-media" }
@@ -102,7 +106,7 @@ exoplayer-ui = { group = "com.google.android.exoplayer", name = "exoplayer-ui", 
 exoplayer-mediaSession = { group = "com.google.android.exoplayer", name = "extension-mediasession", version.ref = "exoplayer" }
 exoplayer-hls = { group = "com.google.android.exoplayer", name = "exoplayer-hls", version.ref = "exoplayer" }
 exoplayer-cast = { group = "com.google.android.exoplayer", name = "extension-cast", version.ref = "exoplayer" }
-exoplayer-cronet = { group = "com.google.android.exoplayer", name = "extension-cronet", version.ref = "exoplayer" }
+exoplayer-okhttp = { group = "com.google.android.exoplayer", name = "extension-okhttp", version.ref = "exoplayer" }
 playservices-cast = { group = "com.google.android.gms", name = "play-services-cast", version.ref = "playservices" }
 playservices-castframework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "playservices" }
 jellyfin-exoplayer-ffmpegextension = { group = "org.jellyfin.exoplayer", name = "exoplayer-ffmpeg-extension", version.ref = "jellyfin-exoplayer-ffmpegextension" }
@@ -145,7 +149,7 @@ exoplayer = [
     "exoplayer-ui",
     "exoplayer-mediaSession",
     "exoplayer-hls",
-    "exoplayer-cronet",
+    "exoplayer-okhttp",
 ]
 playservices = [
     "playservices-cast",


### PR DESCRIPTION
[Cronet](https://exoplayer.dev/network-stacks.html#cronet) supports HTTP/3 and is better suited for streaming over lossy networks than Android's built-in stack. It's also recommended for this use case.
This commit adds a soft dependency on Cronet from Google Play Services and falls back to the previously used implementation if it's not available.

I don't know how a soft dependency on Google Play Services affects the libre build or if 16 MB in-memory cache is acceptable. Therefore, I welcome any feedback.