### PR TITLE
Fix system file browser not being invoked

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebChromeClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebChromeClient.kt
@@ -9,7 +9,7 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import timber.log.Timber
 
-class LoggingWebChromeClient(
+class JellyfinWebChromeClient(
     private val fileChooserListener: FileChooserListener,
 ) : WebChromeClient() {
     override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {

--- a/app/src/main/java/org/jellyfin/mobile/webapp/LoggingWebChromeClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/LoggingWebChromeClient.kt
@@ -32,7 +32,11 @@ class LoggingWebChromeClient(
         return true
     }
 
-    override fun onShowFileChooser(webView: WebView?, filePathCallback: ValueCallback<Array<Uri>>?, fileChooserParams: FileChooserParams?): Boolean {
+    override fun onShowFileChooser(
+        webView: WebView?,
+        filePathCallback: ValueCallback<Array<Uri>>?,
+        fileChooserParams: FileChooserParams?,
+    ): Boolean {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
             type = "*/*"

--- a/app/src/main/java/org/jellyfin/mobile/webapp/LoggingWebChromeClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/LoggingWebChromeClient.kt
@@ -10,7 +10,7 @@ import android.webkit.WebView
 import timber.log.Timber
 
 class LoggingWebChromeClient(
-    private val launchFileOpenActivity: (intent: Intent, filePathCallback: ValueCallback<Array<Uri>>?) -> Unit,
+    private val fileChooserListener: FileChooserListener,
 ) : WebChromeClient() {
     override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
         val logLevel = when (consoleMessage.messageLevel()) {
@@ -33,16 +33,20 @@ class LoggingWebChromeClient(
     }
 
     override fun onShowFileChooser(
-        webView: WebView?,
-        filePathCallback: ValueCallback<Array<Uri>>?,
+        webView: WebView,
+        filePathCallback: ValueCallback<Array<Uri>>,
         fileChooserParams: FileChooserParams?,
     ): Boolean {
-        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-            addCategory(Intent.CATEGORY_OPENABLE)
-            type = "*/*"
+        if (fileChooserParams == null) {
+            filePathCallback.onReceiveValue(null)
+            return true
         }
 
-        launchFileOpenActivity(intent, filePathCallback)
+        fileChooserListener.onShowFileChooser(fileChooserParams.createIntent(), filePathCallback)
         return true
+    }
+
+    interface FileChooserListener {
+        fun onShowFileChooser(intent: Intent, filePathCallback: ValueCallback<Array<Uri>>)
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/webapp/LoggingWebChromeClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/LoggingWebChromeClient.kt
@@ -1,11 +1,17 @@
 package org.jellyfin.mobile.webapp
 
+import android.content.Intent
+import android.net.Uri
 import android.util.Log
 import android.webkit.ConsoleMessage
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
+import android.webkit.WebView
 import timber.log.Timber
 
-class LoggingWebChromeClient : WebChromeClient() {
+class LoggingWebChromeClient(
+    private val launchFileOpenActivity: (intent: Intent, filePathCallback: ValueCallback<Array<Uri>>?) -> Unit,
+) : WebChromeClient() {
     override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
         val logLevel = when (consoleMessage.messageLevel()) {
             ConsoleMessage.MessageLevel.ERROR -> Log.ERROR
@@ -23,6 +29,16 @@ class LoggingWebChromeClient : WebChromeClient() {
             consoleMessage.lineNumber(),
         )
 
+        return true
+    }
+
+    override fun onShowFileChooser(webView: WebView?, filePathCallback: ValueCallback<Array<Uri>>?, fileChooserParams: FileChooserParams?): Boolean {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+        }
+
+        launchFileOpenActivity(intent, filePathCallback)
         return true
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
@@ -49,7 +49,7 @@ import org.jellyfin.mobile.utils.requestNoBatteryOptimizations
 import org.jellyfin.mobile.utils.runOnUiThread
 import org.koin.android.ext.android.inject
 
-class WebViewFragment : Fragment(), BackPressInterceptor, LoggingWebChromeClient.FileChooserListener {
+class WebViewFragment : Fragment(), BackPressInterceptor, JellyfinWebChromeClient.FileChooserListener {
     val appPreferences: AppPreferences by inject()
     private val apiClientController: ApiClientController by inject()
     private val webappFunctionChannel: WebappFunctionChannel by inject()
@@ -187,7 +187,7 @@ class WebViewFragment : Fragment(), BackPressInterceptor, LoggingWebChromeClient
             return
         }
         webViewClient = jellyfinWebViewClient
-        webChromeClient = LoggingWebChromeClient(this@WebViewFragment)
+        webChromeClient = JellyfinWebChromeClient(this@WebViewFragment)
         settings.applyDefault()
         addJavascriptInterface(NativeInterface(requireContext()), "NativeInterface")
         addJavascriptInterface(nativePlayer, "NativePlayer")


### PR DESCRIPTION
**Changes**
This fix adds the invocation of the system file picker for `onShowFileChooser` in the WebChromeClient to enable the upload of local subtitle files.
It implements the recommendation of @Maxr1998 in issue #1082

**Issues**
Fixes #1082 
