### PR TITLE
Remove repeated string in AVAILABLE_VIDEO_CODECS

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -204,7 +204,7 @@ class DeviceProfileBuilder(
             // webm
             arrayOf("vp8", "vp9", "av1"),
             // mkv
-            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp8", "vp9", "av1"),
+            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp8", "vp9"),
             // mp3
             emptyArray(),
             // ogg


### PR DESCRIPTION
**Changes**
Removed "av1" appearing twice in the array designated "mkv" in AVAILABLE_VIDEO_CODECS.

**Issues**
This may have some relevance to jellyfin-androidtv issue [4820](https://github.com/jellyfin/jellyfin-androidtv/issues/4820) because MP4 files containing AV1 video do not get transcoded while MKV files do. However, that's a _separate repository_ and I'm not too sure how it might be related.