### PR TITLE
Add adaptive monochrome icon.

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Android 13 supports themed app icons.
This changes adds a monochromatic icon to `ic_launcher` and `ic_launcher_round`.

---

- **Before**:
![Screenshot_20220901-224322](https://user-images.githubusercontent.com/587220/188019914-df384404-2579-47e8-9a7f-d5db20ed030f.png)

- **After**:
![Screenshot_20220901-224904](https://user-images.githubusercontent.com/587220/188019938-d1d66459-63c6-4918-bfaf-13d321e5527b.png)
