### PR TITLE
Dynamically query device H264 max level for WebView device profile

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -32,6 +32,7 @@ for (const plugin of plugins) {
 }
 
 const { deviceId, deviceName, appName, appVersion } = JSON.parse(window.NativeInterface.getDeviceInformation());
+const codecCaps = JSON.parse(window.NativeInterface.getCodecCapabilities());
 
 window.NativeShell = {
     enableFullscreen() {
@@ -135,7 +136,7 @@ function getDeviceProfile(profileBuilder, item) {
             {
                 Condition: "LessThanEqual",
                 Property: "VideoLevel",
-                Value: "41"
+                Value: codecCaps.h264MaxLevel
             }]
     });
 

--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -32,6 +32,7 @@ for (const plugin of plugins) {
 }
 
 const { deviceId, deviceName, appName, appVersion } = JSON.parse(window.NativeInterface.getDeviceInformation());
+const codecCaps = JSON.parse(window.NativeInterface.getCodecCapabilities());
 
 window.NativeShell = {
     enableFullscreen() {
@@ -131,7 +132,7 @@ function getDeviceProfile(profileBuilder, item) {
             {
                 Condition: "LessThanEqual",
                 Property: "VideoLevel",
-                Value: "41"
+                Value: codecCaps.h264MaxLevel
             }]
     });
 

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import org.jellyfin.mobile.events.ActivityEvent
 import org.jellyfin.mobile.events.ActivityEventHandler
+import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.Constants.EXTRA_ALBUM
 import org.jellyfin.mobile.utils.Constants.EXTRA_ARTIST
@@ -37,6 +38,7 @@ import timber.log.Timber
 class NativeInterface(private val context: Context) : KoinComponent {
     private val activityEventHandler: ActivityEventHandler = get()
     private val remoteVolumeProvider: RemoteVolumeProvider by inject()
+    private val deviceProfileBuilder: DeviceProfileBuilder by inject()
 
     @SuppressLint("HardwareIds")
     @JavascriptInterface
@@ -58,6 +60,9 @@ class NativeInterface(private val context: Context) : KoinComponent {
     } catch (e: JSONException) {
         null
     }
+
+    @JavascriptInterface
+    fun getCodecCapabilities(): String = deviceProfileBuilder.getWebCodecCapabilitiesJson()
 
     @JavascriptInterface
     fun enableFullscreen(): Boolean {

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -8,6 +8,7 @@ import android.webkit.JavascriptInterface
 import androidx.core.content.ContextCompat
 import org.jellyfin.mobile.events.ActivityEvent
 import org.jellyfin.mobile.events.ActivityEventHandler
+import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.Constants.EXTRA_ALBUM
 import org.jellyfin.mobile.utils.Constants.EXTRA_ARTIST
@@ -38,6 +39,7 @@ import java.util.UUID
 class NativeInterface(private val context: Context) : KoinComponent {
     private val activityEventHandler: ActivityEventHandler = get()
     private val remoteVolumeProvider: RemoteVolumeProvider by inject()
+    private val deviceProfileBuilder: DeviceProfileBuilder by inject()
 
     @SuppressLint("HardwareIds")
     @JavascriptInterface
@@ -59,6 +61,9 @@ class NativeInterface(private val context: Context) : KoinComponent {
     } catch (e: JSONException) {
         null
     }
+
+    @JavascriptInterface
+    fun getCodecCapabilities(): String = deviceProfileBuilder.getWebCodecCapabilitiesJson()
 
     @JavascriptInterface
     fun enableFullscreen(): Boolean {

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -1,8 +1,10 @@
 package org.jellyfin.mobile.player.deviceprofile
 
 import android.media.MediaCodecList
+import android.media.MediaFormat
 import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.utils.Constants
+import org.json.JSONObject
 import org.jellyfin.sdk.model.api.CodecProfile
 import org.jellyfin.sdk.model.api.CodecType
 import org.jellyfin.sdk.model.api.ContainerProfile
@@ -23,6 +25,7 @@ class DeviceProfileBuilder(
     private val supportedVideoCodecs: Array<Array<String>>
     private val supportedAudioCodecs: Array<Array<String>>
     private val videoCodecsProfiles: Map<String, Set<String>>
+    private val maxAvcRawLevel: Int
 
     private val transcodingProfiles: List<TranscodingProfile>
 
@@ -34,12 +37,21 @@ class DeviceProfileBuilder(
         // Load Android-supported codecs
         val videoCodecs: MutableMap<String, DeviceCodec.Video> = HashMap()
         val audioCodecs: MutableMap<String, DeviceCodec.Audio> = HashMap()
+        var maxAvcLevel = 0
         val androidCodecs = MediaCodecList(MediaCodecList.REGULAR_CODECS)
         for (codecInfo in androidCodecs.codecInfos) {
             if (codecInfo.isEncoder) continue
 
             for (mimeType in codecInfo.supportedTypes) {
-                val codec = DeviceCodec.from(codecInfo.getCapabilitiesForType(mimeType)) ?: continue
+                val capabilities = codecInfo.getCapabilitiesForType(mimeType)
+
+                if (mimeType == MediaFormat.MIMETYPE_VIDEO_AVC) {
+                    for (pl in capabilities.profileLevels) {
+                        if (pl.level > maxAvcLevel) maxAvcLevel = pl.level
+                    }
+                }
+
+                val codec = DeviceCodec.from(capabilities) ?: continue
                 val name = codec.name
                 when (codec) {
                     is DeviceCodec.Video -> {
@@ -59,6 +71,7 @@ class DeviceProfileBuilder(
                 }
             }
         }
+        maxAvcRawLevel = maxAvcLevel
 
         // Build map of supported codecs from device support and hardcoded data
         supportedVideoCodecs = Array(AVAILABLE_VIDEO_CODECS.size) { i ->
@@ -214,8 +227,13 @@ class DeviceProfileBuilder(
         musicStreamingTranscodingBitrate = Int.MAX_VALUE,
     )
 
+    fun getWebCodecCapabilitiesJson(): String = JSONObject().apply {
+        put("h264MaxLevel", CodecHelpers.getVideoLevel("h264", maxAvcRawLevel)?.toString() ?: DEFAULT_H264_MAX_LEVEL)
+    }.toString()
+
     companion object {
         private const val EXTERNAL_PLAYER_PROFILE_NAME = Constants.APP_INFO_NAME + " External Player"
+        private const val DEFAULT_H264_MAX_LEVEL = "41"
 
         /**
          * List of container formats supported by ExoPlayer


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

This is an attempt, using Claude, to resolve the linked issue.  Instead of hardcoding the maximum H264 level, build it dynamically for the WebView.  This should allow clients which support higher levels to not transcode.

I confirmed with a level 4.2 file on my Pixel 6 Pro.  Using the web player, the current release results in transcoding.  With a build from this branch, the file is direct played.  I was able to reach level 5.2, the maximum my device supports, before transcoding began again.

**Issues**

Fixes #1921 
