### PR TITLE
Compile against SDK 35 (Android 15)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
 
 android {
     namespace = "org.jellyfin.mobile"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
Should not require any changes since it's only the compileSdk and not the targetSdk.