### PR TITLE
Only play fullscreen video in external player

### DIFF
--- a/app/src/main/assets/native/ExternalPlayerPlugin.js
+++ b/app/src/main/assets/native/ExternalPlayerPlugin.js
@@ -34,7 +34,7 @@ export class ExternalPlayerPlugin {
     }
 
     canPlayItem(item, playOptions) {
-        return this._externalPlayer.isEnabled();
+        return this._externalPlayer.isEnabled() && playOptions.fullscreen;
     }
 
     currentSrc() {


### PR DESCRIPTION
**Changes**
Same as #1059 but for the external player.

> This resolves a problem where non-fullscreen media like theme videos would be played in ExoPlayer, instead of playing as a backdrop in the web interface.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
