### PR TITLE
Fix VLC external player crashing on Android 13

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -334,7 +334,7 @@ class ExternalPlayer(
                 ComponentName(packageName, "$packageName.ActivityScreen")
             }
             ExternalPlayerPackage.VLC_PLAYER -> {
-                ComponentName(packageName, "$packageName.gui.video.VideoPlayerActivity")
+                ComponentName(packageName, "$packageName.StartActivity")
             }
             else -> null
         }


### PR DESCRIPTION
**Changes**
Due to security-related changes in Android 13, the entrypoint must be the default start activity.

This requires https://code.videolan.org/videolan/vlc-android/-/merge_requests/1738 to be merged and released for playback tracking to work again.

**Issues**
Fixes #912