### PR TITLE
Add support for VP9 in MP4 containers

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -203,9 +203,9 @@ class DeviceProfileBuilder(
          */
         private val AVAILABLE_VIDEO_CODECS = arrayOf(
             // mp4
-            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1"),
+            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp9"),
             // fmp4
-            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1"),
+            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp9"),
             // webm
             arrayOf("vp8", "vp9", "av1"),
             // mkv


### PR DESCRIPTION
**Changes**
Adds VP9 codec support to the list of supported codecs in MP4 containers.

After testing across various players and environments, including ExoPlayer, VLC, and major web browsers, VP9 in MP4 containers seem to work reliably. This PR should ensure broader compatibility and aligns with real-world usage.

**Issues**
Fixes #1311