### PR TITLE
Remove back-interceptor to not break expected behavior

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -211,17 +211,6 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     }
 
     /**
-     * Exit fullscreen on first back-button press, otherwise exit directly
-     */
-    override fun onInterceptBackPressed(): Boolean = when {
-        playerFullscreenHelper.isFullscreen -> {
-            toggleFullscreen()
-            true
-        }
-        else -> super.onInterceptBackPressed()
-    }
-
-    /**
      * Handle current orientation and update fullscreen state and switcher icon
      */
     private fun updateFullscreenState(configuration: Configuration) {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
This removes the overrides for the back gesture in the integrated player.
The original behaviour breaks native android gestures and makes it impossible to leave playback without using the X-button. This is highly irritating since it deviates from default-android behaviour.

**Issues**
Fixes #1212

