### PR TITLE
Update coil dependency from 2.7.0 to 3.2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -145,7 +145,8 @@ dependencies {
     }
     implementation(libs.okhttp)
     implementation(libs.okio)
-    implementation(libs.coil)
+    implementation(libs.bundles.coil)
+    implementation(libs.coil.network)
 
     // Media
     implementation(libs.androidx.media)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,7 +146,6 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.okio)
     implementation(libs.bundles.coil)
-    implementation(libs.coil.network)
 
     // Media
     implementation(libs.androidx.media)

--- a/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
@@ -21,7 +21,7 @@ import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.source.SingleSampleMediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ts.TsExtractor
-import coil.ImageLoader
+import coil3.ImageLoader
 import kotlinx.coroutines.channels.Channel
 import okhttp3.OkHttpClient
 import org.jellyfin.mobile.MainViewModel

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
@@ -12,9 +12,7 @@ import kotlinx.serialization.json.Json.Default.decodeFromString
 import org.jellyfin.mobile.data.entity.DownloadEntity.Key.ITEM_ID
 import org.jellyfin.mobile.data.entity.DownloadEntity.Key.TABLE_NAME
 import org.jellyfin.mobile.player.source.LocalJellyfinMediaSource
-import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.extensions.toFileSize
-import java.io.File
 
 @Entity(
     tableName = TABLE_NAME,
@@ -58,9 +56,6 @@ data class DownloadEntity(
 
     constructor(mediaSource: LocalJellyfinMediaSource) :
         this(mediaSource.id, mediaSource)
-
-    @Ignore
-    val thumbnailPath: String = File(mediaSource.localDirectoryUri, Constants.DOWNLOAD_THUMBNAIL_FILENAME).canonicalPath
 
     @Ignore
     val fileSize: String = mediaSource.downloadSize.toFileSize()

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
@@ -1,7 +1,5 @@
 package org.jellyfin.mobile.data.entity
 
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
@@ -62,9 +60,7 @@ data class DownloadEntity(
         this(mediaSource.id, mediaSource)
 
     @Ignore
-    val thumbnail: Bitmap? = BitmapFactory.decodeFile(
-        File(mediaSource.localDirectoryUri, Constants.DOWNLOAD_THUMBNAIL_FILENAME).canonicalPath,
-    )
+    val thumbnailPath: String = File(mediaSource.localDirectoryUri, Constants.DOWNLOAD_THUMBNAIL_FILENAME).canonicalPath
 
     @Ignore
     val fileSize: String = mediaSource.downloadSize.toFileSize()

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadUtils.kt
@@ -7,7 +7,6 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager.PERMISSION_GRANTED
-import android.graphics.Bitmap
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -21,15 +20,10 @@ import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.media3.exoplayer.scheduler.Requirements
-import coil3.ImageLoader
-import coil3.request.ImageRequest
-import coil3.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import okio.buffer
-import okio.sink
 import org.jellyfin.mobile.MainActivity
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.app.AppPreferences
@@ -45,10 +39,8 @@ import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.extractId
 import org.jellyfin.mobile.utils.requestPermission
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.serializer.toUUID
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -71,7 +63,6 @@ class DownloadUtils(
     private val contentId: String
     private val downloadDao: DownloadDao by inject()
     private val apiClient: ApiClient = get()
-    private val imageLoader: ImageLoader by inject()
     private val mediaSourceResolver: MediaSourceResolver by inject()
     private val deviceProfileBuilder: DeviceProfileBuilder by inject()
     private val deviceProfile = deviceProfileBuilder.getDeviceProfile()
@@ -166,7 +157,6 @@ class DownloadUtils(
         val jellyfinDownloadTracker = JellyfinDownloadTracker(jellyfinMediaSource)
         downloadTracker.addListener(jellyfinDownloadTracker)
         downloadMediaFile(jellyfinMediaSource)
-        downloadThumbnail()
         downloadExternalSubtitles(jellyfinMediaSource)
     }
 
@@ -184,28 +174,6 @@ class DownloadUtils(
             downloadRequest,
             false,
         )
-    }
-
-    private suspend fun downloadThumbnail() {
-        val size = context.resources.getDimensionPixelSize(R.dimen.media_notification_height)
-
-        val imageUrl = apiClient.imageApi.getItemImageUrl(
-            itemId = itemUUID,
-            imageType = ImageType.PRIMARY,
-            maxWidth = size,
-            maxHeight = size,
-        )
-        val imageRequest = ImageRequest.Builder(context).data(imageUrl).build()
-        val bitmap: Bitmap = imageLoader.execute(imageRequest).image?.toBitmap() ?: throw IOException(
-            context.getString(R.string.failed_thumbnail),
-        )
-
-        val thumbnailFile = File(downloadFolder, Constants.DOWNLOAD_THUMBNAIL_FILENAME)
-        val sink = thumbnailFile.sink().buffer()
-        bitmap.compress(Bitmap.CompressFormat.JPEG, THUMBNAIL_DOWNLOAD_QUALITY, sink.outputStream())
-        withContext(Dispatchers.IO) {
-            sink.close()
-        }
     }
 
     private fun downloadExternalSubtitles(jellyfinMediaSource: JellyfinMediaSource) {
@@ -309,9 +277,5 @@ class DownloadUtils(
                 downloadTracker.removeListener(this)
             }
         }
-    }
-
-    private companion object {
-        const val THUMBNAIL_DOWNLOAD_QUALITY = 80
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadUtils.kt
@@ -17,13 +17,13 @@ import android.os.Build.VERSION_CODES.P
 import android.util.AndroidException
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
-import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.media3.exoplayer.scheduler.Requirements
-import coil.ImageLoader
-import coil.request.ImageRequest
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -196,7 +196,7 @@ class DownloadUtils(
             maxHeight = size,
         )
         val imageRequest = ImageRequest.Builder(context).data(imageUrl).build()
-        val bitmap: Bitmap = imageLoader.execute(imageRequest).drawable?.toBitmap() ?: throw IOException(
+        val bitmap: Bitmap = imageLoader.execute(imageRequest).image?.toBitmap() ?: throw IOException(
             context.getString(R.string.failed_thumbnail),
         )
 

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
@@ -62,8 +62,8 @@ class DownloadsAdapter(
 
             val thumbnailUrl = getThumbnailUrl(context, downloadEntity.mediaSource.itemId)
             binding.imageViewThumbnail.load(thumbnailUrl) {
-                fallback(R.drawable.ic_local_movies_white_128)
-                error(R.drawable.ic_local_movies_white_128)
+                fallback(R.drawable.ic_local_movies_white_64)
+                error(R.drawable.ic_local_movies_white_64)
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.mobile.downloads
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
@@ -10,9 +11,14 @@ import coil3.request.fallback
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.data.entity.DownloadEntity
 import org.jellyfin.mobile.databinding.DownloadItemBinding
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.ImageType
+import java.util.UUID
 
 class DownloadsAdapter(
+    private val apiClient: ApiClient,
     private val onItemClick: (DownloadEntity) -> Unit,
     private val onItemHold: (DownloadEntity) -> Unit,
 ) : ListAdapter<DownloadEntity, DownloadsAdapter.DownloadViewHolder>(
@@ -54,10 +60,22 @@ class DownloadsAdapter(
                 true
             }
 
-            binding.imageViewThumbnail.load(downloadEntity.thumbnailPath) {
+            val thumbnailUrl = getThumbnailUrl(context, downloadEntity.mediaSource.itemId)
+            binding.imageViewThumbnail.load(thumbnailUrl) {
                 fallback(R.drawable.ic_local_movies_white_128)
                 error(R.drawable.ic_local_movies_white_128)
             }
         }
+    }
+
+    fun getThumbnailUrl(context: Context, mediaSourceItemId: UUID): String? {
+        val size = context.resources.getDimensionPixelSize(R.dimen.movie_thumbnail_list_size)
+
+        return apiClient.imageApi.getItemImageUrl(
+            itemId = mediaSourceItemId,
+            imageType = ImageType.PRIMARY,
+            maxWidth = size,
+            maxHeight = size,
+        )
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
@@ -4,6 +4,9 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import coil3.load
+import coil3.request.error
+import coil3.request.fallback
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.data.entity.DownloadEntity
 import org.jellyfin.mobile.databinding.DownloadItemBinding
@@ -27,11 +30,6 @@ class DownloadsAdapter(
     inner class DownloadViewHolder(private val binding: DownloadItemBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(downloadEntity: DownloadEntity) {
-            if (downloadEntity.thumbnail == null) {
-                onItemHold(downloadEntity)
-                return
-            }
-
             val context = itemView.context
 
             val mediaItem: BaseItemDto? = downloadEntity.mediaSource.item
@@ -56,7 +54,10 @@ class DownloadsAdapter(
                 true
             }
 
-            binding.imageViewThumbnail.setImageBitmap(downloadEntity.thumbnail)
+            binding.imageViewThumbnail.load(downloadEntity.thumbnailPath) {
+                fallback(R.drawable.ic_local_movies_white_128)
+                error(R.drawable.ic_local_movies_white_128)
+            }
         }
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsFragment.kt
@@ -68,7 +68,6 @@ class DownloadsFragment : Fragment(), KoinComponent {
     }
 
     private fun onDownloadItemHold(download: DownloadEntity) {
-        val itemMissing = download.thumbnail == null
-        activityEventHandler.emit(ActivityEvent.RemoveDownload(download.mediaSource, force = itemMissing))
+        activityEventHandler.emit(ActivityEvent.RemoveDownload(download.mediaSource))
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsFragment.kt
@@ -18,12 +18,14 @@ import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.utils.applyWindowInsetsAsMargins
 import org.jellyfin.mobile.utils.extensions.requireMainActivity
 import org.jellyfin.mobile.utils.withThemedContext
+import org.jellyfin.sdk.api.client.ApiClient
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class DownloadsFragment : Fragment(), KoinComponent {
     private val viewModel: DownloadsViewModel by inject()
     private val activityEventHandler: ActivityEventHandler by inject()
+    private val apiClient: ApiClient by inject()
     private lateinit var adapter: DownloadsAdapter
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -38,6 +40,7 @@ class DownloadsFragment : Fragment(), KoinComponent {
         }
 
         adapter = DownloadsAdapter(
+            apiClient,
             onItemClick = { download -> onDownloadItemClick(download) },
             onItemHold = { download -> onDownloadItemHold(download) },
         )

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -11,11 +11,11 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
-import coil.ImageLoader
-import coil.request.ImageRequest
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -177,7 +177,7 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
             )
 
             val imageRequest = ImageRequest.Builder(context).data(imageUrl).build()
-            imageLoader.execute(imageRequest).drawable?.toBitmap()
+            imageLoader.execute(imageRequest).image?.toBitmap()
         }
     }
 

--- a/app/src/main/java/org/jellyfin/mobile/ui/content/ImageProvider.kt
+++ b/app/src/main/java/org/jellyfin/mobile/ui/content/ImageProvider.kt
@@ -12,12 +12,13 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.ParcelFileDescriptor
 import androidx.core.os.BundleCompat
-import coil.ImageLoader
-import coil.annotation.ExperimentalCoilApi
-import coil.executeBlocking
-import coil.request.CachePolicy
-import coil.request.ImageRequest
-import coil.request.SuccessResult
+import coil3.ImageLoader
+import coil3.executeBlocking
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
 import org.jellyfin.mobile.BuildConfig
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.imageApi
@@ -86,7 +87,6 @@ class ImageProvider : ContentProvider(), KoinComponent {
     }
 
     @Suppress("ThrowsCount")
-    @OptIn(ExperimentalCoilApi::class)
     private fun loadImage(uri: Uri, size: Point?): AssetFileDescriptor {
         val pathSegments = uri.pathSegments
         if (pathSegments.size < PATH_SEGMENTS_COUNT) {
@@ -120,10 +120,14 @@ class ImageProvider : ContentProvider(), KoinComponent {
             deviceName = apiClient.deviceInfo.name,
             accessToken = apiClient.accessToken,
         )
+        val headers = NetworkHeaders.Builder()
+            .set("Authorization", authorizationHeader)
+            .build()
+
         val imageRequest = ImageRequest.Builder(context!!)
             .data(imageUrl)
             .diskCachePolicy(CachePolicy.ENABLED)
-            .addHeader("Authorization", authorizationHeader)
+            .httpHeaders(headers)
             .build()
 
         val imageResult = imageLoader.executeBlocking(imageRequest)

--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -25,10 +25,10 @@ import android.os.PowerManager
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.getSystemService
-import androidx.core.graphics.drawable.toBitmap
 import androidx.core.text.HtmlCompat
-import coil.ImageLoader
-import coil.request.ImageRequest
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.toBitmap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -218,7 +218,7 @@ class RemotePlayerService : Service(), CoroutineScope {
             val cachedBitmap = largeItemIcon?.takeIf { itemId == currentItemId }
             val bitmap = cachedBitmap ?: if (!imageUrl.isNullOrEmpty()) {
                 val request = ImageRequest.Builder(this@RemotePlayerService).data(imageUrl).build()
-                imageLoader.execute(request).drawable?.toBitmap()?.also { bitmap ->
+                imageLoader.execute(request).image?.toBitmap()?.also { bitmap ->
                     largeItemIcon = bitmap // Cache bitmap for later use
                 }
             } else {

--- a/app/src/main/res/drawable/ic_local_movies_white_128.xml
+++ b/app/src/main/res/drawable/ic_local_movies_white_128.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,3v2h-2L16,3L8,3v2L6,5L6,3L4,3v18h2v-2h2v2h8v-2h2v2h2L20,3h-2zM8,17L6,17v-2h2v2zM8,13L6,13v-2h2v2zM8,9L6,9L6,7h2v2zM18,17h-2v-2h2v2zM18,13h-2v-2h2v2zM18,9h-2L16,7h2v2z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_local_movies_white_64.xml
+++ b/app/src/main/res/drawable/ic_local_movies_white_64.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="128dp"
-    android:height="128dp"
+    android:width="64dp"
+    android:height="64dp"
     android:tint="#FFFFFF"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/layout/download_item.xml
+++ b/app/src/main/res/layout/download_item.xml
@@ -1,42 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:baselineAligned="false"
+    android:orientation="horizontal"
     android:padding="16dp">
 
     <ImageView
         android:id="@+id/imageViewThumbnail"
-        android:layout_width="0dp"
-        android:layout_weight="1.5"
+        android:layout_width="@dimen/movie_thumbnail_list_size"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
         android:adjustViewBounds="true"
-        android:contentDescription="@string/thumbnail_desc" />
+        android:contentDescription="@string/thumbnail_desc"
+        tools:srcCompat="@tools:sample/backgrounds/scenic" />
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_weight="2"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="1"
         android:orientation="vertical"
-        android:gravity="center"
         android:paddingHorizontal="16dp">
 
         <TextView
             android:id="@+id/textViewName"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="21sp" />
+            android:textSize="21sp"
+            tools:text="Movie Name" />
 
         <TextView
             android:id="@+id/textViewDescription"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:text="This is a movie description" />
 
         <TextView
             android:id="@+id/textViewFileSize"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:text="100MB" />
 
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_downloads.xml
+++ b/app/src/main/res/layout/fragment_downloads.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/theme_background">
@@ -18,7 +19,8 @@
         android:layout_height="0dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        tools:listitem="@layout/download_item" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,6 +2,8 @@
 <resources>
     <dimen name="media_notification_height">128dp</dimen>
 
+    <dimen name="movie_thumbnail_list_size">64dp</dimen>
+
     <dimen name="exo_title_text_size">16sp</dimen>
     <dimen name="exo_player_controls_display_padding">12dp</dimen>
     <dimen name="exo_center_icon_padding">12dp</dimen>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ compose-material-icons = "1.7.8"
 jellyfin-sdk = "1.6.8"
 okhttp = "4.12.0"
 okio = "3.12.0"
-coil = "2.7.0"
+coil = "3.2.0"
 
 # Media
 androidx-media = "1.7.0"
@@ -116,7 +116,8 @@ compose-material-icons-extended = { group = "androidx.compose.material", name = 
 jellyfin-sdk = { group = "org.jellyfin.sdk", name = "jellyfin-core", version.ref = "jellyfin-sdk" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
-coil = { group = "io.coil-kt", name = "coil-base", version.ref = "coil" }
+coil = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
+coil-network = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 
 # Media
 androidx-media = { group = "androidx.media", name = "media", version.ref = "androidx-media" }
@@ -157,6 +158,7 @@ detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-form
 [bundles]
 coroutines = ["coroutines-core", "coroutines-android"]
 koin = ["koin", "koin-compose"]
+coil = ["coil", "coil-network"]
 androidx-lifecycle = [
     "androidx-lifecycle-viewmodel",
     "androidx-lifecycle-livedata",


### PR DESCRIPTION
Update coil dependency from 2.7.0 to 3.2.0

**Changes**
Use coil to display the download thumbnail with error handling.  This fixes issue with bitmap decoding being done in the RecyclerView adapter.

