### PR TITLE
Use kotlin time over manual math for tick conversions

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -168,7 +168,7 @@ class ExternalPlayer(
         playerContract.launch(playerIntent)
         Timber.d(
             "Starting playback [id=${source.itemId}, title=${source.name}, " +
-                "playMethod=${source.playMethod}, startTimeMs=${source.startTime.inWholeMilliseconds}]",
+                "playMethod=${source.playMethod}, startTime=${source.startTime}]",
         )
     }
 

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -99,7 +99,7 @@ class ExternalPlayer(
                 itemId = itemId,
                 mediaSourceId = playOptions.mediaSourceId,
                 deviceProfile = externalPlayerProfile,
-                startTimeTicks = playOptions.startPositionTicks,
+                startTime = playOptions.startPosition,
                 audioStreamIndex = playOptions.audioStreamIndex,
                 subtitleStreamIndex = playOptions.subtitleStreamIndex,
                 maxStreamingBitrate = Int.MAX_VALUE, // ensure we always direct play
@@ -139,7 +139,7 @@ class ExternalPlayer(
             }
             setDataAndType(url.toUri(), "video/*")
             putExtra("title", source.name)
-            putExtra("position", source.startTimeMs.toInt())
+            putExtra("position", source.startTime.inWholeMilliseconds.toInt())
             putExtra("return_result", true)
             putExtra("secure_uri", true)
 
@@ -168,7 +168,7 @@ class ExternalPlayer(
         playerContract.launch(playerIntent)
         Timber.d(
             "Starting playback [id=${source.itemId}, title=${source.name}, " +
-                "playMethod=${source.playMethod}, startTimeMs=${source.startTimeMs}]",
+                "playMethod=${source.playMethod}, startTimeMs=${source.startTime.inWholeMilliseconds}]",
         )
     }
 

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
@@ -8,7 +8,6 @@ import org.jellyfin.mobile.events.ActivityEventHandler
 import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.interaction.PlayerEvent
 import org.jellyfin.mobile.settings.VideoPlayerType
-import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.extensions.ticks
 import org.json.JSONObject
 

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
@@ -9,6 +9,7 @@ import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.interaction.PlayerEvent
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
+import org.jellyfin.sdk.model.extensions.ticks
 import org.json.JSONObject
 
 @Suppress("unused")
@@ -50,7 +51,7 @@ class NativePlayer(
 
     @JavascriptInterface
     fun seek(ticks: Long) {
-        playerEventChannel.trySend(PlayerEvent.Seek(ticks / Constants.TICKS_PER_MS))
+        playerEventChannel.trySend(PlayerEvent.Seek(ticks.ticks.inWholeMilliseconds))
     }
 
     @JavascriptInterface

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
@@ -8,8 +8,9 @@ import org.jellyfin.mobile.events.ActivityEventHandler
 import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.interaction.PlayerEvent
 import org.jellyfin.mobile.settings.VideoPlayerType
-import org.jellyfin.sdk.model.extensions.ticks
 import org.json.JSONObject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("unused")
 class NativePlayer(
@@ -49,13 +50,13 @@ class NativePlayer(
     }
 
     @JavascriptInterface
-    fun seek(ticks: Long) {
-        playerEventChannel.trySend(PlayerEvent.Seek(ticks.ticks.inWholeMilliseconds))
+    fun seek(duration: Duration) {
+        playerEventChannel.trySend(PlayerEvent.Seek(duration))
     }
 
     @JavascriptInterface
     fun seekMs(ms: Long) {
-        playerEventChannel.trySend(PlayerEvent.Seek(ms))
+        playerEventChannel.trySend(PlayerEvent.Seek(ms.milliseconds))
     }
 
     @JavascriptInterface

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
@@ -13,6 +13,7 @@ import org.jellyfin.mobile.data.entity.DownloadEntity.Key.ITEM_ID
 import org.jellyfin.mobile.data.entity.DownloadEntity.Key.TABLE_NAME
 import org.jellyfin.mobile.player.source.LocalJellyfinMediaSource
 import org.jellyfin.mobile.utils.extensions.toFileSize
+import kotlin.time.Duration
 
 @Entity(
     tableName = TABLE_NAME,
@@ -31,18 +32,18 @@ data class DownloadEntity(
     /**
      * Converts the [mediaSource] string to a [LocalJellyfinMediaSource] object.
      *
-     * @param startTimeMs The start time in milliseconds. If null, the default start time is used.
+     * @param startTime The start time as a kotlin.time.Duration. If null, the default start time is used.
      * @param audioStreamIndex The index of the audio stream to select. If null, the default audio stream is used.
      * @param subtitleStreamIndex The index of the subtitle stream to select. If -1, subtitles are disabled. If null, the default subtitle stream is used.
      */
     fun asMediaSource(
-        startTimeMs: Long? = null,
+        startTime: Duration? = null,
         audioStreamIndex: Int? = null,
         subtitleStreamIndex: Int? = null,
     ): LocalJellyfinMediaSource = mediaSource
         .also { localJellyfinMediaSource ->
-            startTimeMs
-                ?.let { localJellyfinMediaSource.startTimeMs = it }
+            startTime
+                ?.let { localJellyfinMediaSource.startTime = it }
             audioStreamIndex
                 ?.let { localJellyfinMediaSource.mediaStreams[it] }
                 ?.let(localJellyfinMediaSource::selectAudioStream)

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsFragment.kt
@@ -62,7 +62,7 @@ class DownloadsFragment : Fragment(), KoinComponent {
             ids = listOf(download.mediaSource.itemId),
             mediaSourceId = download.mediaSource.id,
             startIndex = 0,
-            startPositionTicks = null,
+            startPosition = null,
             audioStreamIndex = 1,
             subtitleStreamIndex = -1,
             playFromDownloads = true,

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -380,7 +380,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
 
     private suspend fun Player.reportPlaybackState() {
         val mediaSource = mediaSourceOrNull as? RemoteJellyfinMediaSource ?: return
-        val playbackPositionMillis = currentPosition
+        val playbackPosition = currentPosition.milliseconds
         if (playbackState != Player.STATE_ENDED) {
             val stream = AudioManager.STREAM_MUSIC
             val volumeRange = audioManager.getVolumeRange(stream)
@@ -396,7 +396,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
                         isPaused = !isPlaying,
                         isMuted = false,
                         canSeek = true,
-                        positionTicks = playbackPositionMillis.milliseconds.inWholeTicks,
+                        positionTicks = playbackPosition.inWholeTicks,
                         volumeLevel = (currentVolume - volumeRange.first) * Constants.PERCENT_MAX / volumeRange.width,
                         repeatMode = RepeatMode.REPEAT_NONE,
                         playbackOrder = PlaybackOrder.DEFAULT,

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -355,7 +355,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
                     isPaused = !isPlaying,
                     isMuted = false,
                     canSeek = true,
-                    positionTicks = mediaSource.startTimeMs * Constants.TICKS_PER_MS,
+                    positionTicks = mediaSource.startTimeMs.milliseconds.inWholeTicks,
                     volumeLevel = audioManager.getVolumeLevelPercent(),
                     repeatMode = RepeatMode.REPEAT_NONE,
                     playbackOrder = PlaybackOrder.DEFAULT,
@@ -397,7 +397,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
                         isPaused = !isPlaying,
                         isMuted = false,
                         canSeek = true,
-                        positionTicks = playbackPositionMillis * Constants.TICKS_PER_MS,
+                        positionTicks = playbackPositionMillis.milliseconds.inWholeTicks,
                         volumeLevel = (currentVolume - volumeRange.first) * Constants.PERCENT_MAX / volumeRange.width,
                         repeatMode = RepeatMode.REPEAT_NONE,
                         playbackOrder = PlaybackOrder.DEFAULT,
@@ -415,7 +415,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
         val hasFinished = player.playbackState == Player.STATE_ENDED
         val lastPositionTicks = when {
             hasFinished -> mediaSource.runTimeTicks
-            else -> player.currentPosition * Constants.TICKS_PER_MS
+            else -> player.currentPosition.milliseconds.inWholeTicks
         }
 
         // viewModelScope may already be cancelled at this point, so we need to fallback

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
@@ -3,18 +3,20 @@ package org.jellyfin.mobile.player.interaction
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import org.jellyfin.mobile.utils.extensions.size
+import org.jellyfin.sdk.model.extensions.ticks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 import java.util.UUID
+import kotlin.time.Duration
 
 @Parcelize
 data class PlayOptions(
     val ids: List<UUID>,
     val mediaSourceId: String?,
     val startIndex: Int,
-    val startPositionTicks: Long?,
+    val startPosition: Duration?,
     val audioStreamIndex: Int?,
     val subtitleStreamIndex: Int?,
     val playFromDownloads: Boolean?,
@@ -31,7 +33,7 @@ data class PlayOptions(
                 } ?: emptyList(),
                 mediaSourceId = json.optString("mediaSourceId"),
                 startIndex = json.optInt("startIndex"),
-                startPositionTicks = json.optLong("startPositionTicks").takeIf { it > 0 },
+                startPosition = (json.optLong("startPositionTicks").takeIf { it > 0 })?.ticks,
                 audioStreamIndex = json.optString("audioStreamIndex").toIntOrNull(),
                 subtitleStreamIndex = json.optString("subtitleStreamIndex").toIntOrNull(),
                 playFromDownloads = false,

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerEvent.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerEvent.kt
@@ -1,10 +1,12 @@
 package org.jellyfin.mobile.player.interaction
 
+import kotlin.time.Duration
+
 sealed class PlayerEvent {
     object Pause : PlayerEvent()
     object Resume : PlayerEvent()
     object Stop : PlayerEvent()
     object Destroy : PlayerEvent()
-    data class Seek(val ms: Long) : PlayerEvent()
+    data class Seek(val duration: Duration) : PlayerEvent()
     data class SetVolume(val volume: Int) : PlayerEvent()
 }

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -30,12 +30,14 @@ import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamProtocol
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.PlayMethod
+import org.jellyfin.sdk.model.extensions.inWholeTicks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.component.inject
 import java.io.File
 import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
 
 class QueueManager(
     private val viewModel: PlayerViewModel,
@@ -179,7 +181,7 @@ class QueueManager(
             itemId = currentMediaSource.itemId,
             mediaSourceId = currentMediaSource.id,
             maxStreamingBitrate = bitrate,
-            startTimeTicks = currentPlayState.position * Constants.TICKS_PER_MS,
+            startTimeTicks = currentPlayState.position.milliseconds.inWholeTicks,
             audioStreamIndex = currentMediaSource.selectedAudioStreamIndex,
             subtitleStreamIndex = currentMediaSource.selectedSubtitleStreamIndex,
             playWhenReady = currentPlayState.playWhenReady,
@@ -388,7 +390,7 @@ class QueueManager(
                 itemId = currentMediaSource.itemId,
                 mediaSourceId = currentMediaSource.id,
                 maxStreamingBitrate = currentMediaSource.maxStreamingBitrate,
-                startTimeTicks = currentPlayState.position * Constants.TICKS_PER_MS,
+                startTimeTicks = currentPlayState.position.milliseconds.inWholeTicks,
                 audioStreamIndex = stream.index,
                 subtitleStreamIndex = currentMediaSource.selectedSubtitleStreamIndex,
                 playWhenReady = currentPlayState.playWhenReady,
@@ -421,7 +423,7 @@ class QueueManager(
                 itemId = mediaSource.itemId,
                 mediaSourceId = mediaSource.id,
                 maxStreamingBitrate = mediaSource.maxStreamingBitrate,
-                startTimeTicks = currentPlayState.position * Constants.TICKS_PER_MS,
+                startTimeTicks = currentPlayState.position.milliseconds.inWholeTicks,
                 audioStreamIndex = mediaSource.selectedAudioStreamIndex,
                 subtitleStreamIndex = stream?.index ?: -1, // -1 disables subtitles, null would select the default subtitle
                 playWhenReady = currentPlayState.playWhenReady,

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -21,7 +21,6 @@ import org.jellyfin.mobile.player.source.JellyfinMediaSource
 import org.jellyfin.mobile.player.source.LocalJellyfinMediaSource
 import org.jellyfin.mobile.player.source.MediaSourceResolver
 import org.jellyfin.mobile.player.source.RemoteJellyfinMediaSource
-import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.api.operations.VideosApi

--- a/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
@@ -8,7 +8,10 @@ import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
+import org.jellyfin.sdk.model.extensions.inWholeTicks
+import org.jellyfin.sdk.model.extensions.ticks
 import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
 
 sealed class JellyfinMediaSource(
     val itemId: UUID,
@@ -25,12 +28,12 @@ sealed class JellyfinMediaSource(
     var startTimeTicks: Long? = playbackDetails?.startTimeTicks
         private set
     var startTimeMs: Long
-        get() = (startTimeTicks ?: 0L) / Constants.TICKS_PER_MS
+        get() = (startTimeTicks ?: 0L).ticks.inWholeMilliseconds
         set(value) {
-            startTimeTicks = value * Constants.TICKS_PER_MS
+            startTimeTicks = value.milliseconds.inWholeTicks
         }
     val runTimeTicks: Long = sourceInfo.runTimeTicks ?: 0
-    val runTimeMs: Long = runTimeTicks / Constants.TICKS_PER_MS
+    val runTimeMs: Long = runTimeTicks.ticks.inWholeTicks
 
     val mediaStreams: List<MediaStream> = sourceInfo.mediaStreams.orEmpty()
     val audioStreams: List<MediaStream>

--- a/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
@@ -8,10 +8,9 @@ import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
-import org.jellyfin.sdk.model.extensions.inWholeTicks
 import org.jellyfin.sdk.model.extensions.ticks
 import java.util.UUID
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration
 
 sealed class JellyfinMediaSource(
     val itemId: UUID,
@@ -25,15 +24,8 @@ sealed class JellyfinMediaSource(
 
     abstract val playMethod: PlayMethod
 
-    var startTimeTicks: Long? = playbackDetails?.startTimeTicks
-        private set
-    var startTimeMs: Long
-        get() = (startTimeTicks ?: 0L).ticks.inWholeMilliseconds
-        set(value) {
-            startTimeTicks = value.milliseconds.inWholeTicks
-        }
-    val runTimeTicks: Long = sourceInfo.runTimeTicks ?: 0
-    val runTimeMs: Long = runTimeTicks.ticks.inWholeTicks
+    var startTime: Duration = playbackDetails?.startTime ?: Duration.ZERO
+    val runTime: Duration = sourceInfo.runTimeTicks?.ticks ?: Duration.ZERO
 
     val mediaStreams: List<MediaStream> = sourceInfo.mediaStreams.orEmpty()
     val audioStreams: List<MediaStream>
@@ -106,7 +98,6 @@ sealed class JellyfinMediaSource(
         audioStreams = audio
         subtitleStreams = subtitles
         externalSubtitleStreams = externalSubtitles
-        this.startTimeTicks = startTimeTicks
     }
 
     /**
@@ -163,7 +154,7 @@ sealed class JellyfinMediaSource(
 }
 
 data class PlaybackDetails(
-    val startTimeTicks: Long?,
+    val startTime: Duration?,
     val audioStreamIndex: Int?,
     val subtitleStreamIndex: Int?,
 )

--- a/app/src/main/java/org/jellyfin/mobile/player/source/LocalJellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/LocalJellyfinMediaSource.kt
@@ -24,7 +24,7 @@ class LocalJellyfinMediaSource(
         source.item,
         source.sourceInfo,
         source.playSessionId,
-        PlaybackDetails(source.startTimeTicks, source.selectedAudioStreamIndex, source.selectedSubtitleStreamIndex),
+        PlaybackDetails(source.startTime, source.selectedAudioStreamIndex, source.selectedSubtitleStreamIndex),
         downloadFolder,
         downloadUrl,
         downloadSize,

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -10,9 +10,11 @@ import org.jellyfin.sdk.api.operations.UserLibraryApi
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
+import org.jellyfin.sdk.model.extensions.inWholeTicks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import timber.log.Timber
 import java.util.UUID
+import kotlin.time.Duration
 
 class MediaSourceResolver(private val apiClient: ApiClient) {
     private val mediaInfoApi: MediaInfoApi = apiClient.mediaInfoApi
@@ -24,7 +26,7 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
         mediaSourceId: String? = null,
         deviceProfile: DeviceProfile? = null,
         maxStreamingBitrate: Int? = null,
-        startTimeTicks: Long? = null,
+        startTime: Duration? = null,
         audioStreamIndex: Int? = null,
         subtitleStreamIndex: Int? = null,
         autoOpenLiveStream: Boolean = true,
@@ -41,7 +43,7 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
                     mediaSourceId = mediaSourceId ?: itemId.toString().replace("-", ""),
                     deviceProfile = deviceProfile,
                     maxStreamingBitrate = maxStreamingBitrate,
-                    startTimeTicks = startTimeTicks,
+                    startTimeTicks = startTime?.inWholeTicks,
                     audioStreamIndex = audioStreamIndex,
                     subtitleStreamIndex = subtitleStreamIndex,
                     autoOpenLiveStream = autoOpenLiveStream,
@@ -76,7 +78,7 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
                 playSessionId = playSessionId,
                 liveStreamId = mediaSourceInfo.liveStreamId,
                 maxStreamingBitrate = maxStreamingBitrate,
-                playbackDetails = PlaybackDetails(startTimeTicks, audioStreamIndex, subtitleStreamIndex),
+                playbackDetails = PlaybackDetails(startTime, audioStreamIndex, subtitleStreamIndex),
             )
             Result.success(source)
         } catch (e: IllegalArgumentException) {

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayState.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayState.kt
@@ -1,6 +1,8 @@
 package org.jellyfin.mobile.player.ui
 
+import kotlin.time.Duration
+
 data class PlayState(
     val playWhenReady: Boolean,
-    val position: Long,
+    val position: Duration,
 )

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -102,7 +102,6 @@ object Constants {
 
     // Video player constants
     const val LANGUAGE_UNDEFINED = "und"
-    const val TICKS_PER_MS = 10000
     const val PLAYER_TIME_UPDATE_RATE = 10000L
     const val CHAPTER_MARKING_UPDATE_DELAY = 1000L
     const val DEFAULT_CONTROLS_TIMEOUT_MS = 2500

--- a/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
@@ -33,7 +33,7 @@ fun JellyfinMediaSource.toMediaMetadata(): MediaMetadata = MediaMetadata.Builder
     item?.artists?.joinToString()?.let { artists ->
         putString(MediaMetadata.METADATA_KEY_ARTIST, artists)
     }
-    putLong(MediaMetadata.METADATA_KEY_DURATION, runTimeMs)
+    putLong(MediaMetadata.METADATA_KEY_DURATION, runTime.inWholeMilliseconds)
     val imageUri = ImageProvider.buildItemUri(itemId, ImageType.PRIMARY, item?.imageTags?.get(ImageType.PRIMARY))
     putString(MediaMetadata.METADATA_KEY_ART_URI, imageUri.toString())
 }.build()


### PR DESCRIPTION
Updated all the spots where manual math was being used to convert to and from ticks, to use the built in time utilities instead

`ticks / Constants.TICKS_PER_MS` became `*.ticks.inWholeMilliseconds`
`ms * Constants.TICKS_PER_MS` became `*.milliseconds.inWholeTicks`