### PR TITLE
Add workaround for non reproducible baseline profiles in AGP to libre builds

### DIFF
--- a/app/baselineWorkaround.gradle
+++ b/app/baselineWorkaround.gradle
@@ -1,0 +1,39 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        google()
+    }
+
+    dependencies {
+        classpath libs.android.gradle
+    }
+}
+
+import com.android.tools.profgen.ArtProfileKt
+import com.android.tools.profgen.ArtProfileSerializer
+import com.android.tools.profgen.DexFile
+
+/**
+ * This is a temporary workaround for https://issuetracker.google.com/issues/231837768
+ * which will be fixed in AGP 8.1.0, at which point the workaround may be deleted.
+ */
+project.afterEvaluate {
+    tasks.compileLibreReleaseArtProfile.doLast {
+        outputs.files.each { file ->
+            if (file.toString().endsWith(".profm")) {
+                println("Sorting ${file}")
+                def version = ArtProfileSerializer.valueOf("METADATA_0_0_2")
+                def profile = ArtProfileKt.ArtProfile(file)
+                def keys = new ArrayList(profile.profileData.keySet())
+                def sortedData = new LinkedHashMap()
+                Collections.sort keys, new DexFile.Companion()
+                keys.each { key -> sortedData[key] = profile.profileData[key] }
+                new FileOutputStream(file).with {
+                    write(version.magicBytes$profgen)
+                    write(version.versionBytes$profgen)
+                    version.write$profgen(it, sortedData, "")
+                }
+            }
+        }
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,9 @@ plugins {
     alias(libs.plugins.dependencyupdates)
 }
 
+// Apply workaround
+apply("baselineWorkaround.gradle")
+
 detekt {
     buildUponDefaultConfig = true
     allRules = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutin
 # Core
 koin = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin-compose" }
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-plugin" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidx-core-splashscreen" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }


### PR DESCRIPTION


**Changes**
- Add workaround for non reproducible baseline profiles in AGP to libre builds
  - This workaround must be written in Groovy because it uses internal classes/functions which the Kotlin compiler guards against

Additional context: https://github.com/jellyfin/jellyfin-androidtv/pull/2558, https://github.com/jellyfin/jellyfin-androidtv/issues/1639

**Issues**

Fixes #414
