### PR TITLE
Add ability to direct play ass with exoplayer

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
@@ -74,7 +74,7 @@ val applicationModule = module {
 
     // Media player helpers
     single { MediaSourceResolver(get()) }
-    single { DeviceProfileBuilder() }
+    single { DeviceProfileBuilder(get()) }
     single { QualityOptionsProvider() }
 
     // ExoPlayer factories

--- a/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
@@ -109,6 +109,9 @@ class AppPreferences(context: Context) {
     val exoPlayerAllowBackgroundAudio: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO, false)
 
+    val exoPlayerDirectPlayAss: Boolean
+        get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_DIRECT_PLAY_ASS, false)
+
     @ExternalPlayerPackage
     var externalPlayerApp: String
         get() = sharedPreferences.getString(Constants.PREF_EXTERNAL_PLAYER_APP, ExternalPlayerPackage.SYSTEM_DEFAULT)!!

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.mobile.player.deviceprofile
 
 import android.media.MediaCodecList
+import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.bridge.ExternalPlayer
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.api.CodecProfile
@@ -13,8 +14,11 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.api.SubtitleProfile
 import org.jellyfin.sdk.model.api.TranscodeSeekInfo
 import org.jellyfin.sdk.model.api.TranscodingProfile
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class DeviceProfileBuilder {
+class DeviceProfileBuilder : KoinComponent {
+    private val appPreferences: AppPreferences by inject()
     private val supportedVideoCodecs: Array<Array<String>>
     private val supportedAudioCodecs: Array<Array<String>>
 
@@ -155,13 +159,17 @@ class DeviceProfileBuilder {
             }
         }
 
+        var subtitleProfiles = if (appPreferences.exoPlayerDirectPlayAss)
+            getSubtitleProfiles(EXO_EMBEDDED_SUBTITLES_ASS, EXO_EXTERNAL_SUBTITLES_ASS)
+        else getSubtitleProfiles(EXO_EMBEDDED_SUBTITLES, EXO_EXTERNAL_SUBTITLES);
+
         return DeviceProfile(
             name = Constants.APP_INFO_NAME,
             directPlayProfiles = directPlayProfiles,
             transcodingProfiles = transcodingProfiles,
             containerProfiles = containerProfiles,
             codecProfiles = codecProfiles,
-            subtitleProfiles = getSubtitleProfiles(EXO_EMBEDDED_SUBTITLES, EXO_EXTERNAL_SUBTITLES),
+            subtitleProfiles = subtitleProfiles,
             maxStreamingBitrate = MAX_STREAMING_BITRATE,
             maxStaticBitrate = MAX_STATIC_BITRATE,
             musicStreamingTranscodingBitrate = MAX_MUSIC_TRANSCODING_BITRATE,
@@ -299,7 +307,9 @@ class DeviceProfileBuilder {
         private val FORCED_AUDIO_CODECS = arrayOf(*PCM_CODECS, "alac", "aac", "ac3", "eac3", "dts", "mlp", "truehd")
 
         private val EXO_EMBEDDED_SUBTITLES = arrayOf("srt", "subrip", "ttml")
+        private val EXO_EMBEDDED_SUBTITLES_ASS = arrayOf("srt", "subrip", "ttml", "ssa", "ass")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")
+        private val EXO_EXTERNAL_SUBTITLES_ASS = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt", "ssa", "ass")
         private val EXTERNAL_PLAYER_SUBTITLES = arrayOf(
             "ssa", "ass", "srt", "subrip", "idx", "sub", "vtt", "webvtt", "ttml", "pgs", "pgssub", "smi", "smil",
         )

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -14,11 +14,10 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.api.SubtitleProfile
 import org.jellyfin.sdk.model.api.TranscodeSeekInfo
 import org.jellyfin.sdk.model.api.TranscodingProfile
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 
-class DeviceProfileBuilder : KoinComponent {
-    private val appPreferences: AppPreferences by inject()
+class DeviceProfileBuilder(
+    private val appPreferences: AppPreferences,
+) {
     private val supportedVideoCodecs: Array<Array<String>>
     private val supportedAudioCodecs: Array<Array<String>>
 
@@ -159,9 +158,10 @@ class DeviceProfileBuilder : KoinComponent {
             }
         }
 
-        var subtitleProfiles = if (appPreferences.exoPlayerDirectPlayAss)
-            getSubtitleProfiles(EXO_EMBEDDED_SUBTITLES_ASS, EXO_EXTERNAL_SUBTITLES_ASS)
-        else getSubtitleProfiles(EXO_EMBEDDED_SUBTITLES, EXO_EXTERNAL_SUBTITLES);
+        val subtitleProfiles = when {
+            appPreferences.exoPlayerDirectPlayAss -> getSubtitleProfiles(EXO_EMBEDDED_SUBTITLES + SUBTITLES_SSA, EXO_EXTERNAL_SUBTITLES + SUBTITLES_SSA)
+            else -> getSubtitleProfiles(EXO_EMBEDDED_SUBTITLES, EXO_EXTERNAL_SUBTITLES)
+        }
 
         return DeviceProfile(
             name = Constants.APP_INFO_NAME,
@@ -307,9 +307,8 @@ class DeviceProfileBuilder : KoinComponent {
         private val FORCED_AUDIO_CODECS = arrayOf(*PCM_CODECS, "alac", "aac", "ac3", "eac3", "dts", "mlp", "truehd")
 
         private val EXO_EMBEDDED_SUBTITLES = arrayOf("srt", "subrip", "ttml")
-        private val EXO_EMBEDDED_SUBTITLES_ASS = arrayOf("srt", "subrip", "ttml", "ssa", "ass")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")
-        private val EXO_EXTERNAL_SUBTITLES_ASS = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt", "ssa", "ass")
+        private val SUBTITLES_SSA = arrayOf("ssa", "ass")
         private val EXTERNAL_PLAYER_SUBTITLES = arrayOf(
             "ssa", "ass", "srt", "subrip", "idx", "sub", "vtt", "webvtt", "ttml", "pgs", "pgssub", "smi", "smil",
         )

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -34,6 +34,7 @@ class SettingsFragment : Fragment() {
     private lateinit var swipeGesturesPreference: CheckBoxPreference
     private lateinit var rememberBrightnessPreference: Preference
     private lateinit var backgroundAudioPreference: Preference
+    private lateinit var directPlayAssPreference: Preference
     private lateinit var externalPlayerChoicePreference: Preference
 
     init {
@@ -84,6 +85,7 @@ class SettingsFragment : Fragment() {
                 swipeGesturesPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 rememberBrightnessPreference.enabled = selection == VideoPlayerType.EXO_PLAYER && swipeGesturesPreference.checked
                 backgroundAudioPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
+                directPlayAssPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 externalPlayerChoicePreference.enabled = selection == VideoPlayerType.EXTERNAL_PLAYER
             }
         }
@@ -105,6 +107,11 @@ class SettingsFragment : Fragment() {
         backgroundAudioPreference = checkBox(Constants.PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO) {
             titleRes = R.string.pref_exoplayer_allow_background_audio
             summaryRes = R.string.pref_exoplayer_allow_background_audio_summary
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
+        }
+        directPlayAssPreference = checkBox(Constants.PREF_EXOPLAYER_DIRECT_PLAY_ASS) {
+            titleRes = R.string.pref_exoplayer_direct_play_ass
+            summaryRes = R.string.pref_exoplayer_direct_play_ass_summary
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
         }
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -37,6 +37,7 @@ object Constants {
     const val PREF_EXOPLAYER_REMEMBER_BRIGHTNESS = "pref_exoplayer_remember_brightness"
     const val PREF_EXOPLAYER_BRIGHTNESS = "pref_exoplayer_brightness"
     const val PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO = "pref_exoplayer_allow_background_audio"
+    const val PREF_EXOPLAYER_DIRECT_PLAY_ASS = "pref_exoplayer_direct_play_ass"
     const val PREF_EXTERNAL_PLAYER_APP = "pref_external_player_app"
     const val PREF_DOWNLOAD_LOCATION = "pref_download_location"
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,8 +87,8 @@
     <string name="pref_exoplayer_remember_brightness">Remember display brightness</string>
     <string name="pref_exoplayer_allow_background_audio">Background audio</string>
     <string name="pref_exoplayer_allow_background_audio_summary">Allow playing videos in the background with audio-only</string>
-    <string name="pref_exoplayer_direct_play_ass">Don\'t transcode SSA/ASS subtitles</string>
-    <string name="pref_exoplayer_direct_play_ass_summary">Play subtitles directly with basic styling to prevent transcoding</string>
+    <string name="pref_exoplayer_direct_play_ass">Allow SSA/ASS subtitles in direct play</string>
+    <string name="pref_exoplayer_direct_play_ass_summary">Prevent transcoding and show subtitles with basic styling only. Advanced subtitle styling will not be available if enabled.</string>
 
     <string name="external_player_app">External player app</string>
     <string name="external_player_mpv">MPV Player</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,8 @@
     <string name="pref_exoplayer_remember_brightness">Remember display brightness</string>
     <string name="pref_exoplayer_allow_background_audio">Background audio</string>
     <string name="pref_exoplayer_allow_background_audio_summary">Allow playing videos in the background with audio-only</string>
+    <string name="pref_exoplayer_direct_play_ass">Don\'t transcode SSA/ASS subtitles</string>
+    <string name="pref_exoplayer_direct_play_ass_summary">Play subtitles directly with basic styling to prevent transcoding</string>
 
     <string name="external_player_app">External player app</string>
     <string name="external_player_mpv">MPV Player</string>


### PR DESCRIPTION
**Changes**
Add a check box in the client settings for ExoPlayer to enable direct play SSA/ASS subtitles without transcoding.

ExoPlayer only partially supports ass subtitles. While support for more features of ass is being worked on it currently only displays it as basic text. Because of that the Jellyfin Android app used to always transcode those subtitles when selected before starting playback. However some people may only have files with basic text in ass subtitles, not care about all the fancy styling or need to avoid transcoding because their server isn't that powerful. Therefore this PR adds the option to direct play ass subtitles.


**Issues**

https://github.com/jellyfin/jellyfin-android/issues/696
https://github.com/jellyfin/jellyfin/issues/7809