### PR TITLE
Fix webview closing on unimportant network errors

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
@@ -1,6 +1,5 @@
 package org.jellyfin.mobile.webapp
 
-import android.net.Uri
 import android.net.http.SslError
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceRequest
@@ -84,7 +83,7 @@ abstract class JellyfinWebViewClient(
         val errorMessage = errorResponse.data?.run { bufferedReader().use(Reader::readText) }
         Timber.e("Received WebView HTTP %d error: %s", errorResponse.statusCode, errorMessage)
 
-        if (request.url == Uri.parse(view.url)) onErrorReceived()
+        if (request.isForMainFrame) onErrorReceived()
     }
 
     override fun onReceivedError(
@@ -103,21 +102,11 @@ abstract class JellyfinWebViewClient(
         Timber.e("Received WebView error %d at %s: %s", errorCode, request.url.toString(), description)
 
         // Abort on some specific error codes or when the request url matches the server url
-        when (errorCode) {
-            ERROR_HOST_LOOKUP,
-            ERROR_CONNECT,
-            ERROR_TIMEOUT,
-            ERROR_REDIRECT_LOOP,
-            ERROR_UNSUPPORTED_SCHEME,
-            ERROR_FAILED_SSL_HANDSHAKE,
-            -> onErrorReceived()
-            else -> if (request.url == Uri.parse(view.url)) onErrorReceived()
-        }
+        if (request.isForMainFrame) onErrorReceived()
     }
 
     override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
         Timber.e("Received SSL error: %s", error.toString())
         handler.cancel()
-        onErrorReceived()
     }
 }


### PR DESCRIPTION
When the app opens it tries to load the web-ui from the server. In case that fails (e.g. server is offline or doesn't host the web-ui) it should go back to the connection screen and show an error.
Until now our behavior was a bit too aggressive, it would pop back for pretty much ALL network errors. This would cause issues for users using custom CSS with dead links (CSS import/background images etc) as the app would think those meant the app could not load the webview.

**Changes**

- Update the error handling to only close the webview if the error is triggered on the main frame (the webview page that we load) and not for secondary resources.
- Remove onErrorReceived call from onReceivedSslError as our cancelling of the handler will already propagate to the other error handlers

**Issues**

Fixes #544