### PR TITLE
Configure Room with Gradle plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,11 +3,11 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.app)
-    alias(libs.plugins.android.room)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.androidx.room)
     alias(libs.plugins.detekt)
     alias(libs.plugins.android.junit5)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.app)
+    alias(libs.plugins.android.room)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.parcelize)
@@ -99,10 +100,12 @@ android {
         abortOnError = false
         sarifReport = true
     }
+    room {
+        schemaDirectory("$projectDir/schemas")
+    }
 }
 
 ksp {
-    arg("room.schemaLocation", "$projectDir/schemas")
     arg("room.incremental", "true")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,10 +105,6 @@ android {
     }
 }
 
-ksp {
-    arg("room.incremental", "true")
-}
-
 dependencies {
     val proprietaryImplementation by configurations
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android-junit5" }
+android-room = { id = "androidx.room", version.ref = "androidx-room" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,8 +66,8 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+androidx-room = { id = "androidx.room", version.ref = "androidx-room" }
 android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android-junit5" }
-android-room = { id = "androidx.room", version.ref = "androidx-room" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
 [libraries]


### PR DESCRIPTION
**Changes**
Migrate to the Room Gradle plugin introduced in Room 2.6.0.

> The plugin configures the project such that generated schemas (which are
> an output of the compile tasks and are consumed for auto-migrations) are
> correctly configured to have reproducible and cacheable builds.

https://developer.android.com/jetpack/androidx/releases/room#gradle-plugin
<!-- Describe your changes here in 1-5 sentences. -->

Running Gradle tasks such as `assembleDebug` twice in a row now leads to tasks in the second run being up to date, allowing incremental compilation to work correctly.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
