### PR TITLE
Set namespace in build.gradle.kts instead of Manifest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,10 +21,10 @@ detekt {
 }
 
 android {
+    namespace = "org.jellyfin.mobile"
     compileSdk = 33
 
     defaultConfig {
-        applicationId = "org.jellyfin.mobile"
         minSdk = 21
         targetSdk = 32
         versionName = project.getVersionName()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.jellyfin.mobile"
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />


### PR DESCRIPTION
Setting the package in AndroidManifest.xml is deprecated.
