### PR TITLE
Update jellyfin-sdk-kotlin to v1.6.1

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/ApiClientController.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/ApiClientController.kt
@@ -8,7 +8,6 @@ import org.jellyfin.mobile.data.entity.ServerEntity
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.DeviceInfo
-import org.jellyfin.sdk.model.serializer.toUUID
 
 class ApiClientController(
     private val appPreferences: AppPreferences,
@@ -27,7 +26,7 @@ class ApiClientController(
         appPreferences.currentServerId = withContext(Dispatchers.IO) {
             serverDao.getServerByHostname(hostname)?.id ?: serverDao.insert(hostname)
         }
-        apiClient.baseUrl = hostname
+        apiClient.update(baseUrl = hostname)
     }
 
     suspend fun setupUser(serverId: Long, userId: String, accessToken: String) {
@@ -69,19 +68,21 @@ class ApiClientController(
     }
 
     private fun configureApiClientServer(server: ServerEntity?) {
-        apiClient.baseUrl = server?.hostname
+        apiClient.update(baseUrl = server?.hostname)
     }
 
     private fun configureApiClientUser(userId: String, accessToken: String) {
-        apiClient.userId = userId.toUUID()
-        apiClient.accessToken = accessToken
-        // Append user id to device id to ensure uniqueness across sessions
-        apiClient.deviceInfo = baseDeviceInfo.copy(id = baseDeviceInfo.id + userId)
+        apiClient.update(
+            accessToken = accessToken,
+            // Append user id to device id to ensure uniqueness across sessions
+            deviceInfo = baseDeviceInfo.copy(id = baseDeviceInfo.id + userId),
+        )
     }
 
     private fun resetApiClientUser() {
-        apiClient.userId = null
-        apiClient.accessToken = null
-        apiClient.deviceInfo = baseDeviceInfo
+        apiClient.update(
+            accessToken = null,
+            deviceInfo = baseDeviceInfo,
+        )
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
@@ -37,6 +37,7 @@ import org.jellyfin.mobile.webapp.RemoteVolumeProvider
 import org.jellyfin.mobile.webapp.WebViewFragment
 import org.jellyfin.mobile.webapp.WebappFunctionChannel
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
 import org.koin.android.ext.koin.androidApplication
 import org.koin.androidx.fragment.dsl.fragment
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -111,12 +112,13 @@ val applicationModule = module {
         // Add authorization header. This is needed as we don't pass the
         // access token in the url for Android Auto.
         ResolvingDataSource.Factory(dataSourceFactory) { dataSpec: DataSpec ->
-            val authorizationHeaderString =
-                "MediaBrowser Token=\"${apiClient.accessToken}\", " +
-                    "Client=\"${apiClient.clientInfo.name}\", " +
-                    "Device=\"${apiClient.deviceInfo.name}\", " +
-                    "DeviceId=\"${apiClient.deviceInfo.id}\", " +
-                    "Version=\"${apiClient.clientInfo.version}\""
+            val authorizationHeaderString = AuthorizationHeaderBuilder.buildHeader(
+                clientName = apiClient.clientInfo.name,
+                clientVersion = apiClient.clientInfo.version,
+                deviceId = apiClient.deviceInfo.id,
+                deviceName = apiClient.deviceInfo.name,
+                accessToken = apiClient.accessToken,
+            )
 
             dataSpec.withRequestHeaders(hashMapOf("Authorization" to authorizationHeaderString))
         }

--- a/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
@@ -126,8 +126,9 @@ val applicationModule = module {
                 )
 
                 dataSpec.withRequestHeaders(hashMapOf("Authorization" to authorizationHeaderString))
-            } else
+            } else {
                 dataSpec
+            }
         }
     }
     single<MediaSource.Factory> {

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -66,6 +66,7 @@ import org.jellyfin.sdk.api.operations.HlsSegmentApi
 import org.jellyfin.sdk.api.operations.PlayStateApi
 import org.jellyfin.sdk.api.operations.UserApi
 import org.jellyfin.sdk.model.api.PlayMethod
+import org.jellyfin.sdk.model.api.PlaybackOrder
 import org.jellyfin.sdk.model.api.PlaybackProgressInfo
 import org.jellyfin.sdk.model.api.PlaybackStartInfo
 import org.jellyfin.sdk.model.api.PlaybackStopInfo
@@ -319,6 +320,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
                     positionTicks = mediaSource.startTimeMs * Constants.TICKS_PER_MILLISECOND,
                     volumeLevel = audioManager.getVolumeLevelPercent(),
                     repeatMode = RepeatMode.REPEAT_NONE,
+                    playbackOrder = PlaybackOrder.DEFAULT,
                 ),
             )
         } catch (e: ApiClientException) {
@@ -347,6 +349,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
                         positionTicks = playbackPositionMillis * Constants.TICKS_PER_MILLISECOND,
                         volumeLevel = (currentVolume - volumeRange.first) * Constants.PERCENT_MAX / volumeRange.width,
                         repeatMode = RepeatMode.REPEAT_NONE,
+                        playbackOrder = PlaybackOrder.DEFAULT,
                     ),
                 )
             } catch (e: ApiClientException) {

--- a/app/src/main/java/org/jellyfin/mobile/player/audio/MediaService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/audio/MediaService.kt
@@ -44,7 +44,6 @@ import org.jellyfin.mobile.player.cast.ICastPlayerProvider
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.extensions.mediaUri
 import org.jellyfin.mobile.utils.toast
-import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
 import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
@@ -53,7 +52,6 @@ import com.google.android.exoplayer2.MediaItem as ExoPlayerMediaItem
 
 class MediaService : MediaBrowserServiceCompat() {
     private val apiClientController: ApiClientController by inject()
-    private val apiClient: ApiClient by inject()
     private val libraryBrowser: LibraryBrowser by inject()
 
     private val serviceScope = MainScope()
@@ -177,12 +175,7 @@ class MediaService : MediaBrowserServiceCompat() {
             loadingJob.join()
 
             val items = try {
-                if (apiClient.userId != null) {
-                    libraryBrowser.loadLibrary(parentId)
-                } else {
-                    Timber.e("Missing userId in ApiClient")
-                    null
-                }
+                libraryBrowser.loadLibrary(parentId)
             } catch (e: ApiClientException) {
                 Timber.e(e)
                 null

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -8,6 +8,7 @@ import org.jellyfin.sdk.model.api.ContainerProfile
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.DirectPlayProfile
 import org.jellyfin.sdk.model.api.DlnaProfileType
+import org.jellyfin.sdk.model.api.MediaStreamProtocol
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import org.jellyfin.sdk.model.api.SubtitleProfile
 import org.jellyfin.sdk.model.api.TranscodingProfile
@@ -72,7 +73,7 @@ class DeviceProfileBuilder(
                 container = "ts",
                 videoCodec = "h264",
                 audioCodec = "mp1,mp2,mp3,aac,ac3,eac3,dts,mlp,truehd",
-                protocol = "hls",
+                protocol = MediaStreamProtocol.HLS,
                 conditions = emptyList(),
             ),
             TranscodingProfile(
@@ -80,7 +81,7 @@ class DeviceProfileBuilder(
                 container = "mkv",
                 videoCodec = "h264",
                 audioCodec = AVAILABLE_AUDIO_CODECS[SUPPORTED_CONTAINER_FORMATS.indexOf("mkv")].joinToString(","),
-                protocol = "hls",
+                protocol = MediaStreamProtocol.HLS,
                 conditions = emptyList(),
             ),
             TranscodingProfile(
@@ -88,7 +89,7 @@ class DeviceProfileBuilder(
                 container = "mp3",
                 videoCodec = "",
                 audioCodec = "mp3",
-                protocol = "http",
+                protocol = MediaStreamProtocol.HTTP,
                 conditions = emptyList(),
             ),
         )
@@ -102,7 +103,7 @@ class DeviceProfileBuilder(
         for (i in SUPPORTED_CONTAINER_FORMATS.indices) {
             val container = SUPPORTED_CONTAINER_FORMATS[i]
             if (supportedVideoCodecs[i].isNotEmpty()) {
-                containerProfiles.add(ContainerProfile(type = DlnaProfileType.VIDEO, container = container))
+                containerProfiles.add(ContainerProfile(type = DlnaProfileType.VIDEO, container = container, conditions = emptyList()))
                 directPlayProfiles.add(
                     DirectPlayProfile(
                         type = DlnaProfileType.VIDEO,
@@ -113,7 +114,7 @@ class DeviceProfileBuilder(
                 )
             }
             if (supportedAudioCodecs[i].isNotEmpty()) {
-                containerProfiles.add(ContainerProfile(type = DlnaProfileType.AUDIO, container = container))
+                containerProfiles.add(ContainerProfile(type = DlnaProfileType.AUDIO, container = container, conditions = emptyList()))
                 directPlayProfiles.add(
                     DirectPlayProfile(
                         type = DlnaProfileType.AUDIO,
@@ -141,11 +142,6 @@ class DeviceProfileBuilder(
             maxStreamingBitrate = MAX_STREAMING_BITRATE,
             maxStaticBitrate = MAX_STATIC_BITRATE,
             musicStreamingTranscodingBitrate = MAX_MUSIC_TRANSCODING_BITRATE,
-
-            // TODO: remove redundant defaults after API/SDK is fixed
-            supportedMediaTypes = "",
-            xmlRootAttributes = emptyList(),
-            responseProfiles = emptyList(),
         )
     }
 
@@ -161,8 +157,8 @@ class DeviceProfileBuilder(
     fun getExternalPlayerProfile(): DeviceProfile = DeviceProfile(
         name = EXTERNAL_PLAYER_PROFILE_NAME,
         directPlayProfiles = listOf(
-            DirectPlayProfile(type = DlnaProfileType.VIDEO),
-            DirectPlayProfile(type = DlnaProfileType.AUDIO),
+            DirectPlayProfile(type = DlnaProfileType.VIDEO, container = ""),
+            DirectPlayProfile(type = DlnaProfileType.AUDIO, container = ""),
         ),
         transcodingProfiles = emptyList(),
         containerProfiles = emptyList(),
@@ -178,11 +174,6 @@ class DeviceProfileBuilder(
         maxStreamingBitrate = Int.MAX_VALUE,
         maxStaticBitrate = Int.MAX_VALUE,
         musicStreamingTranscodingBitrate = Int.MAX_VALUE,
-
-        // TODO: remove redundant defaults after API/SDK is fixed
-        supportedMediaTypes = "",
-        xmlRootAttributes = emptyList(),
-        responseProfiles = emptyList(),
     )
 
     companion object {

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -103,7 +103,9 @@ class DeviceProfileBuilder(
         for (i in SUPPORTED_CONTAINER_FORMATS.indices) {
             val container = SUPPORTED_CONTAINER_FORMATS[i]
             if (supportedVideoCodecs[i].isNotEmpty()) {
-                containerProfiles.add(ContainerProfile(type = DlnaProfileType.VIDEO, container = container, conditions = emptyList()))
+                containerProfiles.add(
+                    ContainerProfile(type = DlnaProfileType.VIDEO, container = container, conditions = emptyList()),
+                )
                 directPlayProfiles.add(
                     DirectPlayProfile(
                         type = DlnaProfileType.VIDEO,
@@ -114,7 +116,9 @@ class DeviceProfileBuilder(
                 )
             }
             if (supportedAudioCodecs[i].isNotEmpty()) {
-                containerProfiles.add(ContainerProfile(type = DlnaProfileType.AUDIO, container = container, conditions = emptyList()))
+                containerProfiles.add(
+                    ContainerProfile(type = DlnaProfileType.AUDIO, container = container, conditions = emptyList()),
+                )
                 directPlayProfiles.add(
                     DirectPlayProfile(
                         type = DlnaProfileType.AUDIO,

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -23,6 +23,7 @@ import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.api.operations.VideosApi
 import org.jellyfin.sdk.model.api.MediaProtocol
 import org.jellyfin.sdk.model.api.MediaStream
+import org.jellyfin.sdk.model.api.MediaStreamProtocol
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
@@ -242,7 +243,7 @@ class QueueManager(
             PlayMethod.TRANSCODE -> {
                 val transcodingPath = requireNotNull(sourceInfo.transcodingUrl) { "Missing transcode URL" }
                 val protocol = sourceInfo.transcodingSubProtocol
-                require(protocol == "hls") { "Unsupported transcode protocol '$protocol'" }
+                require(protocol == MediaStreamProtocol.HLS) { "Unsupported transcode protocol '$protocol'" }
                 val transcodingUrl = apiClient.createUrl(transcodingPath)
                 val factory = get<HlsMediaSource.Factory>().setAllowChunklessPreparation(true)
 

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -34,7 +34,6 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
             val response by mediaInfoApi.getPostedPlaybackInfo(
                 itemId = itemId,
                 data = PlaybackInfoDto(
-                    userId = apiClient.userId,
                     // We need to remove the dashes so that the server can find the correct media source.
                     // And if we didn't pass the mediaSourceId, our stream indices would silently get ignored.
                     // https://github.com/jellyfin/jellyfin/blob/9a35fd673203cfaf0098138b2768750f4818b3ab/Jellyfin.Api/Helpers/MediaInfoHelper.cs#L196-L201
@@ -60,8 +59,8 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
 
         // Load additional item info if possible
         val item = try {
-            val response by itemsApi.getItemsByUserId(ids = listOf(itemId))
-            response.items?.firstOrNull()
+            val response by itemsApi.getItems(ids = listOf(itemId))
+            response.items.firstOrNull()
         } catch (e: ApiClientException) {
             Timber.e(e, "Failed to load item for media source $itemId")
             null

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -3,10 +3,10 @@ package org.jellyfin.mobile.player.source
 import org.jellyfin.mobile.player.PlayerException
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.exception.ApiClientException
-import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
-import org.jellyfin.sdk.api.operations.ItemsApi
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.operations.MediaInfoApi
+import org.jellyfin.sdk.api.operations.UserLibraryApi
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
@@ -15,7 +15,7 @@ import java.util.UUID
 
 class MediaSourceResolver(private val apiClient: ApiClient) {
     private val mediaInfoApi: MediaInfoApi = apiClient.mediaInfoApi
-    private val itemsApi: ItemsApi = apiClient.itemsApi
+    private val userLibraryApi: UserLibraryApi = apiClient.userLibraryApi
 
     @Suppress("ReturnCount")
     suspend fun resolveMediaSource(
@@ -59,8 +59,7 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
 
         // Load additional item info if possible
         val item = try {
-            val response by itemsApi.getItems(ids = listOf(itemId))
-            response.items.firstOrNull()
+            userLibraryApi.getItem(itemId).content
         } catch (e: ApiClientException) {
             Timber.e(e, "Failed to load item for media source $itemId")
             null

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ compose-foundation = "1.6.8"
 compose-material = "1.6.8"
 
 # Network
-jellyfin-sdk = "1.4.7"
+jellyfin-sdk = "1.6.1"
 okhttp = "4.12.0"
 coil = "2.6.0"
 cronet-embedded = "119.6045.31"


### PR DESCRIPTION
**Changes**

Updated SDK version and fixed build errors.

Also added the API authorization header to exoplayer since the access token is no longer passed via URL for Android Auto (see https://github.com/jellyfin/jellyfin-sdk-kotlin/pull/871).

I have tested the Android Auto functionality and it seems to work fine. The only thing I cannot test and suspect that may not work is casting. Not sure how I would add the header there since CastPlayer cannot use a DataSource.Factory. In https://github.com/google/ExoPlayer/issues/4760 they claim that the receiver app is responsible for authentication. Not sure if this is implemented in [jellyfin/jellyfin-chromecast](https://github.com/jellyfin/jellyfin-chromecast) though.



