### PR TITLE
Add swipe gesture exclusion size preference

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
@@ -91,6 +91,9 @@ class AppPreferences(context: Context) {
     val exoPlayerAllowSwipeGestures: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES, true)
 
+    val exoPlayerSwipeExclusionSizeVertical: Int
+        get() = sharedPreferences.getInt(Constants.PREF_EXOPLAYER_SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL, 64)
+
     val exoPlayerRememberBrightness: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_REMEMBER_BRIGHTNESS, false)
 

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
@@ -138,7 +138,7 @@ class PlayerGestureHelper(
                 }
 
                 // Check whether swipe was started in excluded region
-                val exclusionSize = playerView.resources.dip(Constants.SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL)
+                val exclusionSize = playerView.resources.dip(appPreferences.exoPlayerSwipeExclusionSizeVertical)
                 if (firstEvent.y < exclusionSize || firstEvent.y > playerView.height - exclusionSize) {
                     return false
                 }

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -18,6 +18,7 @@ import de.Maxr1998.modernpreferences.helpers.defaultOnSelectionChange
 import de.Maxr1998.modernpreferences.helpers.pref
 import de.Maxr1998.modernpreferences.helpers.screen
 import de.Maxr1998.modernpreferences.helpers.singleChoice
+import de.Maxr1998.modernpreferences.helpers.seekBar
 import de.Maxr1998.modernpreferences.preferences.CheckBoxPreference
 import de.Maxr1998.modernpreferences.preferences.choice.SelectionItem
 import org.jellyfin.mobile.R
@@ -37,6 +38,7 @@ class SettingsFragment : Fragment() {
     private val settingsAdapter: PreferencesAdapter by lazy { PreferencesAdapter(buildSettingsScreen()) }
     private lateinit var startLandscapeVideoInLandscapePreference: CheckBoxPreference
     private lateinit var swipeGesturesPreference: CheckBoxPreference
+    private lateinit var swipeExclusionZoneVertical: Preference
     private lateinit var rememberBrightnessPreference: Preference
     private lateinit var backgroundAudioPreference: Preference
     private lateinit var directPlayAssPreference: Preference
@@ -97,6 +99,7 @@ class SettingsFragment : Fragment() {
             defaultOnSelectionChange { selection ->
                 startLandscapeVideoInLandscapePreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 swipeGesturesPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
+                swipeExclusionZoneVertical.enabled = selection == VideoPlayerType.EXO_PLAYER
                 rememberBrightnessPreference.enabled = selection == VideoPlayerType.EXO_PLAYER && swipeGesturesPreference.checked
                 backgroundAudioPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 directPlayAssPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
@@ -113,8 +116,18 @@ class SettingsFragment : Fragment() {
             defaultValue = true
             defaultOnCheckedChange { checked ->
                 rememberBrightnessPreference.enabled = checked
+                swipeExclusionZoneVertical.enabled = checked
             }
         }
+        swipeExclusionZoneVertical = seekBar(Constants.PREF_EXOPLAYER_SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL){
+            titleRes = R.string.pref_exoplayer_swipe_exclusion_size_vertical
+            min = 0
+            default = 64
+            max = 128
+            step = 8
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER && appPreferences.exoPlayerAllowSwipeGestures
+        }
+
         rememberBrightnessPreference = checkBox(Constants.PREF_EXOPLAYER_REMEMBER_BRIGHTNESS) {
             titleRes = R.string.pref_exoplayer_remember_brightness
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER && appPreferences.exoPlayerAllowSwipeGestures

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -35,6 +35,7 @@ object Constants {
     const val PREF_VIDEO_PLAYER_TYPE = "pref_video_player_type"
     const val PREF_EXOPLAYER_START_LANDSCAPE_VIDEO_IN_LANDSCAPE = "pref_exoplayer_start_landscape_video_in_landscape"
     const val PREF_EXOPLAYER_ALLOW_SWIPE_GESTURES = "pref_exoplayer_allow_swipe_gestures"
+    const val PREF_EXOPLAYER_SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL = "pref_exoplayer_swipe_exclusion_size_vertical"
     const val PREF_EXOPLAYER_REMEMBER_BRIGHTNESS = "pref_exoplayer_remember_brightness"
     const val PREF_EXOPLAYER_BRIGHTNESS = "pref_exoplayer_brightness"
     const val PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO = "pref_exoplayer_allow_background_audio"
@@ -101,7 +102,6 @@ object Constants {
     const val TICKS_PER_MILLISECOND = 10000
     const val PLAYER_TIME_UPDATE_RATE = 10000L
     const val DEFAULT_CONTROLS_TIMEOUT_MS = 2500
-    const val SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL = 64
     const val DEFAULT_CENTER_OVERLAY_TIMEOUT_MS = 250
     const val DISPLAY_PREFERENCES_ID_USER_SETTINGS = "usersettings"
     const val DISPLAY_PREFERENCES_CLIENT_EMBY = "emby"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="pref_exoplayer_start_landscape_video_in_landscape">Start landscape mode videos in landscape orientation</string>
     <string name="pref_exoplayer_allow_brightness_volume_gesture">Brightness and volume gestures</string>
     <string name="pref_exoplayer_remember_brightness">Remember display brightness</string>
+    <string name="pref_exoplayer_swipe_exclusion_size_vertical">Gesture dead zone</string>
     <string name="pref_exoplayer_allow_background_audio">Background audio</string>
     <string name="pref_exoplayer_allow_background_audio_summary">Allow playing videos in the background with audio-only</string>
     <string name="pref_exoplayer_direct_play_ass">Allow SSA/ASS subtitles in direct play</string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Adds preference to modify the existing `SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL` constant, allowing the user to configure the size of the vertical exclusion zone when using ExoPlayer. Also implemented the necessary conditionals to enable / disable this setting based on other relevant settings. Retains the current default value of `64`, allows for a range between 0-128.

_NOTE:_ `SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL` was changed to `PREF_EXOPLAYER_SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL` to better conform with existing conventions - let me know if a different name is desired.

<img src="https://user-images.githubusercontent.com/35984346/226373040-c5e44467-a32a-4f49-a563-e2fec3962c02.png" width="300"/>

<img src="https://user-images.githubusercontent.com/35984346/226373093-6366ddf4-33a7-4810-9b31-10ce9e58d64f.png" width="300"/>

<img src="https://user-images.githubusercontent.com/35984346/226373116-7b999f61-88e8-44f2-91cf-6bde37b2557d.png" width="300"/>



**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Implements #994 
