### PR TITLE
Implement downloadFiles in NativeShell

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -60,7 +60,11 @@ window.NativeShell = {
     },
 
     downloadFile(downloadInfo) {
-        window.NativeInterface.downloadFile(JSON.stringify(downloadInfo));
+        window.NativeInterface.downloadFiles(JSON.stringify([downloadInfo]));
+    },
+
+    downloadFiles(downloadInfo) {
+        window.NativeInterface.downloadFiles(JSON.stringify(downloadInfo));
     },
 
     openClientSettings() {

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -118,21 +118,24 @@ class NativeInterface(private val context: Context) : KoinComponent {
     }
 
     @JavascriptInterface
-    fun downloadFile(args: String): Boolean {
-        val title: String
-        val filename: String
-        val url: String
+    fun downloadFiles(args: String): Boolean {
         try {
-            val options = JSONObject(args)
-            title = options.getString("title")
-            filename = options.getString("filename")
-            url = options.getString("url")
+            val files = JSONArray(args)
+
+            repeat(files.length()) { index ->
+                val file = files.getJSONObject(index)
+
+                val title: String = file.getString("title")
+                val filename: String = file.getString("filename")
+                val url: String = file.getString("url")
+
+                emitEvent(ActivityEvent.DownloadFile(Uri.parse(url), title, filename))
+            }
         } catch (e: JSONException) {
             Timber.e("Download failed: %s", e.message)
             return false
         }
 
-        emitEvent(ActivityEvent.DownloadFile(Uri.parse(url), title, filename))
         return true
     }
 


### PR DESCRIPTION
Jellyfin 10.9 will add a new function to the NativeShell: downloadFiles. This is the same as downloadFile but can request multiple files at once.

This PR adds a basic implementation for it, internally it splits the request. In the future we can use  a queue or something to download the files more efficiently.

**Changes**
- Implement downloadFiles in NativeShell
- Add NativeInterface.downloadFiles
- Remove NativeInterface.downloadFile

**Issues**

jellyfin-web pull request: https://github.com/jellyfin/jellyfin-web/pull/4016