### PR TITLE
Implement DownloadManagement app feature in nativeshell

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -1,18 +1,19 @@
 const features = [
-    "filedownload",
+    "castmenuhashchange"
+    "clientsettings",
     "displaylanguage",
-    "subtitleappearancesettings",
-    "subtitleburnsettings",
-    //'sharing',
+    "downloadmanagement",
     "exit",
+    "externallinks",
+    "filedownload",
     "htmlaudioautoplay",
     "htmlvideoautoplay",
-    "externallinks",
-    "clientsettings",
     "multiserver",
     "physicalvolumecontrol",
     "remotecontrol",
-    "castmenuhashchange"
+    "subtitleappearancesettings",
+    "subtitleburnsettings",
+//    'sharing'
 ];
 
 const plugins = [
@@ -65,6 +66,10 @@ window.NativeShell = {
 
     downloadFiles(downloadInfo) {
         window.NativeInterface.downloadFiles(JSON.stringify(downloadInfo));
+    },
+
+    openDownloadManager() {
+        window.NativeInterface.openDownloadManager();
     },
 
     openClientSettings() {

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -145,6 +145,11 @@ class NativeInterface(private val context: Context) : KoinComponent {
     }
 
     @JavascriptInterface
+    fun openDownloadManager() {
+        emitEvent(ActivityEvent.OpenDownloads)
+    }
+
+    @JavascriptInterface
     fun openClientSettings() {
         emitEvent(ActivityEvent.OpenSettings)
     }


### PR DESCRIPTION
Related: jellyfin/jellyfin-web#6833

**Changes**

- Implement support for the new "downloadmanagement" app feature in the nativeshell. This will add a "downloads" link to the app menu so the user can access downloads when connected to a server.
- Sort features array in our JS file.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
