### PR TITLE
Fix app returning to WebViewFragment when activity restarts

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -15,9 +15,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.withStarted
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.jellyfin.mobile.events.ActivityEventHandler
 import org.jellyfin.mobile.player.cast.Chromecast
@@ -123,8 +123,8 @@ class MainActivity : AppCompatActivity() {
 
         // Load UI
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                mainViewModel.serverState.collect { state ->
+            mainViewModel.serverState.collectLatest { state ->
+                lifecycle.withStarted {
                     handleServerState(state)
                 }
             }


### PR DESCRIPTION
`repeatOnLifecycle(Lifecycle.State.STARTED)` caused the flow collection to be restarted after the activity was stopped and then started again (for example, when opening another activity on top and then going back). However, this triggered `handleServerState` with the current state again, which unintentionally replaced the current fragment (for example the player or settings) with the WebViewFragment. The solution is to permanently collect the latest server state, but delay its application to the lifecycle start of the activity.