### PR TITLE
Revert "Update Kotlin to v2.3.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Plugins
 android-plugin = "8.13.2"
-kotlin = "2.3.0"
+kotlin = "2.2.21"
 kotlin-ksp = "2.3.4"
 detekt = "1.23.8"
 android-junit5 = "1.14.0.0"


### PR DESCRIPTION
Reverts jellyfin/jellyfin-android#1875

idk why CI passed in the PR but not after merge 🤷 