### PR TITLE
:bug: Fix External Player missing external subtitles

### DIFF
--- a/app/src/main/assets/native/ExternalPlayerPlugin.js
+++ b/app/src/main/assets/native/ExternalPlayerPlugin.js
@@ -145,7 +145,7 @@ export class ExternalPlayerPlugin {
             MaxStaticBitrate: 1_000_000_000,
             DirectPlayProfiles: [{Type: 'Video'}, {Type: 'Audio'}],
             CodecProfiles: [],
-            SubtitleProfiles: [{Method: 'Embed'}, {Method: 'Drop'}],
+            SubtitleProfiles: [{Method: 'Embed'}, {Method: 'External'}, {Method: 'Drop'}],
             TranscodingProfiles: []
         };
     }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.player.PlayerException
+import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder
 import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.source.ExternalSubtitleStream
 import org.jellyfin.mobile.player.source.JellyfinMediaSource
@@ -29,6 +30,7 @@ import org.jellyfin.mobile.webapp.WebappFunctionChannel
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.api.operations.VideosApi
+import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.json.JSONObject
 import org.koin.core.component.KoinComponent
@@ -46,6 +48,8 @@ class ExternalPlayer(
     private val appPreferences: AppPreferences by inject()
     private val webappFunctionChannel: WebappFunctionChannel by inject()
     private val mediaSourceResolver: MediaSourceResolver by inject()
+    private val deviceProfileBuilder: DeviceProfileBuilder by inject()
+    private val externalPlayerProfile: DeviceProfile = deviceProfileBuilder.getExternalPlayerProfile()
     private val apiClient: ApiClient = get()
     private val videosApi: VideosApi = apiClient.videosApi
 
@@ -93,6 +97,7 @@ class ExternalPlayer(
             mediaSourceResolver.resolveMediaSource(
                 itemId = itemId,
                 mediaSourceId = playOptions.mediaSourceId,
+                deviceProfile = externalPlayerProfile,
                 startTimeTicks = playOptions.startPositionTicks,
                 audioStreamIndex = playOptions.audioStreamIndex,
                 subtitleStreamIndex = playOptions.subtitleStreamIndex,

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -2,6 +2,7 @@ package org.jellyfin.mobile.player.deviceprofile
 
 import android.media.MediaCodecList
 import org.jellyfin.mobile.app.AppPreferences
+import org.jellyfin.mobile.bridge.ExternalPlayer
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.api.CodecProfile
 import org.jellyfin.sdk.model.api.ContainerProfile
@@ -158,7 +159,36 @@ class DeviceProfileBuilder(
         }
     }
 
+    fun getExternalPlayerProfile(): DeviceProfile = DeviceProfile(
+        name = EXTERNAL_PLAYER_PROFILE_NAME,
+        directPlayProfiles = listOf(
+            DirectPlayProfile(type = DlnaProfileType.VIDEO),
+            DirectPlayProfile(type = DlnaProfileType.AUDIO),
+        ),
+        transcodingProfiles = emptyList(),
+        containerProfiles = emptyList(),
+        codecProfiles = emptyList(),
+        subtitleProfiles = buildList {
+            EXTERNAL_PLAYER_SUBTITLES.mapTo(this) { format ->
+                SubtitleProfile(format = format, method = SubtitleDeliveryMethod.EMBED)
+            }
+            EXTERNAL_PLAYER_SUBTITLES.mapTo(this) { format ->
+                SubtitleProfile(format = format, method = SubtitleDeliveryMethod.EXTERNAL)
+            }
+        },
+        maxStreamingBitrate = Int.MAX_VALUE,
+        maxStaticBitrate = Int.MAX_VALUE,
+        musicStreamingTranscodingBitrate = Int.MAX_VALUE,
+
+        // TODO: remove redundant defaults after API/SDK is fixed
+        supportedMediaTypes = "",
+        xmlRootAttributes = emptyList(),
+        responseProfiles = emptyList(),
+    )
+
     companion object {
+        private const val EXTERNAL_PLAYER_PROFILE_NAME = Constants.APP_INFO_NAME + " External Player"
+
         /**
          * List of container formats supported by ExoPlayer
          *
@@ -253,6 +283,7 @@ class DeviceProfileBuilder(
         private val EXO_EMBEDDED_SUBTITLES = arrayOf("dvbsub", "pgssub", "srt", "subrip", "ttml")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")
         private val SUBTITLES_SSA = arrayOf("ssa", "ass")
+        private val EXTERNAL_PLAYER_SUBTITLES = arrayOf("ass", "dvbsub", "pgssub", "srt", "srt", "ssa", "subrip", "subrip", "ttml", "ttml", "vtt", "webvtt")
 
         /**
          * Taken from Jellyfin Web:

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -2,7 +2,6 @@ package org.jellyfin.mobile.player.deviceprofile
 
 import android.media.MediaCodecList
 import org.jellyfin.mobile.app.AppPreferences
-import org.jellyfin.mobile.bridge.ExternalPlayer
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.api.CodecProfile
 import org.jellyfin.sdk.model.api.ContainerProfile


### PR DESCRIPTION
**Changes**
To get external subtitle streams, we have to provide a device profile when resolving the media source.

**Issues**
Fixes #1258.
