### PR TITLE
Fix logo drawn behind status bar

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/MainActivity.kt
@@ -4,12 +4,14 @@ import android.app.Service
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
+import android.graphics.Color
 import android.os.Bundle
 import android.os.IBinder
 import android.provider.Settings
 import android.view.OrientationEventListener
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.SystemBarStyle
 import androidx.activity.addCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
@@ -95,7 +97,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         setupKoinFragmentFactory()
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+        )
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 

--- a/app/src/main/java/org/jellyfin/mobile/ui/screens/connect/ConnectScreen.kt
+++ b/app/src/main/java/org/jellyfin/mobile/ui/screens/connect/ConnectScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -34,6 +35,7 @@ fun ConnectScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .systemBarsPadding()
                 .padding(horizontal = 16.dp),
         ) {
             LogoHeader()


### PR DESCRIPTION
Cherry-picked from one of my bigger rewrite branches.

**Changes**
- Fix logo drawn behind status bar by applying status bar padding onto the connect screen
- Fix status bar icons using wrong color by specifying explicit black theme to enableEdgeToEdge call

| Before | After |
| --- | --- |
| <img width="1080" height="2424" alt="afbeelding" src="https://github.com/user-attachments/assets/f792d072-e5b1-4cb8-8e7c-588a6a504bda" /> | <img width="1080" height="2424" alt="afbeelding" src="https://github.com/user-attachments/assets/024a730e-61a3-42af-899d-dad9a07ec2b8" /> |


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
