### PR TITLE
Switch to binary-only Gradle distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,10 +17,6 @@ allprojects {
     }
 }
 
-tasks.wrapper {
-    distributionType = Wrapper.DistributionType.ALL
-}
-
 tasks.create<Delete>("clean") {
     delete(rootProject.buildDir)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f8b4f4772d302c8ff580bc40d0f56e715de69b163546944f787c87abf209c961
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
+distributionSha256Sum=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
**Changes**
Alter build to use binary-only distribution of the Gradle wrapper.

This saves nearly 100MB on download (138MB instead of 230MB) and more than that in disk space. The complete distribution of the wrapper offers no value to the majority of contributors.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
