### PR TITLE
Fix SSO/OIDC login loop by persisting _deviceId2

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -161,6 +161,16 @@ window.NativeShell.AppHost = {
         deviceName = result.deviceName;
         appName = result.appName;
         appVersion = result.appVersion;
+
+        // The Jellyfin SSO/OIDC redirect page expects the standard Jellyfin Web localStorage key.
+        // In the Android shell path, the device id comes from native code, so ensure it exists too.
+        try {
+            if (deviceId && !localStorage.getItem('_deviceId2')) {
+                localStorage.setItem('_deviceId2', deviceId);
+            }
+        } catch (e) {
+            // Ignore storage failures (private browsing / quota / etc).
+        }
     },
     getDefaultLayout() {
         return "mobile";


### PR DESCRIPTION
When using plugin-sso OIDC, the `/sso/OID/redirect/...` page expects `_deviceId2` to exist in `localStorage`.

In the Android native shell flow, the device id comes from native code but was not persisted under this key, which caused an infinite "Logging in..." loop.

This change ensures `_deviceId2` is set from the native `deviceId` during `NativeShell.AppHost.init()` when missing.

Related: 9p4/jellyfin-plugin-sso#189