### PR TITLE
Disable Google Safe Browsing Service in webviews

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,5 +83,8 @@
         <meta-data
             android:name="com.google.android.gms.car.notification.SmallIcon"
             android:resource="@mipmap/ic_launcher_round" />
+        <meta-data
+            android:name="android.webkit.WebView.EnableSafeBrowsing"
+            android:value="false" />
     </application>
 </manifest>


### PR DESCRIPTION
See:
- https://developer.android.com/develop/ui/views/layout/webapps/managing-webview#safe-browsing
- https://chromium.googlesource.com/chromium/src.git/+/master/android_webview/browser/safe_browsing/README.md

**Changes**

Unfortunately Google is marking the Jellyfin instances of some users as phishing. This breaks the Android app. Fortunately we can disable this tracking service using the Android manifest.

**Issues**

https://github.com/jellyfin/jellyfin-web/issues/4076