### PR TITLE
Port video title format from web client

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -138,7 +138,7 @@ class ExternalPlayer(
                 component = getComponent(appPreferences.externalPlayerApp)
             }
             setDataAndType(url.toUri(), "video/*")
-            putExtra("title", source.name)
+            putExtra("title", source.getName(context))
             putExtra("position", source.startTime.inWholeMilliseconds.toInt())
             putExtra("return_result", true)
             putExtra("secure_uri", true)
@@ -167,7 +167,7 @@ class ExternalPlayer(
         }
         playerContract.launch(playerIntent)
         Timber.d(
-            "Starting playback [id=${source.itemId}, title=${source.name}, " +
+            "Starting playback [id=${source.itemId}, title=${source.getName(context)}, " +
                 "playMethod=${source.playMethod}, startTime=${source.startTime}]",
         )
     }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadUtils.kt
@@ -220,7 +220,7 @@ class DownloadUtils(
         }
 
         val downloadRequest = DownloadManager.Request(downloadURL.toUri())
-            .setTitle(jellyfinMediaSource.name)
+            .setTitle(jellyfinMediaSource.getName(context))
             .setDescription(context.getString(R.string.downloading))
             .setDestinationUri(Uri.fromFile(File(appPreferences.downloadLocation, filename)))
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsAdapter.kt
@@ -39,7 +39,7 @@ class DownloadsAdapter(
             val context = itemView.context
 
             val mediaItem: BaseItemDto? = downloadEntity.mediaSource.item
-            binding.textViewName.text = downloadEntity.mediaSource.name
+            binding.textViewName.text = downloadEntity.mediaSource.getName(context)
             binding.textViewDescription.text = when {
                 mediaItem?.seriesName != null -> context.getString(
                     R.string.tv_show_desc,

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -105,7 +105,7 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
                         setLargeIcon(mediaIcon)
                     }
                 }
-                setContentTitle(currentMediaSource.name)
+                setContentTitle(currentMediaSource.getName(context))
                 currentMediaSource.item?.artists?.joinToString()?.let { artists ->
                     setContentText(artists)
                 }

--- a/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/JellyfinMediaSource.kt
@@ -1,8 +1,11 @@
 package org.jellyfin.mobile.player.source
 
+import android.content.Context
+import org.jellyfin.mobile.R
 import org.jellyfin.mobile.player.deviceprofile.CodecHelpers
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamType
@@ -20,7 +23,6 @@ sealed class JellyfinMediaSource(
     playbackDetails: PlaybackDetails?,
 ) {
     val id: String = requireNotNull(sourceInfo.id) { "Media source has no id" }
-    val name: String = item?.name ?: sourceInfo.name.orEmpty()
 
     abstract val playMethod: PlayMethod
 
@@ -150,6 +152,41 @@ sealed class JellyfinMediaSource(
             }
         }
         throw IllegalArgumentException("Invalid media stream")
+    }
+
+    /**
+     * Get the formatted name of the source.
+     */
+    @Suppress("CyclomaticComplexMethod")
+    fun getName(context: Context): String {
+        return item?.let {
+            buildString {
+                val name = if (
+                    it.type in arrayOf(BaseItemKind.PROGRAM, BaseItemKind.RECORDING) &&
+                    (it.isSeries == true || !it.episodeTitle.isNullOrEmpty())
+                ) { it.episodeTitle } else { it.name }
+
+                val specialEpisode = context.getString(R.string.special_episode)
+                val extraInfo = when {
+                    it.type == BaseItemKind.TV_CHANNEL && !it.channelNumber.isNullOrEmpty() -> it.channelNumber
+                    it.type == BaseItemKind.EPISODE && it.parentIndexNumber == 0 -> specialEpisode
+                    it.type in arrayOf(BaseItemKind.EPISODE, BaseItemKind.RECORDING) &&
+                        it.indexNumber != null && it.parentIndexNumber != null ->
+                        "S${it.parentIndexNumber}:E${it.indexNumber}${it.indexNumberEnd?.let { n -> "-$n" } ?: ""}"
+                    else -> ""
+                }
+
+                listOf(it.seriesName, extraInfo, name)
+                    .filter { str -> !str.isNullOrEmpty() }
+                    .joinTo(this, separator = " - ")
+
+                if (it.type == BaseItemKind.MOVIE && it.productionYear != null) {
+                    append(" (${it.productionYear})")
+                } else if (it.premiereDate != null) {
+                    append(" (${it.premiereDate!!.year})")
+                }
+            }.ifEmpty { null }
+        } ?: sourceInfo.name.orEmpty()
     }
 }
 

--- a/app/src/main/java/org/jellyfin/mobile/player/source/RemoteJellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/RemoteJellyfinMediaSource.kt
@@ -18,6 +18,6 @@ class RemoteJellyfinMediaSource(
         sourceInfo.supportsDirectPlay -> PlayMethod.DIRECT_PLAY
         sourceInfo.supportsDirectStream -> PlayMethod.DIRECT_STREAM
         sourceInfo.supportsTranscoding -> PlayMethod.TRANSCODE
-        else -> throw IllegalArgumentException("No play method found for $name ($itemId)")
+        else -> throw IllegalArgumentException("No play method found for ${sourceInfo.name} ($itemId)")
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -122,7 +122,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
             }
 
             // Update title and player menus
-            toolbar.title = mediaSource.name
+            toolbar.title = mediaSource.getName(requireContext())
             playerMenus?.onQueueItemChanged(mediaSource, viewModel.queueManager.hasNext())
         }
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
@@ -29,7 +29,7 @@ inline fun MediaSession.applyDefaultLocalAudioAttributes(contentType: Int) {
 
 fun JellyfinMediaSource.toMediaMetadata(): MediaMetadata = MediaMetadata.Builder().apply {
     putString(MediaMetadata.METADATA_KEY_MEDIA_ID, itemId.toString())
-    putString(MediaMetadata.METADATA_KEY_TITLE, name)
+    putString(MediaMetadata.METADATA_KEY_TITLE, item?.name ?: sourceInfo.name.orEmpty())
     item?.artists?.joinToString()?.let { artists ->
         putString(MediaMetadata.METADATA_KEY_ARTIST, artists)
     }

--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -112,7 +112,7 @@ suspend fun MainActivity.removeDownload(download: LocalJellyfinMediaSource, forc
         val confirmation = suspendCancellableCoroutine { continuation ->
             AlertDialog.Builder(this)
                 .setTitle(getString(R.string.confirm_deletion))
-                .setMessage(getString(R.string.confirm_deletion_desc, download.name))
+                .setMessage(getString(R.string.confirm_deletion_desc, download.getName(this)))
                 .setPositiveButton(getString(R.string.yes)) { _, _ ->
                     continuation.resume(true)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,4 +140,5 @@
     <string name="tv_show_desc">%1$s - S%2$dE%3$d</string>
     <string name="downloading_desc">Downloading %1$d titles</string>
     <string name="downloaded">Downloaded %1$s</string>
+    <string name="special_episode">Special</string>
 </resources>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Reimplemented video title format used in [Jellyfin web client](https://github.com/jellyfin/jellyfin-web).
When using ExoPlayer or external player, Jellyfin shows only the episode/movie name on the title bar,
meanwhile web client shows series name, episode name,  season number, episode number and release year.
This PR adds title format used by web client to ExoPlayer and external player.

Before:
<img width="2400" height="1080" alt="obraz" src="https://github.com/user-attachments/assets/a24e7fe9-811a-42da-a6cf-7b1ac7f85892" />

After:
<img width="2400" height="1080" alt="obraz" src="https://github.com/user-attachments/assets/4e1012d2-b554-42a4-8899-38c5cbf57c0d" />

After but with VLC as external player:
<img width="2400" height="1080" alt="obraz" src="https://github.com/user-attachments/assets/285c515e-b46b-48ee-bc10-2995bf53b922" />


Web Client for reference:
<img width="1919" height="1132" alt="obraz" src="https://github.com/user-attachments/assets/58f49e64-2b80-4759-bb08-6be956c9a6e3" />


Reference code from web client:
- https://github.com/jellyfin/jellyfin-web/blob/master/src/controllers/playback/video/index.js#L236-L270
- https://github.com/jellyfin/jellyfin-web/blob/master/src/components/itemHelper.js#L14-L64

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
I haven't found any related issues.

