### PR TITLE
Prevent notification from being dismissed while playback is active

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -115,7 +115,7 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
                 setContentIntent(buildContentIntent())
                 setDeleteIntent(buildDeleteIntent())
 
-                //prevents the notification from being dismissed while playback is ongoing
+                // prevents the notification from being dismissed while playback is ongoing
                 setOngoing(player.isPlaying)
             }.build()
 

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -114,6 +114,10 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
                 }
                 setContentIntent(buildContentIntent())
                 setDeleteIntent(buildDeleteIntent())
+
+                //prevents the notification from being dismissed while playback is ongoing
+                //which causes video to stop. see #1284
+                setOngoing(player.isPlaying)
             }.build()
 
             nm.notify(VIDEO_PLAYER_NOTIFICATION_ID, notification)

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -116,7 +116,6 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
                 setDeleteIntent(buildDeleteIntent())
 
                 //prevents the notification from being dismissed while playback is ongoing
-                //which causes video to stop. see #1284
                 setOngoing(player.isPlaying)
             }.build()
 


### PR DESCRIPTION
**Changes**
Adds a call to `setOngoing()` during the creation of the playback notification to determine if the notification can be dismissed. Ongoing notifications won't be dismissed by clicking 'clear all' in the system dropdown menu.

**Issues**
Fixes #1284 



