### PR TITLE
Fix broken external links

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
@@ -41,12 +41,12 @@ abstract class JellyfinWebViewClient(
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
         Timber.d("shouldOverrideUrlLoading: %s", request.url.toString())
-        val url = request.url
         return when {
-            url.toString().startsWith(server.hostname) -> false
+            !request.hasGesture() -> false
+            request.url.toString().startsWith(server.hostname) -> false
             else -> {
-                Timber.d("shouldOverrideUrlLoading: external link, handle with system")
-                val intent = Intent(Intent.ACTION_VIEW, url)
+                Timber.d("shouldOverrideUrlLoading: external link with gesture, handle with system")
+                val intent = Intent(Intent.ACTION_VIEW, request.url)
                 if (intent.resolveActivity(view.context.packageManager) != null) {
                     startActivity(view.context, intent, null)
                 }

--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
@@ -40,15 +40,12 @@ abstract class JellyfinWebViewClient(
     abstract fun onErrorReceived()
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        Timber.d("shouldOverrideUrlLoading: %s", request.url.toString())
         val url = request.url
-        val path = url.path?.lowercase(Locale.ROOT) ?: ""
         return when {
-            path.matches(Constants.MAIN_BUNDLE_PATH_REGEX) && "deferred" !in url.query.orEmpty() -> false
-            path.contains("/native/") -> false
-            path.endsWith(Constants.CAST_SDK_PATH) -> false
-            path.endsWith(Constants.SESSION_CAPABILITIES_PATH) -> false
-            url.toString().contains(server.hostname) -> false
+            url.toString().startsWith(server.hostname) -> false
             else -> {
+                Timber.d("shouldOverrideUrlLoading: external link, handle with system")
                 val intent = Intent(Intent.ACTION_VIEW, url)
                 if (intent.resolveActivity(view.context.packageManager) != null) {
                     startActivity(view.context, intent, null)


### PR DESCRIPTION
**Changes**
Links in metadata would open in the app and lock it up. I override the function shouldOverrideUrlLoading to launch external links with the system. External links are defined as those that aren't intercepted by shouldInterceptRequest and don't contain the server hostname.

**Issues**
Fixes #984
