### PR TITLE
Use artists API for querying artists in Android Auto

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/ArtistsLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/ArtistsLibraryPage.kt
@@ -5,18 +5,15 @@ import org.jellyfin.mobile.sessionbrowser.LibraryPageElement
 import org.jellyfin.mobile.sessionbrowser.LibraryRoute
 import org.jellyfin.mobile.sessionbrowser.libraryPage
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.extensions.itemsApi
-import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.api.client.extensions.artistsApi
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemSortBy
 
 val ArtistsLibraryPage = { api: ApiClient ->
     libraryPage<LibraryRoute.Artists>(grid = true) { route, offset, limit ->
-        val result by api.itemsApi.getItems(
+        val result by api.artistsApi.getArtists(
             parentId = route.libraryId,
-            includeItemTypes = listOf(BaseItemKind.MUSIC_ARTIST),
             sortBy = listOf(ItemSortBy.SORT_NAME),
-            recursive = true,
             imageTypeLimit = 1,
             enableImageTypes = listOf(ImageType.PRIMARY),
             nameLessThan = if (route.startLetter == ALPHA_BROWSER_OTHER) ALPHA_BROWSER_LETTERS[0].toString() else null,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Jellyfin is a bit weird in how it handles artists as they're partially on the file system and partially in the database. Querying artists via the item API will return different results compared to the dedicated artist API.

Switch out artist querying to use the artist API. This is the same API jellyfin-web uses for the artists tab.


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #1995