### PR TITLE
Fix background playback stopping on Android 14

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,7 +67,12 @@
             </intent-filter>
         </activity>
 
-        <service android:name=".webapp.RemotePlayerService" />
+
+        <service
+            android:name=".webapp.RemotePlayerService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback">
+        </service>
 
         <service
             android:name="org.jellyfin.mobile.player.audio.MediaService"

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.media.session.PlaybackState
 import android.net.Uri
 import android.webkit.JavascriptInterface
+import androidx.core.content.ContextCompat
 import org.jellyfin.mobile.events.ActivityEvent
 import org.jellyfin.mobile.events.ActivityEventHandler
 import org.jellyfin.mobile.utils.Constants
@@ -98,7 +99,8 @@ class NativeInterface(private val context: Context) : KoinComponent {
             putExtra(EXTRA_IS_LOCAL_PLAYER, options.optBoolean(EXTRA_IS_LOCAL_PLAYER, true))
             putExtra(EXTRA_IS_PAUSED, options.optBoolean(EXTRA_IS_PAUSED, true))
         }
-        context.startService(intent)
+
+        ContextCompat.startForegroundService(context, intent)
 
         // We may need to request bluetooth permission to react to bluetooth disconnect events
         activityEventHandler.emit(ActivityEvent.RequestBluetoothPermission)

--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -265,10 +265,6 @@ class RemotePlayerService : Service(), CoroutineScope {
                     setPriority(Notification.PRIORITY_LOW)
                 }
 
-                if (AndroidVersion.isAtLeastS) {
-                    setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
-                }
-
                 setContentTitle(title?.let { HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY) })
                 setContentText(artist?.let { HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY) })
                 setSubText(album)
@@ -350,12 +346,12 @@ class RemotePlayerService : Service(), CoroutineScope {
                 startForeground(
                     MEDIA_PLAYER_NOTIFICATION_ID,
                     notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST,
                 )
             } else {
                 startForeground(
                     MEDIA_PLAYER_NOTIFICATION_ID,
-                    notification
+                    notification,
                 )
             }
 

--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -11,6 +11,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.graphics.Bitmap
 import android.media.AudioAttributes
 import android.media.AudioManager
@@ -263,6 +264,11 @@ class RemotePlayerService : Service(), CoroutineScope {
                 } else {
                     setPriority(Notification.PRIORITY_LOW)
                 }
+
+                if (AndroidVersion.isAtLeastS) {
+                    setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+                }
+
                 setContentTitle(title?.let { HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY) })
                 setContentText(artist?.let { HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY) })
                 setSubText(album)
@@ -340,7 +346,18 @@ class RemotePlayerService : Service(), CoroutineScope {
             }.build()
 
             // Post notification
-            notificationManager.notify(MEDIA_PLAYER_NOTIFICATION_ID, notification)
+            if (AndroidVersion.isAtLeastQ) {
+                startForeground(
+                    MEDIA_PLAYER_NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
+                )
+            } else {
+                startForeground(
+                    MEDIA_PLAYER_NOTIFICATION_ID,
+                    notification
+                )
+            }
 
             // Activate MediaSession
             mediaSession.isActive = true


### PR DESCRIPTION
`RemotePlayerService` service was not being properly started as a foreground service for media playback, causing playback stoppage after every track (or sooner for some folks), on android 14.

Different vendors may be more or less aggressive with killing of non-foreground service etc, so people may have gotten different results from the same root issue.

**Changes**
- Changes the manifest entry for `RemotePlayerService` to include the `foregroundServiceType="mediaPlayback"` attribute (see ["Foreground service types are required"](https://developer.android.com/about/versions/14/behavior-changes-14#fgs-types))
- Declares the foreground service behavior as part of the notification (see same req)
- Uses `startForeground` instead of `notificationManager.notify`
- Uses `ContextCompat.startForegroundService` to send intents to the service

Some of these changes can also be found in @dumpfheimer's PR [Improving Chromecast Integration #1298](https://github.com/jellyfin/jellyfin-android/pull/1298)

**Issues**

- Fixes #1378
- Fixes #1401

---

(For a bit of my background: my day job is working on a music streaming android app and we've previously hit similar issues)
