### PR TITLE
Add default changelog to fastlane

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,0 +1,3 @@
+Thank you for using Jellyfin for Android! Using the latest released Jellyfin Server is always recommended.
+
+For more information, please see our blog at jellyfin.org, or read the full changelog on GitHub.


### PR DESCRIPTION
**Changes**
- Add default changelog to fastlane
  It's copied from the ATV repo (https://github.com/jellyfin/jellyfin-androidtv/blob/master/fastlane/metadata/android/en-US/changelogs/default.txt) with a small change for the name.
  The changelog is shown by F-Droid like here https://f-droid.org/en/packages/org.jellyfin.androidtv/

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
