### PR TITLE
Change UserEntity.userId to UUID

### DIFF
--- a/app/schemas/org.jellyfin.mobile.data.JellyfinDatabase/4.json
+++ b/app/schemas/org.jellyfin.mobile.data.JellyfinDatabase/4.json
@@ -1,0 +1,155 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "00434f1e30d6e1643a4e1f0db9d792e7",
+    "entities": [
+      {
+        "tableName": "server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hostname` TEXT NOT NULL, `last_used_timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedTimestamp",
+            "columnName": "last_used_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_server_hostname",
+            "unique": true,
+            "columnNames": [
+              "hostname"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_server_hostname` ON `${TABLE_NAME}` (`hostname`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `server_id` INTEGER NOT NULL, `user_id` TEXT NOT NULL, `access_token` TEXT, `last_login_timestamp` INTEGER NOT NULL, FOREIGN KEY(`server_id`) REFERENCES `server`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "access_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastLoginTimestamp",
+            "columnName": "last_login_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_server_id_user_id",
+            "unique": true,
+            "columnNames": [
+              "server_id",
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_server_id_user_id` ON `${TABLE_NAME}` (`server_id`, `user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "server_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Download",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`item_id` TEXT NOT NULL, `media_source` TEXT NOT NULL, PRIMARY KEY(`item_id`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaSource",
+            "columnName": "media_source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Download_item_id",
+            "unique": true,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Download_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '00434f1e30d6e1643a4e1f0db9d792e7')"
+    ]
+  }
+}

--- a/app/src/main/java/org/jellyfin/mobile/app/ApiClientController.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/ApiClientController.kt
@@ -8,6 +8,7 @@ import org.jellyfin.mobile.data.entity.ServerEntity
 import org.jellyfin.sdk.Jellyfin
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.model.DeviceInfo
+import java.util.UUID
 
 class ApiClientController(
     private val appPreferences: AppPreferences,
@@ -29,7 +30,7 @@ class ApiClientController(
         apiClient.update(baseUrl = hostname)
     }
 
-    suspend fun setupUser(serverId: Long, userId: String, accessToken: String) {
+    suspend fun setupUser(serverId: Long, userId: UUID, accessToken: String) {
         appPreferences.currentUserId = withContext(Dispatchers.IO) {
             userDao.upsert(serverId, userId, accessToken)
         }
@@ -71,7 +72,7 @@ class ApiClientController(
         apiClient.update(baseUrl = server?.hostname)
     }
 
-    private fun configureApiClientUser(userId: String, accessToken: String) {
+    private fun configureApiClientUser(userId: UUID, accessToken: String) {
         apiClient.update(
             accessToken = accessToken,
             // Append user id to device id to ensure uniqueness across sessions

--- a/app/src/main/java/org/jellyfin/mobile/data/JellyfinDatabase.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/JellyfinDatabase.kt
@@ -2,13 +2,21 @@ package org.jellyfin.mobile.data
 
 import androidx.room.AutoMigration
 import androidx.room.Database
+import androidx.room.RenameTable
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
+import androidx.room.migration.AutoMigrationSpec
+import androidx.sqlite.db.SupportSQLiteDatabase
 import org.jellyfin.mobile.data.dao.DownloadDao
 import org.jellyfin.mobile.data.dao.ServerDao
 import org.jellyfin.mobile.data.dao.UserDao
 import org.jellyfin.mobile.data.entity.DownloadEntity
 import org.jellyfin.mobile.data.entity.ServerEntity
 import org.jellyfin.mobile.data.entity.UserEntity
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import timber.log.Timber
+import java.util.UUID
 
 @Database(
     entities = [
@@ -16,13 +24,49 @@ import org.jellyfin.mobile.data.entity.UserEntity
         UserEntity::class,
         DownloadEntity::class,
     ],
-    version = 3,
+    version = 4,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 3, to = 4, spec = JellyfinDatabase.MigrateV4::class),
     ],
 )
+@TypeConverters(JellyfinDatabase.Converters::class)
 abstract class JellyfinDatabase : RoomDatabase() {
     abstract val serverDao: ServerDao
     abstract val userDao: UserDao
     abstract val downloadDao: DownloadDao
+
+    // Converters
+
+    class Converters {
+        @TypeConverter
+        fun fromUuid(uuid: UUID?): String? = uuid?.toString()
+
+        @TypeConverter
+        fun toUuid(value: String?): UUID? = value?.toUUIDOrNull()
+    }
+
+    // Migrations
+
+    @RenameTable(fromTableName = "Server", toTableName = "server")
+    @RenameTable(fromTableName = "User", toTableName = "user")
+    class MigrateV4 : AutoMigrationSpec {
+        override fun onPostMigrate(db: SupportSQLiteDatabase) {
+            val cursor = db.query("SELECT user_id FROM user")
+            while (cursor.moveToNext()) {
+                val oldValue = cursor.getString(0)
+                val newValue = oldValue.toUUIDOrNull()?.toString()
+
+                if (newValue == null) {
+                    Timber.i("Deleting user $oldValue due to invalid userId")
+                    db.execSQL("DELETE FROM user WHERE user_id = ?", arrayOf(oldValue))
+                } else {
+                    Timber.i("Updating user $oldValue to userId $newValue")
+                    db.execSQL("UPDATE user SET user_id = ? WHERE user_id = ?", arrayOf(newValue, oldValue))
+                }
+            }
+
+            cursor.close()
+        }
+    }
 }

--- a/app/src/main/java/org/jellyfin/mobile/data/dao/UserDao.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/dao/UserDao.kt
@@ -12,6 +12,7 @@ import org.jellyfin.mobile.data.entity.UserEntity.Key.ID
 import org.jellyfin.mobile.data.entity.UserEntity.Key.SERVER_ID
 import org.jellyfin.mobile.data.entity.UserEntity.Key.TABLE_NAME
 import org.jellyfin.mobile.data.entity.UserEntity.Key.USER_ID
+import java.util.UUID
 
 @Dao
 @Suppress("TooManyFunctions")
@@ -19,10 +20,10 @@ interface UserDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
     fun insert(entity: UserEntity): Long
 
-    fun insert(serverId: Long, userId: String, accessToken: String?) = insert(UserEntity(serverId, userId, accessToken))
+    fun insert(serverId: Long, userId: UUID, accessToken: String?) = insert(UserEntity(serverId, userId, accessToken))
 
     @Transaction
-    fun upsert(serverId: Long, userId: String, accessToken: String?): Long {
+    fun upsert(serverId: Long, userId: UUID, accessToken: String?): Long {
         return when (val user = getByUserId(serverId, userId)) {
             null -> insert(serverId, userId, accessToken)
             else -> {
@@ -33,22 +34,22 @@ interface UserDao {
     }
 
     @Transaction
-    @Query("SELECT * FROM $TABLE_NAME WHERE $SERVER_ID = :serverId AND $ID = :userId")
-    fun getServerUser(serverId: Long, userId: Long): ServerUser?
+    @Query("SELECT * FROM $TABLE_NAME WHERE $SERVER_ID = :serverId AND $ID = :id")
+    fun getServerUser(serverId: Long, id: Long): ServerUser?
 
     @Transaction
     @Query("SELECT * FROM $TABLE_NAME WHERE $SERVER_ID = :serverId AND $USER_ID = :userId")
-    fun getServerUser(serverId: Long, userId: String): ServerUser?
+    fun getServerUser(serverId: Long, userId: UUID): ServerUser?
 
     @Query("SELECT * FROM $TABLE_NAME WHERE $SERVER_ID = :serverId AND $USER_ID = :userId")
-    fun getByUserId(serverId: Long, userId: String): UserEntity?
+    fun getByUserId(serverId: Long, userId: UUID): UserEntity?
 
     @Query("SELECT * FROM $TABLE_NAME WHERE $SERVER_ID = :serverId")
     fun getAllForServer(serverId: Long): List<UserEntity>
 
-    @Query("UPDATE $TABLE_NAME SET access_token = :accessToken WHERE $ID = :userId")
-    fun update(userId: Long, accessToken: String?): Int
+    @Query("UPDATE $TABLE_NAME SET access_token = :accessToken WHERE $ID = :id")
+    fun update(id: Long, accessToken: String?): Int
 
-    @Query("UPDATE $TABLE_NAME SET $ACCESS_TOKEN = NULL WHERE $ID = :userId")
-    fun logout(userId: Long)
+    @Query("UPDATE $TABLE_NAME SET $ACCESS_TOKEN = NULL WHERE $ID = :id")
+    fun logout(id: Long)
 }

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/ServerEntity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/ServerEntity.kt
@@ -23,7 +23,7 @@ data class ServerEntity(
     constructor(hostname: String) : this(0, hostname, System.currentTimeMillis())
 
     companion object Key {
-        const val TABLE_NAME = "Server"
+        const val TABLE_NAME = "server"
         const val ID = "id"
         const val HOSTNAME = "hostname"
         const val LAST_USED_TIMESTAMP = "last_used_timestamp"

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/UserEntity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/UserEntity.kt
@@ -8,6 +8,7 @@ import androidx.room.PrimaryKey
 import org.jellyfin.mobile.data.entity.UserEntity.Key.SERVER_ID
 import org.jellyfin.mobile.data.entity.UserEntity.Key.TABLE_NAME
 import org.jellyfin.mobile.data.entity.UserEntity.Key.USER_ID
+import java.util.UUID
 
 @Entity(
     tableName = TABLE_NAME,
@@ -25,17 +26,17 @@ data class UserEntity(
     @ColumnInfo(name = SERVER_ID)
     val serverId: Long,
     @ColumnInfo(name = USER_ID)
-    val userId: String,
+    val userId: UUID,
     @ColumnInfo(name = ACCESS_TOKEN)
     val accessToken: String?,
     @ColumnInfo(name = LAST_LOGIN_TIMESTAMP)
     val lastLoginTimestamp: Long,
 ) {
-    constructor(serverId: Long, userId: String, accessToken: String?) :
+    constructor(serverId: Long, userId: UUID, accessToken: String?) :
         this(0, serverId, userId, accessToken, System.currentTimeMillis())
 
     companion object Key {
-        const val TABLE_NAME = "User"
+        const val TABLE_NAME = "user"
         const val ID = "id"
         const val SERVER_ID = "server_id"
         const val USER_ID = "user_id"

--- a/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
@@ -7,13 +7,16 @@ import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 import java.util.Locale
+import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
-suspend fun WebView.initLocale(userId: String) {
+suspend fun WebView.initLocale(userId: UUID) {
     // Try to set locale via user settings
     val userSettings = suspendCoroutine { continuation ->
-        evaluateJavascript("window.localStorage.getItem('$userId-language')") { result ->
+        // jellyfin-web uses dash-less user ids
+        val flatUserId = userId.toString().replace("-", "")
+        evaluateJavascript("window.localStorage.getItem('$flatUserId-language')") { result ->
             try {
                 continuation.resume(JSONObject("{locale:$result}").getString("locale"))
             } catch (e: JSONException) {

--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
@@ -16,6 +16,7 @@ import org.jellyfin.mobile.data.entity.ServerEntity
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.initLocale
 import org.jellyfin.mobile.utils.inject
+import org.jellyfin.sdk.model.serializer.toUUID
 import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
@@ -64,7 +65,7 @@ abstract class JellyfinWebViewClient(
                         }
                     }
                     val storedServer = credentials.getJSONArray("Servers").getJSONObject(0)
-                    val user = storedServer.getString("UserId")
+                    val user = storedServer.getString("UserId").toUUID()
                     val token = storedServer.getString("AccessToken")
                     apiClientController.setupUser(server.id, user, token)
                     webView.initLocale(user)


### PR DESCRIPTION
**Changes**

- Change the userId property in the user entity to be an UUID
- Add migration that changes all users in the database to use dash formatted uuids (instead of dash-less)
- Add custom UUID converter to room
- Fix some variable names in UserDao (id != userId)
- Update language getting to convert uuid into dash-less
- Rename database tables to lower_snake_case

Note: This does NOT modify the download entity as it will be changed in a future PR

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
