### PR TITLE
Replace loadUrl("javascript:...") with evaluateJavascript in WebViewFragment

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
@@ -162,7 +162,7 @@ class WebViewFragment : Fragment(), BackPressInterceptor, JellyfinWebChromeClien
         // Process JS functions called from other components (e.g. the PlayerActivity)
         lifecycleScope.launch {
             for (function in webappFunctionChannel) {
-                webView.loadUrl("javascript:$function")
+                webView.evaluateJavascript(function, null)
             }
         }
     }


### PR DESCRIPTION
**Changes**

Swap the legacy `loadUrl("javascript:...")` form to `webView.evaluateJavascript(function, null)` in `WebViewFragment`, where JS function calls from `webappFunctionChannel` are dispatched to the web client. The Android docs deprecated the `loadUrl` javascript URI form in 4.4 because it adds a navigation entry to the WebView back/forward history on every call. `evaluateJavascript` does not. Semantics are identical for the existing callers, since none of them consume a return value.

**Code assistance**

An LLM helped draft the body in this PR on top of a static-analysis report I am running across a set of Android apps. The actual change is a one-line swap I have read through and understand.

**Issues**

Fixes #1979