### PR TITLE
Load media session artwork from content provider

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,8 +71,7 @@
         <service
             android:name=".webapp.RemotePlayerService"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback">
-        </service>
+            android:foregroundServiceType="mediaPlayback" />
 
         <service
             android:name="org.jellyfin.mobile.player.audio.MediaService"
@@ -88,6 +87,13 @@
             android:name="androidx.mediarouter.media.MediaTransferReceiver"
             android:exported="true"
             tools:ignore="ExportedReceiver" />
+
+        <provider
+            android:name=".ui.content.ImageProvider"
+            android:authorities="${applicationId}.image-provider"
+            android:exported="true"
+            android:grantUriPermissions="true"
+            android:readPermission="android.permission.MEDIA_CONTENT_CONTROL" />
 
         <meta-data
             android:name="com.google.android.gms.version"

--- a/app/src/main/java/org/jellyfin/mobile/ui/content/ImageProvider.kt
+++ b/app/src/main/java/org/jellyfin/mobile/ui/content/ImageProvider.kt
@@ -1,0 +1,152 @@
+package org.jellyfin.mobile.ui.content
+
+import android.content.ContentProvider
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.res.AssetFileDescriptor
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.graphics.Point
+import android.media.MediaMetadata
+import android.net.Uri
+import android.os.Bundle
+import android.os.ParcelFileDescriptor
+import androidx.core.os.BundleCompat
+import coil.ImageLoader
+import coil.annotation.ExperimentalCoilApi
+import coil.executeBlocking
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import org.jellyfin.mobile.BuildConfig
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
+import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
+import org.jellyfin.sdk.api.operations.ImageApi
+import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.io.FileNotFoundException
+import java.util.UUID
+
+class ImageProvider : ContentProvider(), KoinComponent {
+
+    companion object {
+        const val AUTHORITY = "${BuildConfig.APPLICATION_ID}.image-provider"
+
+        fun buildItemUri(itemId: UUID, imageType: ImageType, imageTag: String?): Uri {
+            return Uri.Builder()
+                .scheme(ContentResolver.SCHEME_CONTENT)
+                .authority(AUTHORITY)
+                .appendPath("item")
+                .appendPath(itemId.toString())
+                .appendPath(imageType.name)
+                .apply {
+                    if (imageTag != null) {
+                        appendPath(imageTag)
+                    }
+                }
+                .build()
+        }
+    }
+
+    private val apiClient: ApiClient by inject()
+    private val imageApi: ImageApi by lazy { apiClient.imageApi }
+    private val imageLoader: ImageLoader by inject()
+
+    override fun onCreate(): Boolean = true
+
+    override fun getType(uri: Uri): String = "image/*"
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String?>?,
+        selection: String?,
+        selectionArgs: Array<out String?>?,
+        sortOrder: String?,
+    ): Cursor = MatrixCursor(arrayOf("_id", MediaMetadata.METADATA_KEY_ART_URI)).apply {
+        addRow(arrayOf(0, uri.toString()))
+    }
+
+    override fun openTypedAssetFile(uri: Uri, mimeTypeFilter: String, opts: Bundle?): AssetFileDescriptor {
+        val size = opts?.let {
+            BundleCompat.getParcelable<Point>(opts, ContentResolver.EXTRA_SIZE, Point::class.java)
+        }
+        return loadImage(uri, size)
+    }
+
+    override fun openAssetFile(uri: Uri, mode: String): AssetFileDescriptor {
+        if (mode != "r") {
+            throw UnsupportedOperationException("Unable to write to image provider")
+        }
+        return loadImage(uri, null)
+    }
+
+    @OptIn(ExperimentalCoilApi::class)
+    private fun loadImage(uri: Uri, size: Point?): AssetFileDescriptor {
+        val pathSegments = uri.pathSegments
+        if (pathSegments.size < 3) {
+            throw FileNotFoundException("Unsupported number of parameters")
+        }
+        val (type, itemIdString, imageTypeString) = pathSegments
+        val imageTag = pathSegments.getOrNull(3)
+
+        val itemId = itemIdString.toUUIDOrNull() ?: throw FileNotFoundException("Invalid item ID $itemIdString")
+        val imageType = try {
+            ImageType.valueOf(imageTypeString)
+        } catch (_: IllegalArgumentException) {
+            throw FileNotFoundException("Invalid image type $imageTypeString")
+        }
+        val imageUrl = when (type) {
+            "item" -> imageApi.getItemImageUrl(
+                itemId = itemId,
+                imageType = imageType,
+                quality = 98,
+                fillWidth = size?.x,
+                fillHeight = size?.y,
+                tag = imageTag,
+            )
+            else -> throw FileNotFoundException("Invalid content type $type")
+        }
+
+        val authorizationHeader = AuthorizationHeaderBuilder.buildHeader(
+            clientName = apiClient.clientInfo.name,
+            clientVersion = apiClient.clientInfo.version,
+            deviceId = apiClient.deviceInfo.id,
+            deviceName = apiClient.deviceInfo.name,
+            accessToken = apiClient.accessToken,
+        )
+        val imageRequest = ImageRequest.Builder(context!!)
+            .data(imageUrl)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .addHeader("Authorization", authorizationHeader)
+            .build()
+
+        val imageResult = imageLoader.executeBlocking(imageRequest)
+        if (imageResult !is SuccessResult) {
+            throw FileNotFoundException("Failed to load image")
+        }
+
+        val snapshot = imageResult.diskCacheKey?.let { cacheKey -> imageLoader.diskCache?.openSnapshot(cacheKey) }
+            ?: throw FileNotFoundException("Failed to load image")
+
+        return snapshot.use { snapshot ->
+            val file = snapshot.data.toFile()
+            val parcelFileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            AssetFileDescriptor(parcelFileDescriptor, 0, file.length())
+        }
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? {
+        throw UnsupportedOperationException()
+    }
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String?>?): Int {
+        throw UnsupportedOperationException()
+    }
+
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String?>?): Int {
+        throw UnsupportedOperationException()
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
@@ -12,7 +12,9 @@ import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.analytics.AnalyticsCollector
 import org.jellyfin.mobile.player.source.JellyfinMediaSource
+import org.jellyfin.mobile.ui.content.ImageProvider
 import org.jellyfin.mobile.utils.extensions.width
+import org.jellyfin.sdk.model.api.ImageType
 import com.google.android.exoplayer2.audio.AudioAttributes as ExoPlayerAudioAttributes
 
 inline fun MediaSession.applyDefaultLocalAudioAttributes(contentType: Int) {
@@ -29,7 +31,12 @@ inline fun MediaSession.applyDefaultLocalAudioAttributes(contentType: Int) {
 fun JellyfinMediaSource.toMediaMetadata(): MediaMetadata = MediaMetadata.Builder().apply {
     putString(MediaMetadata.METADATA_KEY_MEDIA_ID, itemId.toString())
     putString(MediaMetadata.METADATA_KEY_TITLE, name)
+    item?.artists?.joinToString()?.let { artists ->
+        putString(MediaMetadata.METADATA_KEY_ARTIST, artists)
+    }
     putLong(MediaMetadata.METADATA_KEY_DURATION, runTimeMs)
+    val imageUri = ImageProvider.buildItemUri(itemId, ImageType.PRIMARY, item?.imageTags?.get(ImageType.PRIMARY))
+    putString(MediaMetadata.METADATA_KEY_ART_URI, imageUri.toString())
 }.build()
 
 fun MediaSession.setPlaybackState(playbackState: Int, position: Long, playbackActions: Long) {


### PR DESCRIPTION
Instead of using the large icon property on the notification, we can pass an artwork uri into the media metadata of our media session. This uri can refer to a content provider in the app that loads the image from the server.

Follow-up to #1493.