### PR TITLE
Ensure ExternalPlayer always direct plays

### DIFF
--- a/app/src/main/assets/native/ExternalPlayerPlugin.js
+++ b/app/src/main/assets/native/ExternalPlayerPlugin.js
@@ -141,12 +141,11 @@ export class ExternalPlayerPlugin {
     async getDeviceProfile() {
         return {
             Name: 'Android External Player Stub',
-            MaxStreamingBitrate: 100000000,
-            MaxStaticBitrate: 100000000,
-            MusicStreamingTranscodingBitrate: 320000,
+            MaxStreamingBitrate: 1000000000,
+            MaxStaticBitrate: 1000000000,
             DirectPlayProfiles: [{Type: 'Video'}, {Type: 'Audio'}],
             CodecProfiles: [],
-            SubtitleProfiles: JSON.parse(this._externalPlayer.getSubtitleProfiles()),
+            SubtitleProfiles: [{Method: 'Embed'}, {Method: 'Drop'}],
             TranscodingProfiles: []
         };
     }

--- a/app/src/main/assets/native/ExternalPlayerPlugin.js
+++ b/app/src/main/assets/native/ExternalPlayerPlugin.js
@@ -141,8 +141,8 @@ export class ExternalPlayerPlugin {
     async getDeviceProfile() {
         return {
             Name: 'Android External Player Stub',
-            MaxStreamingBitrate: 1000000000,
-            MaxStaticBitrate: 1000000000,
+            MaxStreamingBitrate: 1_000_000_000,
+            MaxStaticBitrate: 1_000_000_000,
             DirectPlayProfiles: [{Type: 'Video'}, {Type: 'Audio'}],
             CodecProfiles: [],
             SubtitleProfiles: [{Method: 'Embed'}, {Method: 'Drop'}],

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -102,7 +102,7 @@ class ExternalPlayer(
                 startTimeTicks = playOptions.startPositionTicks,
                 audioStreamIndex = playOptions.audioStreamIndex,
                 subtitleStreamIndex = playOptions.subtitleStreamIndex,
-                maxStreamingBitrate = playOptions.maxBitrate,
+                maxStreamingBitrate = null,
             ).onSuccess { jellyfinMediaSource ->
                 playMediaSource(playOptions, jellyfinMediaSource)
             }.onFailure { error ->

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -167,8 +167,7 @@ class ExternalPlayer(
     }
 
     private fun notifyEvent(event: String, parameters: String = "") {
-        val allowedEvents = arrayOf(Constants.EVENT_CANCELED, Constants.EVENT_ENDED, Constants.EVENT_TIME_UPDATE)
-        if (event in allowedEvents && parameters.isDigitsOnly()) {
+        if (event in ALLOWED_EVENTS && parameters.isDigitsOnly()) {
             webappFunctionChannel.call("window.ExtPlayer.notify$event($parameters)")
         }
     }
@@ -301,5 +300,13 @@ class ExternalPlayer(
             }
             else -> null
         }
+    }
+
+    companion object {
+        private val ALLOWED_EVENTS = arrayOf(
+            Constants.EVENT_CANCELED,
+            Constants.EVENT_ENDED,
+            Constants.EVENT_TIME_UPDATE,
+        )
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -9,6 +9,7 @@ import android.webkit.JavascriptInterface
 import android.widget.Toast
 import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -205,7 +206,8 @@ class ExternalPlayer(
     }
 
     private fun notifyEvent(event: String, parameters: String = "") {
-        if (event in arrayOf(Constants.EVENT_CANCELED, Constants.EVENT_ENDED, Constants.EVENT_TIME_UPDATE) && parameters == parameters.filter { it.isDigit() }) {
+        val allowedEvents = arrayOf(Constants.EVENT_CANCELED, Constants.EVENT_ENDED, Constants.EVENT_TIME_UPDATE)
+        if (event in allowedEvents && parameters.isDigitsOnly()) {
             webappFunctionChannel.call("window.ExtPlayer.notify$event($parameters)")
         }
     }

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -2,7 +2,6 @@ package org.jellyfin.mobile.player.deviceprofile
 
 import android.media.MediaCodecList
 import org.jellyfin.mobile.app.AppPreferences
-import org.jellyfin.mobile.bridge.ExternalPlayer
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.api.CodecProfile
 import org.jellyfin.sdk.model.api.ContainerProfile
@@ -150,24 +149,6 @@ class DeviceProfileBuilder(
         )
     }
 
-    fun getExternalPlayerProfile(): DeviceProfile = DeviceProfile(
-        name = ExternalPlayer.DEVICE_PROFILE_NAME,
-        directPlayProfiles = listOf(
-            DirectPlayProfile(type = DlnaProfileType.VIDEO),
-            DirectPlayProfile(type = DlnaProfileType.AUDIO),
-        ),
-        transcodingProfiles = emptyList(),
-        containerProfiles = emptyList(),
-        codecProfiles = emptyList(),
-        subtitleProfiles = getSubtitleProfiles(EXTERNAL_PLAYER_SUBTITLES, EXTERNAL_PLAYER_SUBTITLES),
-        maxStreamingBitrate = MAX_STREAMING_BITRATE,
-
-        // TODO: remove redundant defaults after API/SDK is fixed
-        supportedMediaTypes = "",
-        xmlRootAttributes = emptyList(),
-        responseProfiles = emptyList(),
-    )
-
     private fun getSubtitleProfiles(embedded: Array<String>, external: Array<String>): List<SubtitleProfile> = ArrayList<SubtitleProfile>().apply {
         for (format in embedded) {
             add(SubtitleProfile(format = format, method = SubtitleDeliveryMethod.EMBED))
@@ -272,9 +253,6 @@ class DeviceProfileBuilder(
         private val EXO_EMBEDDED_SUBTITLES = arrayOf("dvbsub", "pgssub", "srt", "subrip", "ttml")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")
         private val SUBTITLES_SSA = arrayOf("ssa", "ass")
-        private val EXTERNAL_PLAYER_SUBTITLES = arrayOf(
-            "ass", "idx", "pgssub", "smi", "smil", "srt", "ssa", "sub", "subrip", "ttml", "vtt", "webvtt",
-        )
 
         /**
          * Taken from Jellyfin Web:

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
@@ -17,7 +17,6 @@ data class PlayOptions(
     val startPositionTicks: Long?,
     val audioStreamIndex: Int?,
     val subtitleStreamIndex: Int?,
-    val maxBitrate: Int?,
 ) : Parcelable {
     companion object {
         fun fromJson(json: JSONObject): PlayOptions? = try {
@@ -34,7 +33,6 @@ data class PlayOptions(
                 startPositionTicks = json.optLong("startPositionTicks").takeIf { it > 0 },
                 audioStreamIndex = json.optString("audioStreamIndex").toIntOrNull(),
                 subtitleStreamIndex = json.optString("subtitleStreamIndex").toIntOrNull(),
-                maxBitrate = null,
             )
         } catch (e: JSONException) {
             Timber.e(e, "Failed to parse playback options: %s", json)

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -68,7 +68,7 @@ class QueueManager(
         startPlayback(
             itemId = itemId,
             mediaSourceId = playOptions.mediaSourceId,
-            maxStreamingBitrate = playOptions.maxBitrate,
+            maxStreamingBitrate = null,
             startTimeTicks = playOptions.startPositionTicks,
             audioStreamIndex = playOptions.audioStreamIndex,
             subtitleStreamIndex = playOptions.subtitleStreamIndex,

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -21,11 +21,12 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
     suspend fun resolveMediaSource(
         itemId: UUID,
         mediaSourceId: String? = null,
-        deviceProfile: DeviceProfile,
+        deviceProfile: DeviceProfile? = null,
         maxStreamingBitrate: Int? = null,
         startTimeTicks: Long? = null,
         audioStreamIndex: Int? = null,
         subtitleStreamIndex: Int? = null,
+        autoOpenLiveStream: Boolean = true,
     ): Result<JellyfinMediaSource> {
         // Load media source info
         val playSessionId: String
@@ -39,11 +40,11 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
                     // https://github.com/jellyfin/jellyfin/blob/9a35fd673203cfaf0098138b2768750f4818b3ab/Jellyfin.Api/Helpers/MediaInfoHelper.cs#L196-L201
                     mediaSourceId = mediaSourceId ?: itemId.toString().replace("-", ""),
                     deviceProfile = deviceProfile,
-                    maxStreamingBitrate = maxStreamingBitrate ?: deviceProfile.maxStreamingBitrate,
+                    maxStreamingBitrate = maxStreamingBitrate,
                     startTimeTicks = startTimeTicks,
                     audioStreamIndex = audioStreamIndex,
                     subtitleStreamIndex = subtitleStreamIndex,
-                    autoOpenLiveStream = true,
+                    autoOpenLiveStream = autoOpenLiveStream,
                 ),
             )
 


### PR DESCRIPTION
Instead of using a device profile like for ExoPlayer, we always build the direct stream URL, and at the same time tweak the media source request so that it never suggests transcoding. We do that by supplying an effectively unlimited maximum bit rate, which was previously hard-coded to 120 Mbps through the device profile.

Fixes #970.