### PR TITLE
Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,6 @@ org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=512m
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Allow using snapshot releases of Jellyfin SDK. Possible values are:


### PR DESCRIPTION
We don't have any dependencies requiring it anymore, so it can be disabled.

If we want to be on the safe side, we could also leave this open until 2.5.0 is released, just doing a PR so that I don't forget.