### PR TITLE
Remove dependency updates plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-import com.github.benmanes.gradle.versions.updates.gradle.GradleReleaseChannel
 import io.gitlab.arturbosch.detekt.Detekt
 
 plugins {
@@ -9,7 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.detekt)
     alias(libs.plugins.android.junit5)
-    alias(libs.plugins.dependencyupdates)
 }
 
 // Apply workaround
@@ -200,24 +197,6 @@ tasks {
         testLogging {
             outputs.upToDateWhen { false }
             showStandardStreams = true
-        }
-    }
-
-    // Configure dependency updates task
-    withType<DependencyUpdatesTask> {
-        gradleReleaseChannel = GradleReleaseChannel.CURRENT.id
-        rejectVersionIf {
-            val currentType = classifyVersion(currentVersion)
-            val candidateType = classifyVersion(candidate.version)
-
-            when (candidateType) {
-                // Always accept stable updates
-                VersionType.STABLE -> true
-                // Accept milestone updates for current milestone and unstable
-                VersionType.MILESTONE -> currentType != VersionType.STABLE
-                // Only accept unstable for current unstable
-                VersionType.UNSTABLE -> currentType == VersionType.UNSTABLE
-            }.not()
         }
     }
 

--- a/buildSrc/src/main/kotlin/VersionUtils.kt
+++ b/buildSrc/src/main/kotlin/VersionUtils.kt
@@ -67,18 +67,3 @@ fun getVersionCode(versionName: String): Int {
 
     return code
 }
-
-enum class VersionType {
-    STABLE, MILESTONE, UNSTABLE
-}
-
-fun classifyVersion(version: String): VersionType {
-    val normalizedVersion = version.toLowerCase(Locale.ROOT)
-    return when {
-        normalizedVersion.containsAny(listOf("alpha", "beta", "dev")) -> VersionType.UNSTABLE
-        normalizedVersion.containsAny(listOf("rc", "m")) -> VersionType.MILESTONE
-        else -> VersionType.STABLE
-    }
-}
-
-fun String.containsAny(strings: Iterable<String>): Boolean = strings.any { contains(it) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ kotlin = "1.7.20"
 kotlin-ksp = "1.7.20-1.0.8"
 detekt = "1.22.0"
 android-junit5 = "1.9.3.0"
-dependencyupdates = "0.46.0"
 
 # KotlinX
 coroutines = "1.6.4"
@@ -70,7 +69,6 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
 android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android-junit5" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-dependencyupdates = { id = "com.github.ben-manes.versions", version.ref = "dependencyupdates" }
 
 [libraries]
 # KotlinX


### PR DESCRIPTION
Not necessary anymore after exclusively using renovate.