### PR TITLE
A convenient solution for implementing exoplayer rate control.  Step 1/2

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -1,5 +1,7 @@
 package org.jellyfin.mobile.player
 
+import java.io.File
+import android.content.Context 
 import android.annotation.SuppressLint
 import android.app.Application
 import android.media.AudioAttributes
@@ -442,6 +444,9 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
     }
 
     suspend fun changeBitrate(bitrate: Int?): Boolean {
+        val context: Context = get()
+        val cfgFile = File(context.filesDir,"jellyexoplayer.rate")
+        cfgFile.writeText(bitrate.toString())
         return queueManager.changeBitrate(bitrate)
     }
 


### PR DESCRIPTION
Add rate limiting variables to exoplayer.
Step 1/2

Provide a temporary solution before the developer provides exoplayer rate control.


**Changes**
Store bitrate parameters. 


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
