### PR TITLE
Fix issue #544. JF drops to connect screen

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
@@ -96,8 +96,8 @@ abstract class JellyfinWebViewClient(
 
         // Abort on some specific error codes or when the request url matches the server url
         when (errorCode) {
-            ERROR_HOST_LOOKUP,
-            ERROR_CONNECT,
+            //ERROR_HOST_LOOKUP,
+            //ERROR_CONNECT,
             ERROR_TIMEOUT,
             ERROR_REDIRECT_LOOP,
             ERROR_UNSUPPORTED_SCHEME,


### PR DESCRIPTION
Fixes issue #544. Without this fix, any slight interruption in network connectivity, even for a second or 2 causes the UI to return to the Jellyfin Instance URL screen.

This has been tested and shown to prevent the issue from happening.