### PR TITLE
Specify BUILD_TOOLS_VERSION for r0adkll/sign-android-release step in publish workflow

### DIFF
--- a/.github/workflows/app-publish.yaml
+++ b/.github/workflows/app-publish.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Sign libre APK
         id: libreSign
         uses: r0adkll/sign-android-release@349ebdef58775b1e0d8099458af0816dc79b6407 # tag=v1
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
         with:
           releaseDirectory: app/build/outputs/apk/libre/release
           signingKeyBase64: ${{ secrets.KEYSTORE }}
@@ -36,6 +38,8 @@ jobs:
       - name: Sign proprietary APK
         id: proprietarySign
         uses: r0adkll/sign-android-release@349ebdef58775b1e0d8099458af0816dc79b6407 # tag=v1
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
         with:
           releaseDirectory: app/build/outputs/apk/proprietary/release
           signingKeyBase64: ${{ secrets.KEYSTORE }}
@@ -45,6 +49,8 @@ jobs:
       - name: Sign proprietary app bundle
         id: proprietaryBundleSign
         uses: r0adkll/sign-android-release@349ebdef58775b1e0d8099458af0816dc79b6407 # tag=v1
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
         with:
           releaseDirectory: app/build/outputs/bundle/proprietaryRelease
           signingKeyBase64: ${{ secrets.KEYSTORE }}


### PR DESCRIPTION
**Changes**

Fixes publishing

**Issues**

https://github.com/r0adkll/sign-android-release/issues/84