### PR TITLE
Added loading indicator when the app is connecting to the server

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
+import org.jellyfin.mobile.databinding.ActivityMainBinding
 import org.jellyfin.mobile.events.ActivityEventHandler
 import org.jellyfin.mobile.player.cast.Chromecast
 import org.jellyfin.mobile.player.cast.IChromecast
@@ -32,6 +33,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : AppCompatActivity() {
     private val activityEventHandler: ActivityEventHandler = get()
+    private lateinit var binding: ActivityMainBinding
     val mainViewModel: MainViewModel by viewModel()
     val chromecast: IChromecast = Chromecast()
     private val permissionRequestHelper: PermissionRequestHelper by inject()
@@ -53,7 +55,8 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         setupKoinFragmentFactory()
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         // Bind player service
         bindService(Intent(this, RemotePlayerService::class.java), serviceConnection, Service.BIND_AUTO_CREATE)
@@ -86,9 +89,7 @@ class MainActivity : AppCompatActivity() {
             mainViewModel.serverState.collect { state ->
                 with(supportFragmentManager) {
                     when (state) {
-                        ServerState.Pending -> {
-                            // TODO add loading indicator
-                        }
+                        is ServerState.Pending -> binding.progressIndicator.show()
                         is ServerState.Unset -> replaceFragment<ConnectFragment>()
                         is ServerState.Available -> {
                             val currentFragment = findFragmentById(R.id.fragment_container)
@@ -101,6 +102,9 @@ class MainActivity : AppCompatActivity() {
                             }
                         }
                     }
+                }
+                if (state != ServerState.Pending) {
+                    binding.progressIndicator.hide()
                 }
             }
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/fragment_container"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:layout="@layout/fragment_connect"
-    tools:viewBindingIgnore="true" />
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <androidx.core.widget.ContentLoadingProgressBar
+        android:id="@+id/progress_indicator"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        android:visibility="visible" />
+
+</FrameLayout>

--- a/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastConnection.java
+++ b/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastConnection.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import timber.log.Timber;
+
 public class ChromecastConnection {
 
     /**
@@ -432,7 +434,11 @@ public class ChromecastConnection {
                 // remove the callback after timeout ms, and notify caller
                 new Handler().postDelayed(() -> {
                     // And stop the scan for routes
-                    getMediaRouter().removeCallback(callback);
+                    try {
+                        getMediaRouter().removeCallback(callback);
+                    } catch (Exception e) {
+                        Timber.w(e);
+                    }
                     // Notify
                     if (onTimeout != null) {
                         onTimeout.run();

--- a/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastConnection.java
+++ b/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastConnection.java
@@ -31,8 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import timber.log.Timber;
-
 public class ChromecastConnection {
 
     /**
@@ -434,11 +432,7 @@ public class ChromecastConnection {
                 // remove the callback after timeout ms, and notify caller
                 new Handler().postDelayed(() -> {
                     // And stop the scan for routes
-                    try {
-                        getMediaRouter().removeCallback(callback);
-                    } catch (Exception e) {
-                        Timber.w(e);
-                    }
+                    getMediaRouter().removeCallback(callback);
                     // Notify
                     if (onTimeout != null) {
                         onTimeout.run();


### PR DESCRIPTION
**Changes**
I have added a loading indicator that will show when the app is connecting to the server so that users aren't left with a black screen. I have used `ContentLoadingProgressBar` which will try to ensure that the loading process is flicker-free. 

**Issues**
Relates #900 

**Demo**
When it takes 5 seconds to connect to the server the progress indicator is visible. 

https://user-images.githubusercontent.com/33973551/204138567-2178eaf3-2d7b-42de-b9d5-baf8e7c0d80d.mp4

When the connection is quick then the progress indicator won't be visible to reduce flicker.

https://user-images.githubusercontent.com/33973551/204138592-6b350727-a136-448d-ba67-113b53234da7.mp4





