### PR TITLE
Immediately load device information in nativeshell

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -31,10 +31,7 @@ for (const plugin of plugins) {
     };
 }
 
-let deviceId;
-let deviceName;
-let appName;
-let appVersion;
+const { deviceId, deviceName, appName, appVersion } = JSON.parse(window.NativeInterface.getDeviceInformation());
 
 window.NativeShell = {
     enableFullscreen() {
@@ -154,14 +151,7 @@ function getDeviceProfile(profileBuilder, item) {
 }
 
 window.NativeShell.AppHost = {
-    init() {
-        const result = JSON.parse(window.NativeInterface.getDeviceInformation());
-        // set globally so they can be used elsewhere
-        deviceId = result.deviceId;
-        deviceName = result.deviceName;
-        appName = result.appName;
-        appVersion = result.appVersion;
-    },
+    init() {},
     getDefaultLayout() {
         return "mobile";
     },


### PR DESCRIPTION
The Android app fails to provide the device information because of a bug caused by https://github.com/jellyfin/jellyfin-web/pull/7516. The linked change was made while working on our Titan OS client but apparently some edge cases can cause the legacy apiclient to load device info even before that init call is made.

Fortunately for the Android app we don't need it to load asynchronously and we can just set the cached variables on load.

**Changes**

- Immediately load device information in nativeshell

**Issues**

Fixes https://github.com/jellyfin/jellyfin/issues/16534