### PR TITLE
ExoPlayer: Only allow hardware-accelerated video codecs in DirectPlay

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -1,6 +1,9 @@
 package org.jellyfin.mobile.player.deviceprofile
 
 import android.media.MediaCodecList
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.google.android.exoplayer2.util.MimeTypes
 import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.bridge.ExternalPlayer
 import org.jellyfin.mobile.utils.Constants
@@ -14,6 +17,7 @@ import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.api.SubtitleProfile
 import org.jellyfin.sdk.model.api.TranscodeSeekInfo
 import org.jellyfin.sdk.model.api.TranscodingProfile
+
 
 class DeviceProfileBuilder(
     private val appPreferences: AppPreferences,
@@ -130,6 +134,17 @@ class DeviceProfileBuilder(
         )
     }
 
+    @RequiresApi(Build.VERSION_CODES.Q)
+    fun canHardwareDecode(codec: String): Boolean {
+        var parsedCodec = codec
+        if (parsedCodec == "av1") parsedCodec = "av01"
+        val mimeType = MimeTypes.getMediaMimeType(parsedCodec) ?: return false
+        val hardwareCodec = MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
+            .filter { it.isHardwareAccelerated }
+            .find { it.supportedTypes.contains(mimeType) }
+        return hardwareCodec != null
+    }
+
     fun getDeviceProfile(): DeviceProfile {
         val containerProfiles = ArrayList<ContainerProfile>()
         val directPlayProfiles = ArrayList<DirectPlayProfile>()
@@ -137,13 +152,20 @@ class DeviceProfileBuilder(
 
         for (i in SUPPORTED_CONTAINER_FORMATS.indices) {
             val container = SUPPORTED_CONTAINER_FORMATS[i]
-            if (supportedVideoCodecs[i].isNotEmpty()) {
+            val filteredVideoCodecs = supportedVideoCodecs[i].filter {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    canHardwareDecode(it)
+                } else {
+                    true
+                }
+            }
+            if (filteredVideoCodecs.isNotEmpty()) {
                 containerProfiles.add(ContainerProfile(type = DlnaProfileType.VIDEO, container = container))
                 directPlayProfiles.add(
                     DirectPlayProfile(
                         type = DlnaProfileType.VIDEO,
                         container = SUPPORTED_CONTAINER_FORMATS[i],
-                        videoCodec = supportedVideoCodecs[i].joinToString(","),
+                        videoCodec = filteredVideoCodecs.joinToString(","),
                         audioCodec = supportedAudioCodecs[i].joinToString(","),
                     ),
                 )


### PR DESCRIPTION
*(everything here relates to ExoPlayer and the experience of selecting "`Integrated player`" in the client settings)*

### background
When streaming video, ExoPlayer automatically chooses software decoding if there is no hardware decoder available.
However, depending on the codec this may result in an unpleasant experience.
In my case, streaming `AV1` on the device [`gts4lv`](https://wiki.lineageos.org/devices/gts4lv/) resulted in significant stutter when the picture was moving quickly.

Currently there exists an toggle in the player to change between hardware and software encoding.
Software decoding always works (i assume), however hardware encoding will result in an black image if the hardware doesnt support decoding this codec.

### best possible solution
The best situation (in my opinion) would be, that video is transcoded by default if the hardware doesn't support it (especially on android, where the device is usually run on battery).
So when choosing software decoding, DirectPlay is fine, but when choosing hardware decoding, transcoding should automatically be applied if the hardware doesn't support this codec.

### current solution
Sadly due to limited experience with kotlin and the situation I were not able to implement exactly as I would like it to.
This solution here just filters out all codecs from DirectPlay which can't be hardware decoded.

In my situation this forced encoding of `AV1` video and results in a smooth playback experience.

This solution does also prevent direct-streaming the `AV1` stream completely,
but I do think that this should generally lead to a better user experience overall.

### code explaination
I do know this solution might not be the best.
The ExoPlayer API seems to give hardware decoder feedback based on MIME-Types.
The function `MimeTypes.getMediaMimeType(String)` can only interpret `av01` but not `av1`, hence the extra additional rewrite of `av1` to `av01`.
The rest of the codecs seem to be fine, I had some logging in there and it did detect hardware decoding support for `vp8` and `vp9` correctly. (i think also `h264` and `h265` if i remember correctly)
But there definitely is a better solution for this container list to MIME-Type conversion.


<!-- **Issues** -->
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
