### PR TITLE
Disable line breaks after multiline when entries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,7 @@ trim_trailing_whitespace = true
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_line_break_after_multiline_when_entry = false
 ij_kotlin_name_count_to_use_star_import = 999
 ij_kotlin_name_count_to_use_star_import_for_members = 999
 ij_kotlin_packages_to_use_import_on_demand =


### PR DESCRIPTION
This was the default before, and has to be explicitly disabled since Android Studio 2022.2.
