### PR TITLE
Prevent keyboard (dis)connection from restarting the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden|uiMode"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden|navigation|uiMode"
             android:exported="true"
             android:launchMode="singleTask"
             android:supportsPictureInPicture="true">


### PR DESCRIPTION
**Changes**
To prevent USB or Bluetooth keyboards from restarting the app when connected/disconnected, we also need to handle the `navigation` configuration change.

**Issues**
Fixes #897.
