### PR TITLE
Allow changing download network preference

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -25,6 +25,7 @@ import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.databinding.FragmentSettingsBinding
 import org.jellyfin.mobile.utils.BackPressInterceptor
 import org.jellyfin.mobile.utils.Constants
+import org.jellyfin.mobile.utils.DownloadMethod
 import org.jellyfin.mobile.utils.applyWindowInsetsAsMargins
 import org.jellyfin.mobile.utils.extensions.requireMainActivity
 import org.jellyfin.mobile.utils.getDownloadsPaths
@@ -192,6 +193,36 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
         categoryHeader(PREF_CATEGORY_DOWNLOADS) {
             titleRes = R.string.pref_category_downloads
         }
+
+        val downloadMethods = listOf(
+            SelectionItem(
+                "wifi_only",
+                R.string.wifi_only,
+                R.string.wifi_only_summary,
+            ),
+            SelectionItem(
+                "mobile_data",
+                R.string.mobile_data,
+                R.string.mobile_data_summary,
+            ),
+            SelectionItem(
+                "mobile_and_roaming",
+                R.string.mobile_data_and_roaming,
+                R.string.mobile_data_and_roaming_summary,
+            ),
+        )
+        singleChoice("download_method", downloadMethods) {
+            titleRes = R.string.network_title
+
+            defaultOnSelectionChange {
+                appPreferences.downloadMethod = when (it) {
+                    "wifi_only" -> DownloadMethod.WIFI_ONLY
+                    "mobile_data" -> DownloadMethod.MOBILE_DATA
+                    else -> DownloadMethod.MOBILE_AND_ROAMING
+                }
+            }
+        }
+
         val downloadsDirs = requireContext().getDownloadsPaths().map { path ->
             SelectionItem(path, path, null)
         }

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -196,31 +196,24 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
 
         val downloadMethods = listOf(
             SelectionItem(
-                "wifi_only",
+                DownloadMethod.WIFI_ONLY,
                 R.string.wifi_only,
                 R.string.wifi_only_summary,
             ),
             SelectionItem(
-                "mobile_data",
+                DownloadMethod.MOBILE_DATA,
                 R.string.mobile_data,
                 R.string.mobile_data_summary,
             ),
             SelectionItem(
-                "mobile_and_roaming",
+                DownloadMethod.MOBILE_AND_ROAMING,
                 R.string.mobile_data_and_roaming,
                 R.string.mobile_data_and_roaming_summary,
             ),
         )
-        singleChoice("download_method", downloadMethods) {
+        singleChoice(Constants.PREF_DOWNLOAD_METHOD, downloadMethods) {
             titleRes = R.string.network_title
-
-            defaultOnSelectionChange {
-                appPreferences.downloadMethod = when (it) {
-                    "wifi_only" -> DownloadMethod.WIFI_ONLY
-                    "mobile_data" -> DownloadMethod.MOBILE_DATA
-                    else -> DownloadMethod.MOBILE_AND_ROAMING
-                }
-            }
+            initialSelection = appPreferences.downloadMethod
         }
 
         val downloadsDirs = requireContext().getDownloadsPaths().map { path ->

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -213,7 +213,6 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
         )
         singleChoice(Constants.PREF_DOWNLOAD_METHOD, downloadMethods) {
             titleRes = R.string.network_title
-            initialSelection = appPreferences.downloadMethod
         }
 
         val downloadsDirs = requireContext().getDownloadsPaths().map { path ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,10 +29,13 @@
     <string name="bluetooth_permission_granted">Bluetooth permission was granted</string>
     <string name="battery_optimizations_message">Please disable battery optimizations for media playback while the screen is off.</string>
     <string name="network_title">Allowed Network Types</string>
-    <string name="network_message">Do you want to allow the download to run over mobile data or roaming networks? Charges from your provider may apply.</string>
+    <string name="network_message">Do you want to allow the download to run over mobile data or roaming networks? Charges from your provider may apply. You can change this option later from settings.</string>
     <string name="wifi_only">WiFi Only</string>
     <string name="mobile_data">Mobile Data</string>
     <string name="mobile_data_and_roaming">Mobile Data &amp; Roaming</string>
+    <string name="wifi_only_summary">Media will be downloaded over WiFi only.</string>
+    <string name="mobile_data_summary">Media will be downloaded over WiFi and mobile networks.</string>
+    <string name="mobile_data_and_roaming_summary">Media will be downloaded over WiFi, mobile and roaming networks.</string>
     <string name="downloading">Downloading</string>
     <string name="download_no_storage_permission">Cannot download files without storage permissions</string>
 


### PR DESCRIPTION

**Changes**
Adds a section in the settings screen which gives users the option of changing their preferred download network. Previously, users were unable to allow or restrict mobile data downloads after making the initial choice. Additionally updates the message displayed when the initial dialog is displayed to inform users their choice can be updated.

![ss_dialog_update](https://github.com/jellyfin/jellyfin-android/assets/18432394/003f58da-c05a-4bfd-aa55-833a75a7320a)
![ss_allowed_dialog](https://github.com/jellyfin/jellyfin-android/assets/18432394/76cc6a64-f10b-4bc9-ad3c-00c96a74c066)



**Issues**
Fixes #1326
