### PR TITLE
Make playlists a top-level item in Android Auto

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryRoute.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryRoute.kt
@@ -59,7 +59,7 @@ sealed interface LibraryRoute {
     data class Genre(val genreId: UUID) : LibraryRoute
 
     @Serializable
-    data class Playlists(val libraryId: UUID) : LibraryRoute
+    data object Playlists : LibraryRoute
 
     @Serializable
     data class Playlist(val playlistId: UUID) : LibraryRoute

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/PlaylistsLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/PlaylistsLibraryPage.kt
@@ -13,7 +13,6 @@ import org.jellyfin.sdk.model.api.ItemSortBy
 val PlaylistsLibraryPage = { api: ApiClient ->
     libraryPage<LibraryRoute.Playlists>(grid = true) { route, offset, limit ->
         val result by api.itemsApi.getItems(
-            parentId = route.libraryId,
             includeItemTypes = listOf(BaseItemKind.PLAYLIST),
             sortBy = listOf(ItemSortBy.SORT_NAME),
             recursive = true,

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/RootLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/RootLibraryPage.kt
@@ -8,7 +8,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 import org.jellyfin.sdk.model.api.CollectionType
 
-private val collectionTypes = setOf(CollectionType.MUSIC, CollectionType.BOOKS)
+private val collectionTypes = setOf(CollectionType.MUSIC, CollectionType.BOOKS, CollectionType.PLAYLISTS)
 
 /**
  * Root library page that returns the available libraries (user views) for Android Auto playback.
@@ -28,7 +28,10 @@ val RootLibraryPage = { api: ApiClient ->
                     item = it,
                     image = null,
                     iconRes = null,
-                    action = LibraryItemAction.Navigate(LibraryRoute.Library(it.id, it.collectionType)),
+                    action = when (it.collectionType) {
+                        CollectionType.PLAYLISTS -> LibraryItemAction.Navigate(LibraryRoute.Playlists)
+                        else -> LibraryItemAction.Navigate(LibraryRoute.Library(it.id, it.collectionType))
+                    },
                 )
             }
     }

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/UserViewLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/UserViewLibraryPage.kt
@@ -60,14 +60,6 @@ val UserViewLibraryPage = { context: Context ->
 
             add(
                 LibraryPageElement.Item(
-                    title = context.getString(R.string.media_service_car_section_playlists),
-                    iconRes = R.drawable.ic_playlist,
-                    action = LibraryItemAction.Navigate(LibraryRoute.Playlists(route.libraryId)),
-                ),
-            )
-
-            add(
-                LibraryPageElement.Item(
                     title = context.getString(R.string.media_service_car_section_recents),
                     iconRes = R.drawable.ic_recently_played,
                     action = LibraryItemAction.Navigate(LibraryRoute.Recent(route.libraryId)),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,6 @@
     <string name="media_service_car_section_artists">Artists</string>
     <string name="media_service_car_section_songs">Songs</string>
     <string name="media_service_car_section_genres">Genres</string>
-    <string name="media_service_car_section_playlists">Playlists</string>
     <string name="media_service_car_item_no_title">No title</string>
 
     <string name="music_notification_channel">Jellyfin Music Player</string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

The server is unable to query playlists per-library. We already have a "playlists" user view so change the Android Auto support to show a top-level "Playlists" entry instead.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #1988