### PR TITLE
Fix Live TV playback stop not releasing tuner

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -360,6 +360,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
                         itemId = mediaSource.itemId,
                         positionTicks = lastPositionTicks,
                         playSessionId = mediaSource.playSessionId,
+                        liveStreamId = mediaSource.liveStreamId,
                         failed = false,
                     ),
                 )

--- a/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
@@ -15,6 +15,7 @@ class JellyfinMediaSource(
     val item: BaseItemDto?,
     val sourceInfo: MediaSourceInfo,
     val playSessionId: String,
+    val liveStreamId: String?,
     val maxStreamingBitrate: Int?,
     private var startTimeTicks: Long? = null,
     audioStreamIndex: Int? = null,

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -74,6 +74,7 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
                 item = item,
                 sourceInfo = mediaSourceInfo,
                 playSessionId = playSessionId,
+                liveStreamId = mediaSourceInfo.liveStreamId,
                 maxStreamingBitrate = maxStreamingBitrate,
                 startTimeTicks = startTimeTicks,
                 audioStreamIndex = audioStreamIndex,


### PR DESCRIPTION
**Changes**
This fix implements adding LiveStreamId to server calls from the Android client to stop LiveTV playback. This is an implementation of the recommended fix by @jellouser in issue #1279.

This change addresses the issue of the tuner not being released by the server when Live TV playback is stopped in the Anrdroid client.

**Issues**
Fixes #1279