### PR TITLE
Add pgssub to ExoPlayer subtitle codecs

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -319,11 +319,11 @@ class DeviceProfileBuilder(
          */
         private val FORCED_AUDIO_CODECS = arrayOf(*PCM_CODECS, "alac", "aac", "ac3", "eac3", "dts", "mlp", "truehd")
 
-        private val EXO_EMBEDDED_SUBTITLES = arrayOf("srt", "subrip", "ttml")
+        private val EXO_EMBEDDED_SUBTITLES = arrayOf("pgssub", "srt", "subrip", "ttml")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")
         private val SUBTITLES_SSA = arrayOf("ssa", "ass")
         private val EXTERNAL_PLAYER_SUBTITLES = arrayOf(
-            "ssa", "ass", "srt", "subrip", "idx", "sub", "vtt", "webvtt", "ttml", "pgs", "pgssub", "smi", "smil",
+            "ass", "idx", "pgssub", "smi", "smil", "srt", "ssa", "sub", "subrip", "ttml", "vtt", "webvtt",
         )
 
         /**


### PR DESCRIPTION
ExoPlayer supports decoding embedded pgssub subtitles, so they should be enabled.

Tested locally and confirmed working.
I also removed the likely invalid `pgs` specification from the external player profile, since ffprobe lists pgs subtitles as `pgssub`.