### PR TITLE
Add swipe to auto-brightness at 0% in exoPlayer

### DIFF
--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -29,12 +29,27 @@
             android:visibility="gone"
             tools:visibility="visible">
 
-            <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/gesture_overlay_image"
-                android:layout_width="@dimen/exo_gesture_overlay_image_size"
-                android:layout_height="@dimen/exo_gesture_overlay_image_size"
-                android:layout_marginVertical="16dp"
-                tools:srcCompat="@drawable/ic_brightness_white_24dp" />
+            <RelativeLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/gesture_overlay_image"
+                    android:layout_width="@dimen/exo_gesture_overlay_image_size"
+                    android:layout_height="@dimen/exo_gesture_overlay_image_size"
+                    android:layout_marginVertical="16dp"
+                    tools:srcCompat="@drawable/ic_brightness_white_24dp"/>
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/auto_brightness_indicator"
+                    android:layout_width="@dimen/exo_gesture_overlay_image_size"
+                    android:layout_height="@dimen/exo_gesture_overlay_image_size"
+                    android:layout_marginTop="24dp"
+                    android:gravity="bottom|end"
+                    android:text="@string/exoplayer_auto_brightness_indicator"
+                    android:textColorLink="#FFFFFF"
+                    android:textSize="20sp"
+                    android:textStyle="bold" />
+            </RelativeLayout>
 
             <ProgressBar
                 android:id="@+id/gesture_overlay_progress"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,4 +116,6 @@
 
     <string name="pref_category_downloads">Downloads</string>
     <string name="pref_download_location">Download location</string>
+
+    <string name="exoplayer_auto_brightness_indicator">A</string>
 </resources>


### PR DESCRIPTION
**Changes**
 - enhances PlayerGestureHelper to allow swiping past 0% brightness to restore auto brightness from system
 - adds "A" ui-indicator to brightness overlay when auto-brightness is enabled
 
![Screen_Recording_20240414_174344_Jellyfin Debug](https://github.com/jellyfin/jellyfin-android/assets/5832060/83e9a8af-8a57-461f-b738-bb0f4f4a40e2)

**Issues**
- adds feature mentioned in comment of  #1185
