### PR TITLE
Fix initial download method dialog

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -83,17 +83,17 @@ suspend fun MainActivity.requestDownload(uri: Uri, title: String, filename: Stri
         AlertDialog.Builder(this)
             .setTitle(R.string.network_title)
             .setMessage(R.string.network_message)
-            .setNegativeButton(R.string.wifi_only) { _, _ ->
+            .setPositiveButton(R.string.wifi_only) { _, _ ->
                 val selectedDownloadMethod = DownloadMethod.WIFI_ONLY
                 appPreferences.downloadMethod = selectedDownloadMethod
                 continuation.resume(selectedDownloadMethod)
             }
-            .setPositiveButton(R.string.mobile_data) { _, _ ->
+            .setNegativeButton(R.string.mobile_data) { _, _ ->
                 val selectedDownloadMethod = DownloadMethod.MOBILE_DATA
                 appPreferences.downloadMethod = selectedDownloadMethod
                 continuation.resume(selectedDownloadMethod)
             }
-            .setPositiveButton(R.string.mobile_data_and_roaming) { _, _ ->
+            .setNeutralButton(R.string.mobile_data_and_roaming) { _, _ ->
                 val selectedDownloadMethod = DownloadMethod.MOBILE_AND_ROAMING
                 appPreferences.downloadMethod = selectedDownloadMethod
                 continuation.resume(selectedDownloadMethod)


### PR DESCRIPTION
**Changes**
Adds a third option to the initial download method dialog, allowing users to properly pick between the three network options

**Issues**
Fixes #1330
