### PR TITLE
Add opus to MP4 direct play profile

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -248,7 +248,7 @@ class DeviceProfileBuilder(
          */
         private val AVAILABLE_AUDIO_CODECS = arrayOf(
             // mp4
-            arrayOf("mp1", "mp2", "mp3", "aac", "alac", "ac3"),
+            arrayOf("mp1", "mp2", "mp3", "aac", "alac", "ac3", "opus"),
             // fmp4
             arrayOf("mp3", "aac", "ac3", "eac3"),
             // webm


### PR DESCRIPTION
**Changes**
Adds OPUS to the MP4 container direct play profile.  OPUS is supported for direct play in other containers, but not MP4.  The MP4 spec supports OPUS.

**Issues**
Resolves this user's issue with unnecessary transcoding.

https://forum.jellyfin.org/t-solved-direct-play-problem-with-mp4-and-certain-codecs-on-android-native-player