### PR TITLE
Fix the issue of blurry media images in notifications.

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -125,9 +125,11 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
             mediaIcon?.let {
                 viewModel.mediaSession.controller.metadata?.let {
                     if (!it.containsKey(MediaMetadata.METADATA_KEY_ART)) {
-                        viewModel.mediaSession.setMetadata(MediaMetadata.Builder(it)
-                            .putBitmap(MediaMetadata.METADATA_KEY_ART, mediaIcon)
-                            .build())
+                        viewModel.mediaSession.setMetadata(
+                            MediaMetadata.Builder(it)
+                                .putBitmap(MediaMetadata.METADATA_KEY_ART, mediaIcon)
+                                .build()
+                        )
                     }
                 }
             }

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.graphics.Bitmap
+import android.media.MediaMetadata
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.toBitmap
@@ -120,6 +121,16 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
             }.build()
 
             nm.notify(VIDEO_PLAYER_NOTIFICATION_ID, notification)
+
+            mediaIcon?.let {
+                viewModel.mediaSession.controller.metadata?.let {
+                    if (!it.containsKey(MediaMetadata.METADATA_KEY_ART)) {
+                        viewModel.mediaSession.setMetadata(MediaMetadata.Builder(it)
+                            .putBitmap(MediaMetadata.METADATA_KEY_ART, mediaIcon)
+                            .build())
+                    }
+                }
+            }
         }
 
         if (receiverRegistered.compareAndSet(false, true)) {

--- a/app/src/main/res/values-v29/dimens.xml
+++ b/app/src/main/res/values-v29/dimens.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="media_notification_height">140dp</dimen>
+    <dimen name="media_notification_height">196dp</dimen>
 </resources>


### PR DESCRIPTION
**Changes**
Use MediaMetadata art to override large icon in notification, fix art not clear issue.

Before:
![微信截图_20241011232259](https://github.com/user-attachments/assets/c5560cd1-4291-496f-b7bc-b9afe8b955c7)

After:
![微信截图_20241011232400](https://github.com/user-attachments/assets/d8c8cc10-c79e-4bb0-92b0-ac2a28348cf8)


