### PR TITLE
Update Jellyfin SDK (1.4.2) and Exoplayer (2.18.6)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ compose-material = "1.3.1"
 compose-compiler = "1.3.2"
 
 # Network
-jellyfin-sdk = "1.4.1"
+jellyfin-sdk = "1.4.2"
 okhttp = "4.10.0"
 coil = "2.2.2"
 cronet-embedded = "108.5359.79"
@@ -44,8 +44,8 @@ cronet-embedded = "108.5359.79"
 # Media
 androidx-media = "1.6.0"
 androidx-mediarouter = "1.3.1"
-exoplayer = "2.18.5"
-jellyfin-exoplayer-ffmpegextension = "2.18.2+1"
+exoplayer = "2.18.6"
+jellyfin-exoplayer-ffmpegextension = "2.18.6+1"
 playservices = "21.2.0"
 
 # Room


### PR DESCRIPTION
Because Renovate is at it's 10 PR limit

**Changes**
- Update Jellyfin SDK to 1.4.2
- Update Exoplayer to 2.18.6 (including our ffmpeg extension)

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
