### PR TITLE
Disable ExoPlayer and External player while in SyncPlay

### DIFF
--- a/app/src/main/assets/native/ExoPlayerPlugin.js
+++ b/app/src/main/assets/native/ExoPlayerPlugin.js
@@ -48,7 +48,9 @@ export class ExoPlayerPlugin {
     }
 
     canPlayItem(item, playOptions) {
-        return this._nativePlayer.isEnabled() && playOptions.fullscreen;
+        return this._nativePlayer.isEnabled() &&
+            playOptions.fullscreen &&
+            !this.playbackManager.syncPlayEnabled;
     }
 
     async stop(destroyPlayer) {

--- a/app/src/main/assets/native/ExternalPlayerPlugin.js
+++ b/app/src/main/assets/native/ExternalPlayerPlugin.js
@@ -34,7 +34,9 @@ export class ExternalPlayerPlugin {
     }
 
     canPlayItem(item, playOptions) {
-        return this._externalPlayer.isEnabled() && playOptions.fullscreen;
+        return this._externalPlayer.isEnabled() &&
+            playOptions.fullscreen &&
+            !this.playbackManager.syncPlayEnabled;
     }
 
     currentSrc() {


### PR DESCRIPTION
Because neither player currently supports SyncPlay, detecting a running session and falling back to the web player makes a lot of sense.