### PR TITLE
Fix deprecations in build scripts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.app)
@@ -16,6 +16,13 @@ detekt {
     allRules = false
     config = files("${rootProject.projectDir}/detekt.yml")
     autoCorrect = true
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+        optIn.add("kotlin.RequiresOptIn")
+    }
 }
 
 android {
@@ -81,10 +88,6 @@ android {
         buildConfig = true
         viewBinding = true
         compose = true
-    }
-    kotlinOptions {
-        @Suppress("SuspiciousCollectionReassignment")
-        freeCompilerArgs += listOf("-Xopt-in=kotlin.RequiresOptIn")
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -175,12 +178,6 @@ dependencies {
 }
 
 tasks {
-    withType<KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_11.toString()
-        }
-    }
-
     withType<Detekt> {
         jvmTarget = JavaVersion.VERSION_11.toString()
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -202,9 +202,9 @@ tasks {
     }
 
     register("versionTxt") {
-        val path = buildDir.resolve("version.txt")
-
         doLast {
+            val path = layout.buildDirectory.file("version.txt").get().asFile
+
             val versionString = "v${android.defaultConfig.versionName}=${android.defaultConfig.versionCode}"
             println("Writing [$versionString] to $path")
             path.writeText("$versionString\n")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,5 +22,5 @@ tasks.wrapper {
 }
 
 tasks.create<Delete>("clean") {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
**Changes**
Fix these deprecations:
* https://kotlinlang.org/docs/whatsnew20.html#deprecated-old-ways-of-defining-compiler-options
* https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
