### PR TITLE
fix: + button in edit images in android app

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -6,6 +6,7 @@ const features = [
     "exit",
     "externallinks",
     "filedownload",
+    "fileinput",
     "htmlaudioautoplay",
     "htmlvideoautoplay",
     "multiserver",


### PR DESCRIPTION
Fix: Add images '+' button in edit images section of android app

**Issue**
closes https://github.com/jellyfin/jellyfin-android/issues/1879

**Cause of Issue**
     - The Jellyfin web interface (imageeditor.js) checks if appHost.supports(AppFeature.FileInput) returns true before showing the upload button
     - The Android app already implements full file chooser support via JellyfinWebChromeClient.onShowFileChooser()

**Changes**
     - The native shell just needed to declare support for this feature in its features array

**POT**
<img width="472" height="939" alt="Screenshot From 2026-01-04 21-04-44" src="https://github.com/user-attachments/assets/dc8b48fb-d899-4691-92a6-248310282d44" />


