### PR TITLE
Improve Android TV compatibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
             <!-- declare legacy support for voice actions -->
             <intent-filter>

--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -12,7 +12,8 @@ const features = [
     "multiserver",
     "physicalvolumecontrol",
     "remotecontrol",
-    "castmenuhashchange"
+    "castmenuhashchange",
+    "displaymode"
 ];
 
 const plugins = [
@@ -175,7 +176,10 @@ window.NativeShell.AppHost = {
         }
     },
     getDefaultLayout() {
-        return "mobile";
+        if(window.NativeInterface.isAndroidTV())
+            return "tv";
+        else
+            return "mobile";
     },
     supports(command) {
         return features.includes(command.toLowerCase());

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -1,8 +1,10 @@
 package org.jellyfin.mobile.bridge
 
 import android.annotation.SuppressLint
+import android.app.UiModeManager
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.media.session.PlaybackState
 import android.net.Uri
 import android.webkit.JavascriptInterface
@@ -165,5 +167,10 @@ class NativeInterface(private val context: Context) : KoinComponent {
     @Suppress("NOTHING_TO_INLINE")
     private inline fun emitEvent(event: ActivityEvent) {
         activityEventHandler.emit(event)
+    }
+
+    @JavascriptInterface
+    fun isAndroidTV(): Boolean{
+        return (context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager).currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
@@ -1,6 +1,9 @@
 package org.jellyfin.mobile.webapp
 
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.graphics.Rect
 import android.net.Uri
 import android.os.Bundle
@@ -177,6 +180,9 @@ class WebViewFragment : Fragment(), BackPressInterceptor {
         webViewClient = jellyfinWebViewClient
         webChromeClient = LoggingWebChromeClient()
         settings.applyDefault()
+        // If running on Android TV
+        if((context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager).currentModeType == Configuration.UI_MODE_TYPE_TELEVISION)
+            settings.userAgentString = settings.userAgentString.replace("Mobile","TV")
         addJavascriptInterface(NativeInterface(requireContext()), "NativeInterface")
         addJavascriptInterface(nativePlayer, "NativePlayer")
         addJavascriptInterface(externalPlayer, "ExternalPlayer")


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
- Setting default layout to TV when running on Android TV 
- Adding an entry to the android TV launcher

the web UI is better that the native app, which encounters too many problems on my end. Still a bit of work to be done on the web UI but still, it's more usable on my Nexus Player from 2014

