### PR TITLE
Rewrite queue management and play options handling

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/TrackSelectionHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/TrackSelectionHelper.kt
@@ -40,7 +40,7 @@ class TrackSelectionHelper(
 
         // For transcoding and external streams, we need to restart playback
         if (mediaSource.playMethod == PlayMethod.TRANSCODE || selectedMediaStream.isExternal) {
-            return viewModel.mediaQueueManager.selectAudioStreamAndRestartPlayback(selectedMediaStream)
+            return viewModel.queueManager.selectAudioStreamAndRestartPlayback(selectedMediaStream)
         }
 
         return selectPlayerAudioTrack(mediaSource, selectedMediaStream, initial = false).also { success ->
@@ -95,7 +95,7 @@ class TrackSelectionHelper(
             selectedMediaStream?.deliveryMethod == SubtitleDeliveryMethod.ENCODE ||
             mediaSource.selectedSubtitleStream?.deliveryMethod == SubtitleDeliveryMethod.ENCODE
         ) {
-            return viewModel.mediaQueueManager.selectSubtitleStreamAndRestartPlayback(selectedMediaStream)
+            return viewModel.queueManager.selectSubtitleStreamAndRestartPlayback(selectedMediaStream)
         }
 
         return selectSubtitleTrack(mediaSource, selectedMediaStream, initial = false).also { success ->

--- a/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
@@ -50,6 +50,13 @@ class JellyfinMediaSource(
     var selectedSubtitleStream: MediaStream? = null
         private set
 
+    val selectedAudioStreamIndex: Int?
+        get() = selectedAudioStream?.index
+    val selectedSubtitleStreamIndex: Int
+        // -1 disables subtitles, null would select the default subtitle
+        // If the default should be played, it would be explicitly set above
+        get() = selectedSubtitleStream?.index ?: -1
+
     init {
         // Classify MediaStreams
         val audio = ArrayList<MediaStream>()

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -101,10 +101,8 @@ class PlayerFragment : Fragment() {
             val safeMessage = message.ifEmpty { requireContext().getString(R.string.player_error_unspecific_exception) }
             requireContext().toast(safeMessage)
         }
-        viewModel.mediaQueueManager.mediaQueue.observe(this) { queueItem ->
-            val jellyfinMediaSource = queueItem.jellyfinMediaSource
-
-            if (jellyfinMediaSource.selectedVideoStream?.isLandscape == false) {
+        viewModel.queueManager.currentMediaSource.observe(this) { mediaSource ->
+            if (mediaSource.selectedVideoStream?.isLandscape == false) {
                 // For portrait videos, immediately enable fullscreen
                 playerFullscreenHelper.enableFullscreen()
             } else if (appPreferences.exoPlayerStartLandscapeVideoInLandscape) {
@@ -113,8 +111,8 @@ class PlayerFragment : Fragment() {
             }
 
             // Update title and player menus
-            toolbar.title = jellyfinMediaSource.name
-            playerMenus?.onQueueItemChanged(queueItem)
+            toolbar.title = mediaSource.name
+            playerMenus?.onQueueItemChanged(mediaSource, viewModel.queueManager.hasNext())
         }
 
         // Handle fragment arguments, extract playback options and start playback
@@ -125,7 +123,7 @@ class PlayerFragment : Fragment() {
                 context.toast(R.string.player_error_invalid_play_options)
                 return@launch
             }
-            when (viewModel.mediaQueueManager.startPlayback(playOptions, playWhenReady = true)) {
+            when (viewModel.queueManager.initializePlaybackQueue(playOptions)) {
                 is PlayerException.InvalidPlayOptions -> context.toast(R.string.player_error_invalid_play_options)
                 is PlayerException.NetworkFailure -> context.toast(R.string.player_error_network_failure)
                 is PlayerException.UnsupportedContent -> context.toast(R.string.player_error_unsupported_content)

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
@@ -15,7 +15,7 @@ import org.jellyfin.mobile.R
 import org.jellyfin.mobile.databinding.ExoPlayerControlViewBinding
 import org.jellyfin.mobile.databinding.FragmentPlayerBinding
 import org.jellyfin.mobile.player.qualityoptions.QualityOptionsProvider
-import org.jellyfin.mobile.player.queue.QueueManager
+import org.jellyfin.mobile.player.source.JellyfinMediaSource
 import org.jellyfin.sdk.model.api.MediaStream
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -101,10 +101,9 @@ class PlayerMenus(
         }
     }
 
-    fun onQueueItemChanged(queueItem: QueueManager.QueueItem.Loaded) {
-        nextButton.isEnabled = queueItem.hasNext()
-
-        val mediaSource = queueItem.jellyfinMediaSource
+    fun onQueueItemChanged(mediaSource: JellyfinMediaSource, hasNext: Boolean) {
+        // previousButton is always enabled and will rewind if at the start of the queue
+        nextButton.isEnabled = hasNext
 
         val videoStream = mediaSource.selectedVideoStream
 


### PR DESCRIPTION
Caching media sources in the queue was unnecessary and overly complex, and could cause issues if playback options changed in between (i.e. a new bitrate). Additionally, there was some duplication between the cached play options and the current media source, which caused more confusion and issues.