### PR TITLE
Add dvbsub to ExoPlayer subtitle codecs

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -320,7 +320,7 @@ class DeviceProfileBuilder(
          */
         private val FORCED_AUDIO_CODECS = arrayOf(*PCM_CODECS, "alac", "aac", "ac3", "eac3", "dts", "mlp", "truehd")
 
-        private val EXO_EMBEDDED_SUBTITLES = arrayOf("pgssub", "srt", "subrip", "ttml")
+        private val EXO_EMBEDDED_SUBTITLES = arrayOf("dvbsub", "pgssub", "srt", "subrip", "ttml")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")
         private val SUBTITLES_SSA = arrayOf("ssa", "ass")
         private val EXTERNAL_PLAYER_SUBTITLES = arrayOf(


### PR DESCRIPTION
Add support for dvb_subtitles to ExoPlayer. Tested with Movistar IPTV streams.
