### PR TITLE
Fix a memory leak inside ServiceBinder

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -468,8 +468,9 @@ class RemotePlayerService : Service(), CoroutineScope {
         super.onDestroy()
     }
 
-    class ServiceBinder(private val service: RemotePlayerService) : Binder() {
+    class ServiceBinder(service: RemotePlayerService) : Binder() {
+        private val serviceRef = java.lang.ref.WeakReference(service)
         val isPlaying: Boolean
-            get() = service.playbackState?.state == PlaybackState.STATE_PLAYING
+            get() = serviceRef.get()?.playbackState?.state == PlaybackState.STATE_PLAYING
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

While playing around with trying to get my car head unit to display album artwork over Bluetooth, the debug build popped up a notification about a leak, which reported ~4.1 MB across 114 objects.  ServiceBinder held a strong reference to its outer RemotePlayerService instance. This replaces the strong reference with a WeakReference so the service can be collected normally after destruction.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
