### PR TITLE
Remove LeakCanary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,7 +164,6 @@ dependencies {
 
     // Monitoring
     implementation(libs.timber)
-    debugImplementation(libs.leakcanary)
 
     // Testing
     testImplementation(libs.junit.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,6 @@ androidx-room = "2.7.2"
 
 # Monitoring
 timber = "5.0.1"
-leakcanary = "2.14"
 
 # Testing
 junit = "6.0.3"
@@ -137,7 +136,6 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 
 # Monitoring
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
-leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
 
 # Testing
 junit-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }


### PR DESCRIPTION
**Changes**

Although a useful tool, it's annoying to be there by default. Especially when you test on your daily-driver (because no Android Auto in emulator 🫠). This PR removes leakcanary from the codebase, adding it back for testing is easy enough.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
