### PR TITLE
Fix bitrate not set for external player profile

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -101,6 +101,7 @@ class ExternalPlayer(
                 startTimeTicks = playOptions.startPositionTicks,
                 audioStreamIndex = playOptions.audioStreamIndex,
                 subtitleStreamIndex = playOptions.subtitleStreamIndex,
+                maxStreamingBitrate = playOptions.maxBitrate,
             ).onSuccess { jellyfinMediaSource ->
                 playMediaSource(playOptions, jellyfinMediaSource)
             }.onFailure { error ->

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -203,6 +203,7 @@ class DeviceProfileBuilder(
         containerProfiles = emptyList(),
         codecProfiles = emptyList(),
         subtitleProfiles = getSubtitleProfiles(EXTERNAL_PLAYER_SUBTITLES, EXTERNAL_PLAYER_SUBTITLES),
+        maxStreamingBitrate = MAX_STREAMING_BITRATE,
 
         // TODO: remove redundant defaults after API/SDK is fixed
         timelineOffsetSeconds = 0,


### PR DESCRIPTION
When the bitrate is set to null the app will be unable to find a media source to play. The max bitrate was removed by accident when bitrate selection was added to the internal player.

**Changes**
- Fix bitrate not set for external player profile

**Issues**

Fixes #1046