### PR TITLE
Only play fullscreen video in ExoPlayer

### DIFF
--- a/app/src/main/assets/native/ExoPlayerPlugin.js
+++ b/app/src/main/assets/native/ExoPlayerPlugin.js
@@ -48,7 +48,7 @@ export class ExoPlayerPlugin {
     }
 
     canPlayItem(item, playOptions) {
-        return this._nativePlayer.isEnabled();
+        return this._nativePlayer.isEnabled() && playOptions.fullscreen;
     }
 
     async stop(destroyPlayer) {


### PR DESCRIPTION
**Changes**
This resolves a problem where non-fullscreen media like theme videos would be played in ExoPlayer, instead of playing as a backdrop in the web interface.

**Issues**
Fixes #706.