### PR TITLE
Update dependency de.maxr1998:modernandroidpreferences to v2.4.0-beta2

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -192,7 +192,7 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
         categoryHeader(PREF_CATEGORY_DOWNLOADS) {
             titleRes = R.string.pref_category_downloads
         }
-        val downloadsDirs: List<SelectionItem> = requireContext().getDownloadsPaths().map { path ->
+        val downloadsDirs = requireContext().getDownloadsPaths().map { path ->
             SelectionItem(path, path, null)
         }
         singleChoice(Constants.PREF_DOWNLOAD_LOCATION, downloadsDirs) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ androidx-lifecycle = "2.7.0"
 androidx-constraintlayout = "2.1.4"
 google-material = "1.10.0"
 androidx-webkit = "1.9.0"
-modernandroidpreferences = "2.3.2"
+modernandroidpreferences = "2.4.0-beta2"
 
 # Compose
 compose = "1.5.4"


### PR DESCRIPTION
Adds support for `singleChoice` preferences with an Int key.