### PR TITLE
Add Trickplay view over the seekbar in ExoPlayer

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
@@ -8,11 +8,15 @@ import android.widget.ImageButton
 import android.widget.PopupMenu
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.get
 import androidx.core.view.isVisible
 import androidx.core.view.size
 import androidx.core.view.updateLayoutParams
+import androidx.media3.ui.DefaultTimeBar
+import androidx.media3.ui.TimeBar
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.databinding.ExoPlayerControlViewBinding
 import org.jellyfin.mobile.databinding.FragmentPlayerBinding
@@ -59,16 +63,30 @@ class PlayerMenus(
     private val qualityMenu: PopupMenu = createQualityMenu()
     private val decoderMenu: PopupMenu = createDecoderMenu()
     private val chapterMarkingContainer: ConstraintLayout by playerControlsBinding::chapterMarkingContainer
+    private val exoProgress: DefaultTimeBar by playerControlsBinding::exoProgress
+    private val seekBarContainer: View by playerControlsBinding::seekBarContainer
+    private val trickplayContainer: View by playerControlsBinding::trickplayContainer
+    private val trickplayThumbnail: AppCompatImageView by playerControlsBinding::trickplayThumbnail
+    private val trickplayChapterName: AppCompatTextView by playerControlsBinding::trickplayChapterName
+    private val trickplayTime: AppCompatTextView by playerControlsBinding::trickplayTime
     private val skipSegmentButton: Button by playerBinding::skipSegmentButton
 
     private var subtitleCount = 0
     private var subtitlesEnabled = false
+
+    private val trickplayHelper = TrickplayHelper(trickplayContainer, trickplayThumbnail, seekBarContainer, trickplayChapterName, trickplayTime)
 
     private val playerMenuHelper: PlayerMenuHelper = PlayerMenuHelper(
         skipMediaSegmentButton = SkipMediaSegmentButton(skipSegmentButton, fragment::onSkipMediaSegment),
     )
 
     init {
+        exoProgress.addListener(object : TimeBar.OnScrubListener {
+            override fun onScrubStart(timeBar: TimeBar, position: Long) = trickplayHelper.onScrubMove(position)
+            override fun onScrubMove(timeBar: TimeBar, position: Long) = trickplayHelper.onScrubMove(position)
+            override fun onScrubStop(timeBar: TimeBar, position: Long, cancelled: Boolean) = trickplayHelper.onScrubStop()
+        })
+
         previousButton.setOnClickListener {
             fragment.onSkipToPrevious()
         }
@@ -128,6 +146,8 @@ class PlayerMenus(
     fun onQueueItemChanged(mediaSource: JellyfinMediaSource, hasNext: Boolean) {
         // previousButton is always enabled and will rewind if at the start of the queue
         nextButton.isEnabled = hasNext
+
+        trickplayHelper.onMediaSourceChanged(mediaSource)
 
         val chapters = mediaSource.item?.chapters
         updateLayoutConstraints(!chapters.isNullOrEmpty())

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
@@ -74,7 +74,13 @@ class PlayerMenus(
     private var subtitleCount = 0
     private var subtitlesEnabled = false
 
-    private val trickplayHelper = TrickplayHelper(trickplayContainer, trickplayThumbnail, seekBarContainer, trickplayChapterName, trickplayTime)
+    private val trickplayHelper = TrickplayHelper(
+        trickplayContainer,
+        trickplayThumbnail,
+        seekBarContainer,
+        trickplayChapterName,
+        trickplayTime,
+    )
 
     private val playerMenuHelper: PlayerMenuHelper = PlayerMenuHelper(
         skipMediaSegmentButton = SkipMediaSegmentButton(skipSegmentButton, fragment::onSkipMediaSegment),

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
@@ -90,7 +90,11 @@ class PlayerMenus(
         exoProgress.addListener(object : TimeBar.OnScrubListener {
             override fun onScrubStart(timeBar: TimeBar, position: Long) = trickplayHelper.onScrubMove(position)
             override fun onScrubMove(timeBar: TimeBar, position: Long) = trickplayHelper.onScrubMove(position)
-            override fun onScrubStop(timeBar: TimeBar, position: Long, cancelled: Boolean) = trickplayHelper.onScrubStop()
+            override fun onScrubStop(
+                timeBar: TimeBar,
+                position: Long,
+                cancelled: Boolean,
+            ) = trickplayHelper.onScrubStop()
         })
 
         previousButton.setOnClickListener {

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
@@ -1,0 +1,192 @@
+package org.jellyfin.mobile.player.ui
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.text.format.DateUtils
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import kotlin.math.roundToInt
+import coil3.ImageLoader
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.Disposable
+import coil3.request.ImageRequest
+import coil3.request.maxBitmapSize
+import coil3.request.transformations
+import coil3.size.Dimension
+import coil3.size.Size
+import coil3.toBitmap
+import org.jellyfin.mobile.R
+import org.jellyfin.mobile.player.source.JellyfinMediaSource
+import org.jellyfin.mobile.utils.Constants
+import org.jellyfin.mobile.utils.coil.SubsetTransformation
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.trickplayApi
+import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
+import org.jellyfin.sdk.model.api.ChapterInfo
+import org.jellyfin.sdk.model.api.TrickplayInfo
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.UUID
+
+class TrickplayHelper(
+    private val thumbnailContainer: View,
+    private val thumbnailView: AppCompatImageView,
+    private val seekBarContainer: View,
+    private val chapterNameView: AppCompatTextView,
+    private val timeView: AppCompatTextView,
+) : KoinComponent {
+    private val api: ApiClient by inject()
+    private val imageLoader: ImageLoader by inject()
+    private val context = thumbnailView.context
+    private val handler = Handler(Looper.getMainLooper())
+    private val thumbnailDisplayHeight = context.resources.getDimensionPixelSize(R.dimen.trickplay_thumbnail_height)
+    private var thumbnailDisplayWidth = 0
+
+    private var trickPlayInfo: TrickplayInfo? = null
+    private var itemId: UUID? = null
+    private var mediaSourceId: UUID? = null
+    private var durationMs: Long = 0L
+    private var currentRequest: Disposable? = null
+    private var pendingRequest: Runnable? = null
+    private var pendingTile = -1
+    private var lastDispatchedTile = -1
+    private var isScrubbing = false
+    private var nextDispatchAt = 0L
+    private var chapters: List<ChapterInfo>? = null
+
+    fun onMediaSourceChanged(source: JellyfinMediaSource?) {
+        trickPlayInfo = null
+        itemId = null
+        mediaSourceId = null
+        durationMs = 0L
+        pendingTile = -1
+        lastDispatchedTile = -1
+        pendingRequest?.let { handler.removeCallbacks(it) }
+        pendingRequest = null
+        chapters = null
+        thumbnailContainer.visibility = View.GONE
+
+        if (source == null) return
+        val item = source.item ?: return
+        val resolvedMediaSourceId = source.id.toUUIDOrNull() ?: return
+        val info = item.trickplay?.get(source.id)?.values?.firstOrNull() ?: return
+
+        trickPlayInfo = info
+        itemId = item.id
+        mediaSourceId = resolvedMediaSourceId
+        durationMs = source.runTime.inWholeMilliseconds
+        chapters = item.chapters
+        thumbnailDisplayWidth = (thumbnailDisplayHeight * info.width.toFloat() / info.height).roundToInt()
+        thumbnailView.updateLayoutParams<ViewGroup.LayoutParams> { width = thumbnailDisplayWidth }
+    }
+
+    fun onScrubMove(position: Long) {
+        isScrubbing = true
+        val info = trickPlayInfo ?: return
+        val resolvedItemId = itemId ?: return
+        val resolvedMediaSourceId = mediaSourceId ?: return
+        if (durationMs <= 0) return
+
+        // Calculate trickplay tile position and offset based on scrubberposition
+        val currentTile = position.floorDiv(info.interval).toInt()
+        val tileSize = info.tileWidth * info.tileHeight
+        val tileOffset = currentTile % tileSize
+        val tileIndex = currentTile / tileSize
+        val tileOffsetX = tileOffset % info.tileWidth
+        val tileOffsetY = tileOffset / info.tileWidth
+        val offsetX = tileOffsetX * info.width
+        val offsetY = tileOffsetY * info.height
+
+        // Always update horizontal position regardless of tile change, centered above scrubber
+        val fraction = position.toFloat() / durationMs.toFloat()
+        val scrubberX = seekBarContainer.x + fraction * seekBarContainer.width
+        thumbnailContainer.x = (scrubberX - thumbnailDisplayWidth / 2f)
+            .coerceIn(seekBarContainer.x, seekBarContainer.x + seekBarContainer.width - thumbnailDisplayWidth)
+
+        // Update chapter name and timestamp on every move
+        val chapterName = chapters?.lastOrNull { it.startPositionTicks <= position * Constants.TICKS_PER_MILLISECOND }?.name
+        chapterNameView.isVisible = !chapterName.isNullOrEmpty()
+        if (!chapterName.isNullOrEmpty()) chapterNameView.text = chapterName
+        timeView.text = DateUtils.formatElapsedTime(position / 1000)
+
+        // Same tile already pending or already displayed - position updated above, nothing else to do
+        if (currentTile == pendingTile || currentTile == lastDispatchedTile) return
+
+        // Cancel previous pending request and schedule a new one for the latest tile
+        pendingRequest?.let { handler.removeCallbacks(it) }
+        pendingTile = currentTile
+
+        val url = api.trickplayApi.getTrickplayTileImageUrl(
+            itemId = resolvedItemId,
+            width = info.width,
+            index = tileIndex,
+            mediaSourceId = resolvedMediaSourceId,
+        )
+
+        val runnable = Runnable {
+            dispatchRequest(url, offsetX, offsetY, info.width, info.height, currentTile)
+        }
+        pendingRequest = runnable
+
+        // Run immediately if next dispatch time has passed, otherwise schedule for the remaining time
+        handler.postAtTime(runnable, maxOf(SystemClock.uptimeMillis(), nextDispatchAt))
+    }
+
+    private fun dispatchRequest(url: String, offsetX: Int, offsetY: Int, tileWidth: Int, tileHeight: Int, tile: Int) {
+        lastDispatchedTile = tile
+        pendingTile = -1
+        pendingRequest = null
+        nextDispatchAt = SystemClock.uptimeMillis() + Constants.TRICKPLAY_TILE_REFRESH_WINDOW_MS
+
+        currentRequest?.dispose()
+        currentRequest = imageLoader.enqueue(
+            ImageRequest.Builder(context)
+                .data(url)
+                .size(Size.ORIGINAL)
+                .maxBitmapSize(Size(Dimension.Undefined, Dimension.Undefined))
+                .httpHeaders(
+                    NetworkHeaders.Builder()
+                        .set(
+                            "Authorization",
+                            AuthorizationHeaderBuilder.buildHeader(
+                                clientName = api.clientInfo.name,
+                                clientVersion = api.clientInfo.version,
+                                deviceId = api.deviceInfo.id,
+                                deviceName = api.deviceInfo.name,
+                                accessToken = api.accessToken,
+                            ),
+                        )
+                        .build(),
+                )
+                .transformations(SubsetTransformation(offsetX, offsetY, tileWidth, tileHeight))
+                .target(
+                    onSuccess = { image ->
+                        if (isScrubbing) {
+                            thumbnailView.setImageBitmap(image.toBitmap())
+                            thumbnailContainer.visibility = View.VISIBLE
+                        }
+                    },
+                )
+                .build(),
+        )
+    }
+
+    fun onScrubStop() {
+        isScrubbing = false
+        pendingRequest?.let { handler.removeCallbacks(it) }
+        pendingRequest = null
+        pendingTile = -1
+        lastDispatchedTile = -1
+        nextDispatchAt = 0L
+        currentRequest?.dispose()
+        currentRequest = null
+        thumbnailContainer.visibility = View.GONE
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
@@ -10,7 +10,6 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
-import kotlin.math.roundToInt
 import coil3.ImageLoader
 import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
@@ -34,6 +33,8 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
+import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.milliseconds
 
 class TrickplayHelper(
     private val thumbnailContainer: View,
@@ -73,36 +74,38 @@ class TrickplayHelper(
         chapters = null
         thumbnailContainer.visibility = View.GONE
 
-        if (source == null) return
-        val item = source.item ?: return
-        val resolvedMediaSourceId = source.id.toUUIDOrNull() ?: return
-        val info = item.trickplay?.get(source.id)?.values?.firstOrNull() ?: return
+        val item = source?.item
+        val resolvedSourceId = source?.id
+        val resolvedMediaSourceId = resolvedSourceId?.toUUIDOrNull()
+        val resolvedTrickPlayInfo = item?.trickplay?.get(resolvedSourceId)?.values?.firstOrNull()
+        if (item == null || resolvedMediaSourceId == null || resolvedTrickPlayInfo == null) return
 
-        trickPlayInfo = info
+        trickPlayInfo = resolvedTrickPlayInfo
         itemId = item.id
         mediaSourceId = resolvedMediaSourceId
         durationMs = source.runTime.inWholeMilliseconds
         chapters = item.chapters
-        thumbnailDisplayWidth = (thumbnailDisplayHeight * info.width.toFloat() / info.height).roundToInt()
+        thumbnailDisplayWidth = (thumbnailDisplayHeight * resolvedTrickPlayInfo.width.toFloat() / resolvedTrickPlayInfo.height).roundToInt()
         thumbnailView.updateLayoutParams<ViewGroup.LayoutParams> { width = thumbnailDisplayWidth }
     }
 
     fun onScrubMove(position: Long) {
         isScrubbing = true
-        val info = trickPlayInfo ?: return
-        val resolvedItemId = itemId ?: return
-        val resolvedMediaSourceId = mediaSourceId ?: return
-        if (durationMs <= 0) return
+        if (trickPlayInfo == null || itemId == null || mediaSourceId == null || durationMs <= 0) return
+
+        val resolvedTrickPlayInfo = trickPlayInfo!!
+        val resolvedItemId = itemId!!
+        val resolvedMediaSourceId = mediaSourceId!!
 
         // Calculate trickplay tile position and offset based on scrubberposition
-        val currentTile = position.floorDiv(info.interval).toInt()
-        val tileSize = info.tileWidth * info.tileHeight
+        val currentTile = position.floorDiv(resolvedTrickPlayInfo.interval).toInt()
+        val tileSize = resolvedTrickPlayInfo.tileWidth * resolvedTrickPlayInfo.tileHeight
         val tileOffset = currentTile % tileSize
         val tileIndex = currentTile / tileSize
-        val tileOffsetX = tileOffset % info.tileWidth
-        val tileOffsetY = tileOffset / info.tileWidth
-        val offsetX = tileOffsetX * info.width
-        val offsetY = tileOffsetY * info.height
+        val tileOffsetX = tileOffset % resolvedTrickPlayInfo.tileWidth
+        val tileOffsetY = tileOffset / resolvedTrickPlayInfo.tileWidth
+        val offsetX = tileOffsetX * resolvedTrickPlayInfo.width
+        val offsetY = tileOffsetY * resolvedTrickPlayInfo.height
 
         // Always update horizontal position regardless of tile change, centered above scrubber
         val fraction = position.toFloat() / durationMs.toFloat()
@@ -115,7 +118,7 @@ class TrickplayHelper(
         val chapterName = chapters?.lastOrNull { it.startPositionTicks <= position * Constants.TICKS_PER_MILLISECOND }?.name
         chapterNameView.isVisible = !chapterName.isNullOrEmpty()
         if (!chapterName.isNullOrEmpty()) chapterNameView.text = chapterName
-        timeView.text = DateUtils.formatElapsedTime(position / 1000)
+        timeView.text = formatPositionAsElapsedTime(position)
 
         // Same tile already pending or already displayed - position updated above, nothing else to do
         if (currentTile == pendingTile || currentTile == lastDispatchedTile) return
@@ -126,13 +129,13 @@ class TrickplayHelper(
 
         val url = api.trickplayApi.getTrickplayTileImageUrl(
             itemId = resolvedItemId,
-            width = info.width,
+            width = resolvedTrickPlayInfo.width,
             index = tileIndex,
             mediaSourceId = resolvedMediaSourceId,
         )
 
         val runnable = Runnable {
-            dispatchRequest(url, offsetX, offsetY, info.width, info.height, currentTile)
+            dispatchRequest(url, offsetX, offsetY, resolvedTrickPlayInfo.width, resolvedTrickPlayInfo.height, currentTile)
         }
         pendingRequest = runnable
 
@@ -189,5 +192,11 @@ class TrickplayHelper(
         currentRequest?.dispose()
         currentRequest = null
         thumbnailContainer.visibility = View.GONE
+    }
+
+    private fun formatPositionAsElapsedTime(positionMs: Long): String {
+        // Add half a second before truncating to match Media3's time display round-to-nearest behavior
+        val roundToNearestThresholdMs = 500L
+        return DateUtils.formatElapsedTime((positionMs + roundToNearestThresholdMs).milliseconds.inWholeSeconds)
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
@@ -107,8 +107,9 @@ class TrickplayHelper(
         // Always update horizontal position regardless of tile change, centered above scrubber
         val fraction = position.toFloat() / durationMs.toFloat()
         val scrubberX = seekBarContainer.x + fraction * seekBarContainer.width
-        thumbnailContainer.x = (scrubberX - thumbnailDisplayWidth / 2f)
-            .coerceIn(seekBarContainer.x, seekBarContainer.x + seekBarContainer.width - thumbnailDisplayWidth)
+        val clampMin = seekBarContainer.x
+        val clampMax = (seekBarContainer.x + seekBarContainer.width - thumbnailDisplayWidth).coerceAtLeast(clampMin)
+        thumbnailContainer.x = (scrubberX - thumbnailDisplayWidth / 2f).coerceIn(clampMin, clampMax)
 
         // Update chapter name and timestamp on every move
         val chapterName = chapters?.lastOrNull { it.startPositionTicks <= position * Constants.TICKS_PER_MILLISECOND }?.name

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/TrickplayHelper.kt
@@ -91,7 +91,8 @@ class TrickplayHelper(
 
     fun onScrubMove(position: Long) {
         isScrubbing = true
-        if (trickPlayInfo == null || itemId == null || mediaSourceId == null || durationMs <= 0) return
+        if (trickPlayInfo == null || itemId == null || mediaSourceId == null) return
+        if (durationMs <= 0) return
 
         val resolvedTrickPlayInfo = trickPlayInfo!!
         val resolvedItemId = itemId!!
@@ -135,12 +136,22 @@ class TrickplayHelper(
         )
 
         val runnable = Runnable {
-            dispatchRequest(url, offsetX, offsetY, resolvedTrickPlayInfo.width, resolvedTrickPlayInfo.height, currentTile)
+            dispatchRequest(
+                url,
+                offsetX,
+                offsetY,
+                resolvedTrickPlayInfo.width,
+                resolvedTrickPlayInfo.height,
+                currentTile,
+            )
         }
         pendingRequest = runnable
 
         // Run immediately if next dispatch time has passed, otherwise schedule for the remaining time
-        handler.postAtTime(runnable, maxOf(SystemClock.uptimeMillis(), nextDispatchAt))
+        handler.postAtTime(
+            runnable, 
+            maxOf(SystemClock.uptimeMillis(), nextDispatchAt),
+        )
     }
 
     private fun dispatchRequest(url: String, offsetX: Int, offsetY: Int, tileWidth: Int, tileHeight: Int, tile: Int) {

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -132,6 +132,8 @@ object Constants {
     const val VIDEO_PLAYER_NOTIFICATION_ID = 99
     const val DOWNLOAD_NOTIFICATION_ID = 80
     const val MAX_SKIP_TO_PREV_CHAPTER_MS = 10_000L
+    const val TICKS_PER_MILLISECOND = 10_000L
+    const val TRICKPLAY_TILE_REFRESH_WINDOW_MS = 100L
 
     // Video player intent extras
     const val EXTRA_MEDIA_PLAY_OPTIONS = "org.jellyfin.mobile.MEDIA_PLAY_OPTIONS"

--- a/app/src/main/java/org/jellyfin/mobile/utils/coil/SubsetTransformation.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/coil/SubsetTransformation.kt
@@ -1,0 +1,17 @@
+package org.jellyfin.mobile.utils.coil
+
+import android.graphics.Bitmap
+import coil3.size.Size
+import coil3.transform.Transformation
+
+class SubsetTransformation(
+    private val x: Int,
+    private val y: Int,
+    private val width: Int,
+    private val height: Int,
+) : Transformation() {
+    override val cacheKey: String = "$x,$y,$width,$height"
+
+    override suspend fun transform(input: Bitmap, size: Size): Bitmap =
+        Bitmap.createBitmap(input, x, y, width, height)
+}

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -260,4 +260,56 @@
         android:src="@drawable/ic_fullscreen_enter_white_32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/trickplay_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:elevation="4dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/seek_bar_container"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/trickplay_thumbnail"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/trickplay_thumbnail_height"
+            android:scaleType="fitXY" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:orientation="vertical"
+            android:padding="4dp">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/trickplay_chapter_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha="0.85"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:shadowColor="#CC000000"
+                android:shadowDx="0"
+                android:shadowDy="0"
+                android:shadowRadius="4"
+                android:textColor="@android:color/white"
+                android:textSize="12sp"
+                android:visibility="gone" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/trickplay_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:shadowColor="#CC000000"
+                android:shadowDx="0"
+                android:shadowDy="0"
+                android:shadowRadius="4"
+                android:textColor="@android:color/white"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+    </FrameLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -266,7 +266,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:elevation="4dp"
+        android:background="#282828"
+        android:elevation="8dp"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/seek_bar_container"
         app:layout_constraintStart_toStartOf="parent">
@@ -282,33 +283,37 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:orientation="vertical"
-            android:padding="4dp">
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:paddingTop="4dp"
+            android:paddingBottom="8dp">
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/trickplay_chapter_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:alpha="0.85"
+                android:alpha="0.9"
                 android:ellipsize="end"
                 android:maxLines="1"
-                android:shadowColor="#CC000000"
+                android:shadowColor="#FF000000"
                 android:shadowDx="0"
                 android:shadowDy="0"
-                android:shadowRadius="4"
+                android:shadowRadius="6"
                 android:textColor="@android:color/white"
-                android:textSize="12sp"
+                android:textSize="14sp"
                 android:visibility="gone" />
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/trickplay_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:shadowColor="#CC000000"
+                android:layout_marginTop="4dp"
+                android:shadowColor="#FF000000"
                 android:shadowDx="0"
                 android:shadowDy="0"
-                android:shadowRadius="4"
+                android:shadowRadius="6"
                 android:textColor="@android:color/white"
-                android:textSize="14sp"
+                android:textSize="20sp"
                 android:textStyle="bold" />
         </LinearLayout>
     </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -15,4 +15,5 @@
     <dimen name="exo_gesture_overlay_image_size">72dp</dimen>
     <dimen name="exo_chapter_marking_width">3dp</dimen>
     <dimen name="exo_chapter_marking_height">15dp</dimen>
+    <dimen name="trickplay_thumbnail_height">128dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -15,5 +15,5 @@
     <dimen name="exo_gesture_overlay_image_size">72dp</dimen>
     <dimen name="exo_chapter_marking_width">3dp</dimen>
     <dimen name="exo_chapter_marking_height">15dp</dimen>
-    <dimen name="trickplay_thumbnail_height">128dp</dimen>
+    <dimen name="trickplay_thumbnail_height">160dp</dimen>
 </resources>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
- Added Trickplay view over the seekbar when ExoPlayer is used.
- I used parts of the existing logic from the Android TV client - calculations, image caching and transformations.
- Mimic the existing Trickplay view from the web-based player with a chapter title and position time at the bottom of the image.

<img width="2992" height="1344" alt="share_7032594885023039744" src="https://github.com/user-attachments/assets/bd8bc73d-c154-4d21-b494-f3bdef50a0c7" />

**Issues**
Implements https://github.com/jellyfin/jellyfin-android/issues/1465, https://github.com/jellyfin/jellyfin-android/issues/1509
