### PR TITLE
Fix discouraging external player from playing some videos

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -51,7 +51,7 @@ class ExternalPlayer(
     private val webappFunctionChannel: WebappFunctionChannel by inject()
     private val mediaSourceResolver: MediaSourceResolver by inject()
     private val deviceProfileBuilder: DeviceProfileBuilder by inject()
-    private val externalPlayerProfile: DeviceProfile = deviceProfileBuilder.getExternalPlayerProfile()
+    private val externalPlayerProfile: DeviceProfile = deviceProfileBuilder.getDeviceProfile()
     private val apiClient: ApiClient = get()
     private val videosApi: VideosApi = apiClient.videosApi
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Change the generator for `externalPlayerProfile` in class `ExternalPlayer`, use `deviceProfileBuilder.getDeviceProfile()` instead

**Issues**
#970 