### PR TITLE
don't automatically change orientation for landscape video

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
@@ -92,6 +92,9 @@ class AppPreferences(context: Context) {
     val videoPlayerType: String
         get() = sharedPreferences.getString(Constants.PREF_VIDEO_PLAYER_TYPE, VideoPlayerType.WEB_PLAYER)!!
 
+    val exoPlayerStartLandscapeVideoInLandscape: Boolean
+        get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_START_LANDSCAPE_VIDEO_IN_LANDSCAPE, false)
+
     val exoPlayerAllowSwipeGestures: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES, true)
 

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -28,6 +28,7 @@ import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.ui.PlayerView
 import kotlinx.coroutines.launch
 import org.jellyfin.mobile.R
+import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.databinding.ExoPlayerControlViewBinding
 import org.jellyfin.mobile.databinding.FragmentPlayerBinding
 import org.jellyfin.mobile.player.PlayerException
@@ -46,8 +47,10 @@ import org.jellyfin.mobile.utils.extensions.isFullscreen
 import org.jellyfin.mobile.utils.extensions.isLandscape
 import org.jellyfin.mobile.utils.toast
 import org.jellyfin.sdk.model.api.MediaStream
+import org.koin.android.ext.android.inject
 
 class PlayerFragment : Fragment() {
+    private val appPreferences: AppPreferences by inject()
     private val viewModel: PlayerViewModel by viewModels()
     private var _playerBinding: FragmentPlayerBinding? = null
     private val playerBinding: FragmentPlayerBinding get() = _playerBinding!!
@@ -103,6 +106,9 @@ class PlayerFragment : Fragment() {
                     // For portrait videos, immediately enable fullscreen
                     enableFullscreen()
                     updateFullscreenSwitcher(isFullscreen())
+                } else if (appPreferences.exoPlayerStartLandscapeVideoInLandscape) {
+                    // Auto-switch to landscape for landscape videos if enabled
+                    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
                 }
             }
 

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -99,10 +99,7 @@ class PlayerFragment : Fragment() {
             val jellyfinMediaSource = queueItem.jellyfinMediaSource
 
             with(requireActivity()) {
-                if (jellyfinMediaSource.selectedVideoStream?.isLandscape != false) {
-                    // Switch to landscape for landscape videos
-                    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-                } else {
+                if (jellyfinMediaSource.selectedVideoStream?.isLandscape == false) {
                     // For portrait videos, immediately enable fullscreen
                     enableFullscreen()
                     updateFullscreenSwitcher(isFullscreen())

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -31,6 +31,7 @@ class SettingsFragment : Fragment() {
 
     private val appPreferences: AppPreferences by inject()
     private val settingsAdapter: PreferencesAdapter by lazy { PreferencesAdapter(buildSettingsScreen()) }
+    private lateinit var startLandscapeVideoInLandscapePreference: CheckBoxPreference
     private lateinit var swipeGesturesPreference: CheckBoxPreference
     private lateinit var rememberBrightnessPreference: Preference
     private lateinit var backgroundAudioPreference: Preference
@@ -81,11 +82,16 @@ class SettingsFragment : Fragment() {
             titleRes = R.string.pref_video_player_type_title
             initialSelection = VideoPlayerType.WEB_PLAYER
             defaultOnSelectionChange { selection ->
+                startLandscapeVideoInLandscapePreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 swipeGesturesPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 rememberBrightnessPreference.enabled = selection == VideoPlayerType.EXO_PLAYER && swipeGesturesPreference.checked
                 backgroundAudioPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 externalPlayerChoicePreference.enabled = selection == VideoPlayerType.EXTERNAL_PLAYER
             }
+        }
+        startLandscapeVideoInLandscapePreference = checkBox(Constants.PREF_EXOPLAYER_START_LANDSCAPE_VIDEO_IN_LANDSCAPE) {
+            titleRes = R.string.pref_exoplayer_start_landscape_video_in_landscape
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
         }
         swipeGesturesPreference = checkBox(Constants.PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES) {
             titleRes = R.string.pref_exoplayer_allow_brightness_volume_gesture

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -33,6 +33,7 @@ object Constants {
     const val PREF_DOWNLOAD_METHOD = "pref_download_method"
     const val PREF_MUSIC_NOTIFICATION_ALWAYS_DISMISSIBLE = "pref_music_notification_always_dismissible"
     const val PREF_VIDEO_PLAYER_TYPE = "pref_video_player_type"
+    const val PREF_EXOPLAYER_START_LANDSCAPE_VIDEO_IN_LANDSCAPE = "pref_exoplayer_start_landscape_video_in_landscape"
     const val PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES = "pref_exoplayer_allow_swipe_gestures"
     const val PREF_EXOPLAYER_REMEMBER_BRIGHTNESS = "pref_exoplayer_remember_brightness"
     const val PREF_EXOPLAYER_BRIGHTNESS = "pref_exoplayer_brightness"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="video_player_web_description">The default HTML video player from the Web UI</string>
     <string name="video_player_native_description">Based on ExoPlayer, supports more video formats and codecs, and is more integrated into the OS</string>
     <string name="video_player_external_description">External video playback apps like MX Player and VLC</string>
+    <string name="pref_exoplayer_start_landscape_video_in_landscape">Start landscape mode videos in landscape orientation</string>
     <string name="pref_exoplayer_allow_brightness_volume_gesture">Brightness and volume gestures</string>
     <string name="pref_exoplayer_remember_brightness">Remember display brightness</string>
     <string name="pref_exoplayer_allow_background_audio">Background audio</string>


### PR DESCRIPTION
This change prevents the screen orientation from automatically changing on playback start in ExoPlayer.

The player now keeps the currently active screen orientation. When the device is rotated (with auto-rotate active), the player rotates accordingly. The player is also rotated when pressing the fullscreen button.

Only works in ExoPlayer, the web player still shows the old behaviour. I'm not sure where the corresponding code is for the web player.

Probably fixes #141 