### PR TITLE
Remove direct dependencies on OkHttp/Okio

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,8 +144,6 @@ dependencies {
             "unstable-snapshot" -> version { strictly(JellyfinSdk.SNAPSHOT_UNSTABLE) }
         }
     }
-    implementation(libs.okhttp)
-    implementation(libs.okio)
     implementation(libs.bundles.coil)
 
     // Media

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,8 +37,6 @@ compose-material-icons = "1.7.8"
 
 # Network
 jellyfin-sdk = "1.6.8"
-okhttp = "4.12.0"
-okio = "3.15.0"
 coil = "3.3.0"
 
 # Media
@@ -114,8 +112,6 @@ compose-material-icons-extended = { group = "androidx.compose.material", name = 
 
 # Network
 jellyfin-sdk = { group = "org.jellyfin.sdk", name = "jellyfin-core", version.ref = "jellyfin-sdk" }
-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 coil = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
 coil-network = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 


### PR DESCRIPTION
We don't use either of them directly in the app and they're already kept up-to-date-ish via our SDK and other dependencies using them.

**Changes**
- Remove direct dependencies on OkHttp/Okio

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
