### PR TITLE
Add option to disallow some codecs for exoplayer

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
@@ -117,6 +117,9 @@ class AppPreferences(context: Context) {
     val exoPlayerAllowBackgroundAudio: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO, false)
 
+    val exoPlayerDisallowedCodecs: String?
+        get() = sharedPreferences.getString(Constants.PREF_EXOPLAYER_DISALLOWED_CODECS, "")
+
     val exoPlayerDirectPlayAss: Boolean
         get() = sharedPreferences.getBoolean(Constants.PREF_EXOPLAYER_DIRECT_PLAY_ASS, false)
 

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -16,6 +16,7 @@ import de.Maxr1998.modernpreferences.helpers.checkBox
 import de.Maxr1998.modernpreferences.helpers.defaultOnCheckedChange
 import de.Maxr1998.modernpreferences.helpers.defaultOnClick
 import de.Maxr1998.modernpreferences.helpers.defaultOnSelectionChange
+import de.Maxr1998.modernpreferences.helpers.editText
 import de.Maxr1998.modernpreferences.helpers.pref
 import de.Maxr1998.modernpreferences.helpers.screen
 import de.Maxr1998.modernpreferences.helpers.singleChoice
@@ -43,6 +44,7 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
     private lateinit var rememberBrightnessPreference: Preference
     private lateinit var backgroundAudioPreference: Preference
     private lateinit var directPlayAssPreference: Preference
+    private lateinit var disallowedCodecsPreference: Preference
     private lateinit var externalPlayerChoicePreference: Preference
 
     init {
@@ -137,6 +139,13 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
         directPlayAssPreference = checkBox(Constants.PREF_EXOPLAYER_DIRECT_PLAY_ASS) {
             titleRes = R.string.pref_exoplayer_direct_play_ass
             summaryRes = R.string.pref_exoplayer_direct_play_ass_summary
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
+        }
+
+        disallowedCodecsPreference = editText(Constants.PREF_EXOPLAYER_DISALLOWED_CODECS) {
+            textInputHintRes = R.string.pref_exoplayer_disallowed_codecs_hint
+            titleRes = R.string.pref_exoplayer_disallowed_codecs
+            summaryRes = R.string.pref_exoplayer_disallowed_codecs_summary
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
         }
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -38,6 +38,7 @@ object Constants {
     const val PREF_EXOPLAYER_REMEMBER_BRIGHTNESS = "pref_exoplayer_remember_brightness"
     const val PREF_EXOPLAYER_BRIGHTNESS = "pref_exoplayer_brightness"
     const val PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO = "pref_exoplayer_allow_background_audio"
+    const val PREF_EXOPLAYER_DISALLOWED_CODECS = "pref_exoplayer_disallowed_codecs"
     const val PREF_EXOPLAYER_DIRECT_PLAY_ASS = "pref_exoplayer_direct_play_ass"
     const val PREF_EXTERNAL_PLAYER_APP = "pref_external_player_app"
     const val PREF_SUBTITLE_STYLE = "pref_subtitle_style"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,9 @@
     <string name="pref_exoplayer_remember_brightness">Remember display brightness</string>
     <string name="pref_exoplayer_allow_background_audio">Background audio</string>
     <string name="pref_exoplayer_allow_background_audio_summary">Allow playing videos in the background with audio-only</string>
+    <string name="pref_exoplayer_disallowed_codecs">Disallowed Codecs</string>
+    <string name="pref_exoplayer_disallowed_codecs_summary">Try to prevent playing some codecs and request transcoding instead.</string>
+    <string name="pref_exoplayer_disallowed_codecs_hint">A comma-separated list of codecs to exclude from the exoplayer</string>
     <string name="pref_exoplayer_direct_play_ass">Allow SSA/ASS subtitles in direct play</string>
     <string name="pref_exoplayer_direct_play_ass_summary">Prevent transcoding and show subtitles with basic styling only. Advanced subtitle styling will not be available if enabled.</string>
 


### PR DESCRIPTION
Some devices can't play some codecs using exoplayer for a variety of reasons, such as poor performance, bad hardware, or even buggy software. This change allows users to specify some codecs that their device has issues with. Jellyfin will try to transcode media to something else.

First time trying to contribute so please let me know if there are things I can improve.

**Changes**
Added an option to the Client Settings page for the exoplayer to list codecs to try not to play. 

**Issues**
Allows users to work around some issues by specifying the problematic codec such as 
#1359 #1342 #1389 #1264 #1220 #1174
