### PR TITLE
Direct play Live TV MPEG-TS streams

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
@@ -149,9 +149,9 @@ val applicationModule = module {
             }
     }
 
-    single<MediaSource.Factory> {
+    single<DefaultExtractorsFactory> {
         val context: Context = get()
-        val extractorsFactory = DefaultExtractorsFactory().apply {
+        DefaultExtractorsFactory().apply {
             // https://github.com/google/ExoPlayer/issues/8571
             setTsExtractorTimestampSearchBytes(
                 when {
@@ -160,9 +160,19 @@ val applicationModule = module {
                 },
             )
         }
-        DefaultMediaSourceFactory(get<CacheDataSource.Factory>(), extractorsFactory)
     }
-    single { ProgressiveMediaSource.Factory(get<CacheDataSource.Factory>()) }
+    single<MediaSource.Factory> {
+        DefaultMediaSourceFactory(
+            get<CacheDataSource.Factory>(),
+            get<DefaultExtractorsFactory>(),
+        )
+    }
+    single {
+        ProgressiveMediaSource.Factory(
+            get<CacheDataSource.Factory>(),
+            get<DefaultExtractorsFactory>(),
+        )
+    }
     single { HlsMediaSource.Factory(get<CacheDataSource.Factory>()) }
     single { SingleSampleMediaSource.Factory(get<CacheDataSource.Factory>()) }
 }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.mobile.bridge
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -11,16 +12,19 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
 import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.player.PlayerException
 import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder
 import org.jellyfin.mobile.player.interaction.PlayOptions
+import org.jellyfin.mobile.player.queue.DirectPlayHttpUrl
 import org.jellyfin.mobile.player.source.ExternalSubtitleStream
-import org.jellyfin.mobile.player.source.JellyfinMediaSource
 import org.jellyfin.mobile.player.source.MediaSourceResolver
+import org.jellyfin.mobile.player.source.RemoteJellyfinMediaSource
 import org.jellyfin.mobile.settings.ExternalPlayerPackage
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
@@ -28,9 +32,13 @@ import org.jellyfin.mobile.utils.isPackageInstalled
 import org.jellyfin.mobile.utils.toast
 import org.jellyfin.mobile.webapp.WebappFunctionChannel
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.exception.ApiClientException
+import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
+import org.jellyfin.sdk.api.operations.MediaInfoApi
 import org.jellyfin.sdk.api.operations.VideosApi
 import org.jellyfin.sdk.model.api.DeviceProfile
+import org.jellyfin.sdk.model.api.MediaProtocol
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.json.JSONObject
 import org.koin.core.component.KoinComponent
@@ -52,12 +60,16 @@ class ExternalPlayer(
     private val externalPlayerProfile: DeviceProfile = deviceProfileBuilder.getExternalPlayerProfile()
     private val apiClient: ApiClient = get()
     private val videosApi: VideosApi = apiClient.videosApi
+    private val mediaInfoApi: MediaInfoApi = apiClient.mediaInfoApi
+    private var currentLiveStreamId: String? = null
 
     private val playerContract = registry.register(
         "externalplayer",
         lifecycleOwner,
         ActivityResultContracts.StartActivityForResult(),
     ) { result ->
+        closeCurrentLiveStream()
+
         val resultCode = result.resultCode
         val intent = result.data
         when (val action = intent?.action) {
@@ -103,7 +115,6 @@ class ExternalPlayer(
                 audioStreamIndex = playOptions.audioStreamIndex,
                 subtitleStreamIndex = playOptions.subtitleStreamIndex,
                 maxStreamingBitrate = Int.MAX_VALUE, // ensure we always direct play
-                autoOpenLiveStream = false,
             ).onSuccess { jellyfinMediaSource ->
                 playMediaSource(playOptions, jellyfinMediaSource)
             }.onFailure { error ->
@@ -117,14 +128,13 @@ class ExternalPlayer(
         }
     }
 
-    private fun playMediaSource(playOptions: PlayOptions, source: JellyfinMediaSource) {
-        // Create direct play URL
-        val url = videosApi.getVideoStreamUrl(
-            itemId = source.itemId,
-            static = true,
-            mediaSourceId = source.id,
-            playSessionId = source.playSessionId,
-        )
+    private fun playMediaSource(playOptions: PlayOptions, source: RemoteJellyfinMediaSource) {
+        val url = runCatching { createDirectPlayUrl(source) }.getOrElse {
+            Timber.e(it, "Unable to create direct play URL for external player")
+            closeLiveStream(source.liveStreamId)
+            context.toast(R.string.player_error_unsupported_content)
+            return
+        }
 
         // Select correct subtitle
         val selectedSubtitleStream = playOptions.subtitleStreamIndex?.let { index ->
@@ -165,11 +175,66 @@ class ExternalPlayer(
             // VLC
             if (enabledSubUrl != null) putExtra("subtitles_location", enabledSubUrl)
         }
-        playerContract.launch(playerIntent)
+        if (currentLiveStreamId != source.liveStreamId) {
+            closeCurrentLiveStream()
+        }
+        currentLiveStreamId = source.liveStreamId
+        try {
+            playerContract.launch(playerIntent)
+        } catch (e: ActivityNotFoundException) {
+            Timber.e(e, "No external player available")
+            closeCurrentLiveStream()
+            notifyEvent(Constants.EVENT_CANCELED)
+            context.toast(R.string.external_player_invalid_player, Toast.LENGTH_LONG)
+            return
+        }
+        val playbackMessage = "Starting playback [id=${source.itemId}, title=${source.getName(context)}, " +
+            "playMethod=${source.playMethod}, startTime=${source.startTime}]"
         Timber.d(
-            "Starting playback [id=${source.itemId}, title=${source.getName(context)}, " +
-                "playMethod=${source.playMethod}, startTime=${source.startTime}]",
+            playbackMessage,
         )
+    }
+
+    private fun createDirectPlayUrl(source: RemoteJellyfinMediaSource): String {
+        val sourceInfo = source.sourceInfo
+
+        return when (sourceInfo.protocol) {
+            MediaProtocol.FILE -> videosApi.getVideoStreamUrl(
+                itemId = source.itemId,
+                static = true,
+                mediaSourceId = source.id,
+                playSessionId = source.playSessionId,
+                deviceId = apiClient.deviceInfo.id,
+                liveStreamId = source.liveStreamId,
+            )
+            MediaProtocol.HTTP -> DirectPlayHttpUrl.resolve(
+                path = requireNotNull(sourceInfo.path),
+                serverBaseUrl = apiClient.baseUrl,
+                createServerUrl = apiClient::createUrl,
+            )
+            else -> throw IllegalArgumentException("Unsupported protocol ${sourceInfo.protocol}")
+        }
+    }
+
+    private fun closeCurrentLiveStream() {
+        val liveStreamId = currentLiveStreamId ?: return
+        currentLiveStreamId = null
+
+        closeLiveStream(liveStreamId)
+    }
+
+    private fun closeLiveStream(liveStreamId: String?) {
+        if (liveStreamId == null) return
+
+        coroutinesScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    mediaInfoApi.closeLiveStream(liveStreamId)
+                }
+            } catch (e: ApiClientException) {
+                Timber.e(e, "Failed to close external player live stream")
+            }
+        }
     }
 
     private fun notifyEvent(event: String, parameters: String = "") {

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceCodecs.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceCodecs.kt
@@ -1,0 +1,6 @@
+package org.jellyfin.mobile.player.deviceprofile
+
+data class DeviceCodecs(
+    val video: Map<String, DeviceCodec.Video>,
+    val audio: Map<String, DeviceCodec.Audio>,
+)

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -19,6 +19,7 @@ import org.jellyfin.sdk.model.api.TranscodingProfile
 
 class DeviceProfileBuilder(
     private val appPreferences: AppPreferences,
+    private val deviceCodecs: DeviceCodecs = loadDeviceCodecs(),
 ) {
     private val supportedVideoCodecs: Array<Array<String>>
     private val supportedAudioCodecs: Array<Array<String>>
@@ -31,47 +32,18 @@ class DeviceProfileBuilder(
             SUPPORTED_CONTAINER_FORMATS.size == AVAILABLE_VIDEO_CODECS.size && SUPPORTED_CONTAINER_FORMATS.size == AVAILABLE_AUDIO_CODECS.size,
         )
 
-        // Load Android-supported codecs
-        val videoCodecs: MutableMap<String, DeviceCodec.Video> = HashMap()
-        val audioCodecs: MutableMap<String, DeviceCodec.Audio> = HashMap()
-        val androidCodecs = MediaCodecList(MediaCodecList.REGULAR_CODECS)
-        for (codecInfo in androidCodecs.codecInfos) {
-            if (codecInfo.isEncoder) continue
-
-            for (mimeType in codecInfo.supportedTypes) {
-                val codec = DeviceCodec.from(codecInfo.getCapabilitiesForType(mimeType)) ?: continue
-                val name = codec.name
-                when (codec) {
-                    is DeviceCodec.Video -> {
-                        if (videoCodecs.containsKey(name)) {
-                            videoCodecs[name] = videoCodecs[name]!!.mergeCodec(codec)
-                        } else {
-                            videoCodecs[name] = codec
-                        }
-                    }
-                    is DeviceCodec.Audio -> {
-                        if (audioCodecs.containsKey(mimeType)) {
-                            audioCodecs[name] = audioCodecs[name]!!.mergeCodec(codec)
-                        } else {
-                            audioCodecs[name] = codec
-                        }
-                    }
-                }
-            }
-        }
-
         // Build map of supported codecs from device support and hardcoded data
         supportedVideoCodecs = Array(AVAILABLE_VIDEO_CODECS.size) { i ->
             AVAILABLE_VIDEO_CODECS[i].filter { codec ->
-                videoCodecs.containsKey(codec)
+                deviceCodecs.video.containsKey(codec)
             }.toTypedArray()
         }
         supportedAudioCodecs = Array(AVAILABLE_AUDIO_CODECS.size) { i ->
             AVAILABLE_AUDIO_CODECS[i].filter { codec ->
-                audioCodecs.containsKey(codec) || codec in FORCED_AUDIO_CODECS
+                deviceCodecs.audio.containsKey(codec) || codec in FORCED_AUDIO_CODECS
             }.toTypedArray()
         }
-        videoCodecsProfiles = videoCodecs.entries.associate { (k, v) -> k to v.profiles }
+        videoCodecsProfiles = deviceCodecs.video.entries.associate { (k, v) -> k to v.profiles }
 
         transcodingProfiles = listOf(
             TranscodingProfile(
@@ -219,94 +191,30 @@ class DeviceProfileBuilder(
 
         /**
          * List of container formats supported by ExoPlayer
-         *
-         * IMPORTANT: Don't change without updating [AVAILABLE_VIDEO_CODECS] and [AVAILABLE_AUDIO_CODECS]
          */
-        private val SUPPORTED_CONTAINER_FORMATS = arrayOf(
-            "mp4", "fmp4", "webm", "mkv", "mp3", "ogg", "wav", "mpegts", "flv", "aac", "flac", "3gp",
-        )
+        private val SUPPORTED_CONTAINER_FORMATS = ExoPlayerDirectPlayProfile.containers
+            .map(ExoPlayerContainerSupport::container)
+            .toTypedArray()
 
         /**
-         * IMPORTANT: Must have same length as [SUPPORTED_CONTAINER_FORMATS],
-         * as it maps the codecs to the containers with the same index!
+         * Video codecs mapped to [SUPPORTED_CONTAINER_FORMATS] by index.
          */
-        private val AVAILABLE_VIDEO_CODECS = arrayOf(
-            // mp4
-            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp9"),
-            // fmp4
-            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp9"),
-            // webm
-            arrayOf("vp8", "vp9", "av1"),
-            // mkv
-            arrayOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp8", "vp9"),
-            // mp3
-            emptyArray(),
-            // ogg
-            emptyArray(),
-            // wav
-            emptyArray(),
-            // mpegts
-            arrayOf("mpeg1video", "mpeg2video", "mpeg4", "h264", "hevc"),
-            // flv
-            arrayOf("mpeg4", "h264"),
-            // aac
-            emptyArray(),
-            // flac
-            emptyArray(),
-            // 3gp
-            arrayOf("h263", "mpeg4", "h264", "hevc"),
-        )
+        private val AVAILABLE_VIDEO_CODECS = ExoPlayerDirectPlayProfile.containers
+            .map { container -> container.videoCodecs.toTypedArray() }
+            .toTypedArray()
 
         /**
-         * List of PCM codecs supported by ExoPlayer by default
+         * Audio codecs mapped to [SUPPORTED_CONTAINER_FORMATS] by index.
          */
-        private val PCM_CODECS = arrayOf(
-            "pcm_s8",
-            "pcm_s16be",
-            "pcm_s16le",
-            "pcm_s24le",
-            "pcm_s32le",
-            "pcm_f32le",
-            "pcm_alaw",
-            "pcm_mulaw",
-        )
-
-        /**
-         * IMPORTANT: Must have same length as [SUPPORTED_CONTAINER_FORMATS],
-         * as it maps the codecs to the containers with the same index!
-         */
-        private val AVAILABLE_AUDIO_CODECS = arrayOf(
-            // mp4
-            arrayOf("mp1", "mp2", "mp3", "aac", "alac", "ac3", "opus"),
-            // fmp4
-            arrayOf("mp3", "aac", "ac3", "eac3"),
-            // webm
-            arrayOf("vorbis", "opus"),
-            // mkv
-            arrayOf(*PCM_CODECS, "mp1", "mp2", "mp3", "aac", "vorbis", "opus", "flac", "alac", "ac3", "eac3", "dts", "mlp", "truehd"),
-            // mp3
-            arrayOf("mp3"),
-            // ogg
-            arrayOf("vorbis", "opus", "flac"),
-            // wav
-            PCM_CODECS,
-            // mpegts
-            arrayOf(*PCM_CODECS, "mp1", "mp2", "mp3", "aac", "ac3", "eac3", "dts", "mlp", "truehd"),
-            // flv
-            arrayOf("mp3", "aac"),
-            // aac
-            arrayOf("aac"),
-            // flac
-            arrayOf("flac"),
-            // 3gp
-            arrayOf("3gpp", "aac", "flac"),
-        )
+        private val AVAILABLE_AUDIO_CODECS = ExoPlayerDirectPlayProfile.containers
+            .map { container -> container.audioCodecs.toTypedArray() }
+            .toTypedArray()
 
         /**
          * List of audio codecs that will be added to the device profile regardless of [MediaCodecList] advertising them.
          * This is especially useful for codecs supported by decoders integrated to ExoPlayer or added through an extension.
          */
-        private val FORCED_AUDIO_CODECS = arrayOf(*PCM_CODECS, "alac", "aac", "ac3", "eac3", "dts", "mlp", "truehd")
+        private val FORCED_AUDIO_CODECS = ExoPlayerDirectPlayProfile.forcedAudioCodecs
 
         private val EXO_EMBEDDED_SUBTITLES = arrayOf("dvbsub", "pgssub", "srt", "subrip", "ttml")
         private val EXO_EXTERNAL_SUBTITLES = arrayOf("srt", "subrip", "ttml", "vtt", "webvtt")
@@ -332,5 +240,36 @@ class DeviceProfileBuilder(
          * https://github.com/jellyfin/jellyfin-web/blob/de690740f03c0568ba3061c4c586bd78b375d882/src/scripts/browserDeviceProfile.js#L373
          */
         private const val MAX_MUSIC_TRANSCODING_BITRATE = 384000
+
+        private fun loadDeviceCodecs(): DeviceCodecs {
+            val videoCodecs: MutableMap<String, DeviceCodec.Video> = HashMap()
+            val audioCodecs: MutableMap<String, DeviceCodec.Audio> = HashMap()
+            val androidCodecs = MediaCodecList(MediaCodecList.REGULAR_CODECS)
+
+            for (codecInfo in androidCodecs.codecInfos) {
+                if (codecInfo.isEncoder) continue
+
+                for (mimeType in codecInfo.supportedTypes) {
+                    val codec = DeviceCodec.from(codecInfo.getCapabilitiesForType(mimeType)) ?: continue
+                    addDeviceCodec(codec, videoCodecs, audioCodecs)
+                }
+            }
+
+            return DeviceCodecs(
+                video = videoCodecs,
+                audio = audioCodecs,
+            )
+        }
+
+        private fun addDeviceCodec(
+            codec: DeviceCodec,
+            videoCodecs: MutableMap<String, DeviceCodec.Video>,
+            audioCodecs: MutableMap<String, DeviceCodec.Audio>,
+        ) {
+            when (codec) {
+                is DeviceCodec.Video -> videoCodecs[codec.name] = videoCodecs[codec.name]?.mergeCodec(codec) ?: codec
+                is DeviceCodec.Audio -> audioCodecs[codec.name] = audioCodecs[codec.name]?.mergeCodec(codec) ?: codec
+            }
+        }
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/ExoPlayerDirectPlayProfile.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/ExoPlayerDirectPlayProfile.kt
@@ -1,0 +1,108 @@
+package org.jellyfin.mobile.player.deviceprofile
+
+internal data class ExoPlayerContainerSupport(
+    val container: String,
+    val videoCodecs: List<String>,
+    val audioCodecs: List<String>,
+)
+
+internal object ExoPlayerDirectPlayProfile {
+    val pcmCodecs = listOf(
+        "pcm_s8",
+        "pcm_s16be",
+        "pcm_s16le",
+        "pcm_s24le",
+        "pcm_s32le",
+        "pcm_f32le",
+        "pcm_alaw",
+        "pcm_mulaw",
+    )
+
+    val mpegTsContainers = listOf("mpegts", "ts")
+    val mpegTsVideoCodecs = listOf("mpeg1video", "mpeg2video", "mpeg4", "h264", "hevc")
+    val mpegTsAudioCodecs = pcmCodecs + listOf("mp1", "mp2", "mp3", "aac", "ac3", "eac3", "dts", "mlp", "truehd")
+    val containers = listOf(
+        ExoPlayerContainerSupport(
+            container = "mp4",
+            videoCodecs = listOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp9"),
+            audioCodecs = listOf("mp1", "mp2", "mp3", "aac", "alac", "ac3", "opus"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "fmp4",
+            videoCodecs = listOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp9"),
+            audioCodecs = listOf("mp3", "aac", "ac3", "eac3"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "webm",
+            videoCodecs = listOf("vp8", "vp9", "av1"),
+            audioCodecs = listOf("vorbis", "opus"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "mkv",
+            videoCodecs = listOf("mpeg1video", "mpeg2video", "h263", "mpeg4", "h264", "hevc", "av1", "vp8", "vp9"),
+            audioCodecs = pcmCodecs + listOf("mp1", "mp2", "mp3", "aac", "vorbis", "opus", "flac", "alac", "ac3", "eac3", "dts", "mlp", "truehd"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "mp3",
+            videoCodecs = emptyList(),
+            audioCodecs = listOf("mp3"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "ogg",
+            videoCodecs = emptyList(),
+            audioCodecs = listOf("vorbis", "opus", "flac"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "wav",
+            videoCodecs = emptyList(),
+            audioCodecs = pcmCodecs,
+        ),
+        ExoPlayerContainerSupport(
+            container = "mpegts",
+            videoCodecs = mpegTsVideoCodecs,
+            audioCodecs = mpegTsAudioCodecs,
+        ),
+        ExoPlayerContainerSupport(
+            container = "ts",
+            videoCodecs = mpegTsVideoCodecs,
+            audioCodecs = mpegTsAudioCodecs,
+        ),
+        ExoPlayerContainerSupport(
+            container = "flv",
+            videoCodecs = listOf("mpeg4", "h264"),
+            audioCodecs = listOf("mp3", "aac"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "aac",
+            videoCodecs = emptyList(),
+            audioCodecs = listOf("aac"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "flac",
+            videoCodecs = emptyList(),
+            audioCodecs = listOf("flac"),
+        ),
+        ExoPlayerContainerSupport(
+            container = "3gp",
+            videoCodecs = listOf("h263", "mpeg4", "h264", "hevc"),
+            audioCodecs = listOf("3gpp", "aac", "flac"),
+        ),
+    )
+
+    val forcedAudioCodecs = pcmCodecs + listOf(
+        "mp1",
+        "mp2",
+        "mp3",
+        "alac",
+        "aac",
+        "ac3",
+        "eac3",
+        "dts",
+        "mlp",
+        "truehd",
+    )
+
+    fun isMpegTsContainer(container: String?): Boolean = container
+        ?.split(',', '|')
+        ?.any { value -> value.trim().lowercase() in mpegTsContainers } == true
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
@@ -31,7 +31,7 @@ data class PlayOptions(
                         }
                     }
                 } ?: emptyList(),
-                mediaSourceId = json.optString("mediaSourceId"),
+                mediaSourceId = json.optString("mediaSourceId").ifBlank { null },
                 startIndex = json.optInt("startIndex"),
                 startPosition = (json.optLong("startPositionTicks").takeIf { it > 0 })?.ticks,
                 audioStreamIndex = json.optString("audioStreamIndex").toIntOrNull(),

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/DirectPlayHttpMediaSourceType.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/DirectPlayHttpMediaSourceType.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.mobile.player.queue
+
+import org.jellyfin.mobile.player.deviceprofile.ExoPlayerDirectPlayProfile
+
+internal enum class DirectPlayHttpMediaSourceType {
+    HLS,
+    PROGRESSIVE,
+    ;
+
+    companion object {
+        fun from(
+            container: String?,
+            path: String?,
+            formats: List<String>?,
+        ): DirectPlayHttpMediaSourceType = when {
+            path.hasHlsExtension() -> HLS
+            ExoPlayerDirectPlayProfile.isMpegTsContainer(container) -> PROGRESSIVE
+            formats.orEmpty().any(ExoPlayerDirectPlayProfile::isMpegTsContainer) -> PROGRESSIVE
+            path.hasMpegTsExtension() -> PROGRESSIVE
+            else -> HLS
+        }
+
+        fun fromContainer(container: String?): DirectPlayHttpMediaSourceType = when {
+            ExoPlayerDirectPlayProfile.isMpegTsContainer(container) -> PROGRESSIVE
+            else -> HLS
+        }
+
+        private fun String?.hasHlsExtension(): Boolean {
+            val path = this.pathWithoutQueryOrFragment() ?: return false
+
+            return path.endsWith(".m3u8") || path.endsWith(".m3u")
+        }
+
+        private fun String?.hasMpegTsExtension(): Boolean {
+            val path = this.pathWithoutQueryOrFragment() ?: return false
+
+            return path.endsWith(".ts") || path.endsWith(".mpegts")
+        }
+
+        private fun String?.pathWithoutQueryOrFragment(): String? = this
+            ?.substringBefore('?')
+            ?.substringBefore('#')
+            ?.lowercase()
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/DirectPlayHttpUrl.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/DirectPlayHttpUrl.kt
@@ -1,0 +1,61 @@
+package org.jellyfin.mobile.player.queue
+
+import java.net.URI
+
+internal object DirectPlayHttpUrl {
+    private const val LIVE_TV_STREAM_PATH = "/LiveTv/LiveStreamFiles/"
+
+    fun resolve(path: String, serverBaseUrl: String?, createServerUrl: (String) -> String): String = when (
+        val serverPath = path.toJellyfinLiveTvStreamPath(serverBaseUrl)
+    ) {
+        null -> when {
+            path.isAbsoluteUrl() -> path
+            else -> createServerUrl(path)
+        }
+        else -> createServerUrl(serverPath)
+    }
+
+    private fun String.toJellyfinLiveTvStreamPath(serverBaseUrl: String?): String? {
+        val uri = runCatching { URI(this) }.getOrNull() ?: return null
+        val path = uri.rawPath ?: return null
+        val serverUri = serverBaseUrl?.let { url -> runCatching { URI(url) }.getOrNull() }
+        val candidatePath = path.removeServerBasePath(serverUri?.rawPath)
+
+        if (!candidatePath.startsWith(LIVE_TV_STREAM_PATH, ignoreCase = true)) return null
+        if (uri.isAbsolute && uri.isNotServerGeneratedUrl(serverUri)) return null
+
+        return buildString {
+            append(candidatePath)
+            uri.rawQuery?.let { query ->
+                append('?')
+                append(query)
+            }
+        }
+    }
+
+    private fun String.removeServerBasePath(serverBasePath: String?): String {
+        val basePath = serverBasePath
+            ?.takeUnless { path -> path == "/" }
+            ?.trimEnd('/')
+            ?: return this
+
+        return when {
+            startsWith("$basePath/", ignoreCase = true) -> substring(basePath.length)
+            else -> this
+        }
+    }
+
+    private fun URI.isNotServerGeneratedUrl(serverUri: URI?): Boolean {
+        val serverAuthority = serverUri?.authority
+        return !authority.equals(serverAuthority, ignoreCase = true) && host?.isLoopbackHost() != true
+    }
+
+    private fun String.isLoopbackHost(): Boolean = equals("localhost", ignoreCase = true) ||
+        this == "127.0.0.1" ||
+        this == "::1" ||
+        this == "[::1]"
+
+    private fun String.isAbsoluteUrl(): Boolean = runCatching {
+        URI(this).isAbsolute
+    }.getOrDefault(false)
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -25,6 +25,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.api.operations.VideosApi
 import org.jellyfin.sdk.model.api.MediaProtocol
+import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamProtocol
 import org.jellyfin.sdk.model.api.MediaStreamType
@@ -257,7 +258,7 @@ class QueueManager(
      * @return A [MediaSource]. The type of MediaSource depends on the playback method/protocol.
      */
     @CheckResult
-    private fun createVideoMediaSource(source: JellyfinMediaSource): MediaSource {
+    private fun createVideoMediaSource(source: RemoteJellyfinMediaSource): MediaSource {
         val sourceInfo = source.sourceInfo
         val (url, factory) = when (source.playMethod) {
             PlayMethod.DIRECT_PLAY -> {
@@ -269,16 +270,12 @@ class QueueManager(
                             playSessionId = source.playSessionId,
                             mediaSourceId = source.id,
                             deviceId = apiClient.deviceInfo.id,
+                            liveStreamId = source.liveStreamId,
                         )
 
                         url to get<ProgressiveMediaSource.Factory>()
                     }
-                    MediaProtocol.HTTP -> {
-                        val url = requireNotNull(sourceInfo.path)
-                        val factory = get<HlsMediaSource.Factory>().setAllowChunklessPreparation(true)
-
-                        url to factory
-                    }
+                    MediaProtocol.HTTP -> createDirectPlayHttpMediaSource(sourceInfo)
                     else -> throw IllegalArgumentException("Unsupported protocol ${sourceInfo.protocol}")
                 }
             }
@@ -290,6 +287,7 @@ class QueueManager(
                     playSessionId = source.playSessionId,
                     mediaSourceId = source.id,
                     deviceId = apiClient.deviceInfo.id,
+                    liveStreamId = source.liveStreamId,
                 )
 
                 url to get<ProgressiveMediaSource.Factory>()
@@ -311,6 +309,26 @@ class QueueManager(
             .build()
 
         return factory.createMediaSource(mediaItem)
+    }
+
+    private fun createDirectPlayHttpMediaSource(sourceInfo: MediaSourceInfo): Pair<String, MediaSource.Factory> {
+        val url = DirectPlayHttpUrl.resolve(
+            path = requireNotNull(sourceInfo.path),
+            serverBaseUrl = apiClient.baseUrl,
+            createServerUrl = apiClient::createUrl,
+        )
+        val factory: MediaSource.Factory = when (
+            DirectPlayHttpMediaSourceType.from(
+                container = sourceInfo.container,
+                path = url,
+                formats = sourceInfo.formats,
+            )
+        ) {
+            DirectPlayHttpMediaSourceType.PROGRESSIVE -> get<ProgressiveMediaSource.Factory>()
+            DirectPlayHttpMediaSourceType.HLS -> get<HlsMediaSource.Factory>().setAllowChunklessPreparation(true)
+        }
+
+        return url to factory
     }
 
     /**

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -9,11 +9,11 @@ import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.operations.MediaInfoApi
 import org.jellyfin.sdk.api.operations.UserLibraryApi
+import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.extensions.inWholeTicks
-import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import timber.log.Timber
 import java.util.UUID
 import kotlin.time.Duration
@@ -33,6 +33,8 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
         subtitleStreamIndex: Int? = null,
         autoOpenLiveStream: Boolean = true,
     ): Result<RemoteJellyfinMediaSource> {
+        val item = loadItem(itemId)
+
         // Load media source info
         val playSessionId: String
         val mediaSourceInfo: MediaSourceInfo = try {
@@ -43,7 +45,11 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
                         // We need to remove the dashes so that the server can find the correct media source.
                         // And if we didn't pass the mediaSourceId, our stream indices would silently get ignored.
                         // https://github.com/jellyfin/jellyfin/blob/9a35fd673203cfaf0098138b2768750f4818b3ab/Jellyfin.Api/Helpers/MediaInfoHelper.cs#L196-L201
-                        mediaSourceId = mediaSourceId ?: itemId.toString().replace("-", ""),
+                        mediaSourceId = playbackInfoMediaSourceId(
+                            requestedMediaSourceId = mediaSourceId,
+                            itemId = itemId,
+                            itemType = item?.type,
+                        ),
                         deviceProfile = deviceProfile,
                         maxStreamingBitrate = maxStreamingBitrate,
                         startTimeTicks = startTime?.inWholeTicks,
@@ -56,23 +62,13 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
 
             playSessionId = response.playSessionId ?: return Result.failure(PlayerException.UnsupportedContent())
 
-            response.mediaSources.let { sources ->
-                sources.find { source -> source.id?.toUUIDOrNull() == itemId } ?: sources.firstOrNull()
-            } ?: return Result.failure(PlayerException.UnsupportedContent())
+            MediaSourceSelector.select(
+                sources = response.mediaSources,
+                requestedMediaSourceId = mediaSourceId,
+            ) ?: return Result.failure(PlayerException.UnsupportedContent())
         } catch (e: ApiClientException) {
             Timber.e(e, "Failed to load media source $itemId")
             return Result.failure(PlayerException.NetworkFailure(e))
-        }
-
-        // Load additional item info if possible
-
-        val item = try {
-            withContext(Dispatchers.IO) {
-                userLibraryApi.getItem(itemId).content
-            }
-        } catch (e: ApiClientException) {
-            Timber.e(e, "Failed to load item for media source $itemId")
-            null
         }
 
         // Create JellyfinMediaSource
@@ -92,4 +88,22 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
             Result.failure(PlayerException.UnsupportedContent(e))
         }
     }
+
+    private suspend fun loadItem(itemId: UUID) = try {
+        withContext(Dispatchers.IO) {
+            userLibraryApi.getItem(itemId).content
+        }
+    } catch (e: ApiClientException) {
+        Timber.e(e, "Failed to load item for media source $itemId")
+        null
+    }
+}
+
+internal fun playbackInfoMediaSourceId(
+    requestedMediaSourceId: String?,
+    itemId: UUID,
+    itemType: BaseItemKind?,
+): String? = requestedMediaSourceId ?: when (itemType) {
+    BaseItemKind.TV_CHANNEL -> null
+    else -> itemId.toString().replace("-", "")
 }

--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceSelector.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceSelector.kt
@@ -1,0 +1,36 @@
+package org.jellyfin.mobile.player.source
+
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+
+internal object MediaSourceSelector {
+    private const val DIRECT_PLAY_PRIORITY = 0
+    private const val DIRECT_STREAM_PRIORITY = 1
+    private const val TRANSCODE_PRIORITY = 2
+    private const val UNSUPPORTED_PRIORITY = 3
+
+    fun select(
+        sources: List<MediaSourceInfo>,
+        requestedMediaSourceId: String?,
+    ): MediaSourceInfo? {
+        requestedMediaSourceId?.takeIf(String::isNotBlank)?.let { requestedId ->
+            sources.find { source -> source.id.matchesMediaSourceId(requestedId) }
+        }?.let { source -> return source }
+
+        return sources.minByOrNull { source -> source.playMethodPriority() }
+    }
+
+    private fun String?.matchesMediaSourceId(other: String): Boolean {
+        if (this == null) return false
+
+        return normalizeMediaSourceId() == other.normalizeMediaSourceId()
+    }
+
+    private fun String.normalizeMediaSourceId(): String = replace("-", "").lowercase()
+
+    private fun MediaSourceInfo.playMethodPriority(): Int = when {
+        supportsDirectPlay || RemoteDirectPlaySupport.canPlayMpegTsHttpDirectly(this) -> DIRECT_PLAY_PRIORITY
+        supportsDirectStream -> DIRECT_STREAM_PRIORITY
+        supportsTranscoding -> TRANSCODE_PRIORITY
+        else -> UNSUPPORTED_PRIORITY
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/source/RemoteDirectPlaySupport.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/RemoteDirectPlaySupport.kt
@@ -1,0 +1,30 @@
+package org.jellyfin.mobile.player.source
+
+import org.jellyfin.mobile.player.deviceprofile.ExoPlayerDirectPlayProfile
+import org.jellyfin.sdk.model.api.MediaProtocol
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+import org.jellyfin.sdk.model.api.MediaStream
+import org.jellyfin.sdk.model.api.MediaStreamType
+
+internal object RemoteDirectPlaySupport {
+    fun canPlayMpegTsHttpDirectly(sourceInfo: MediaSourceInfo): Boolean {
+        if (sourceInfo.protocol != MediaProtocol.HTTP) return false
+        if (sourceInfo.path.isNullOrBlank()) return false
+        if (!ExoPlayerDirectPlayProfile.isMpegTsContainer(sourceInfo.container)) return false
+
+        val streams = sourceInfo.mediaStreams.orEmpty()
+        return streams.codecsSupported(
+            streamType = MediaStreamType.VIDEO,
+            supportedCodecs = ExoPlayerDirectPlayProfile.mpegTsVideoCodecs,
+        ) && streams.codecsSupported(
+            streamType = MediaStreamType.AUDIO,
+            supportedCodecs = ExoPlayerDirectPlayProfile.mpegTsAudioCodecs,
+        )
+    }
+
+    private fun List<MediaStream>.codecsSupported(
+        streamType: MediaStreamType,
+        supportedCodecs: Collection<String>,
+    ): Boolean = filter { stream -> stream.type == streamType }
+        .all { stream -> stream.codec?.lowercase() in supportedCodecs }
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/source/RemoteJellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/RemoteJellyfinMediaSource.kt
@@ -16,6 +16,7 @@ class RemoteJellyfinMediaSource(
 ) : JellyfinMediaSource(itemId, item, sourceInfo, playSessionId, playbackDetails) {
     override val playMethod: PlayMethod = when {
         sourceInfo.supportsDirectPlay -> PlayMethod.DIRECT_PLAY
+        RemoteDirectPlaySupport.canPlayMpegTsHttpDirectly(sourceInfo) -> PlayMethod.DIRECT_PLAY
         sourceInfo.supportsDirectStream -> PlayMethod.DIRECT_STREAM
         sourceInfo.supportsTranscoding -> PlayMethod.TRANSCODE
         else -> throw IllegalArgumentException("No play method found for ${sourceInfo.name} ($itemId)")

--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -32,7 +32,7 @@ import org.jellyfin.mobile.downloads.JellyfinDownloadService
 import org.jellyfin.mobile.player.source.LocalJellyfinMediaSource
 import org.jellyfin.mobile.settings.ExternalPlayerPackage
 import org.jellyfin.mobile.webapp.WebViewFragment
-import org.jellyfin.sdk.model.serializer.toUUID
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.android.ext.android.get
 import timber.log.Timber
 import java.io.File
@@ -202,8 +202,9 @@ fun Uri.extractId(): String {
     val uri = toString()
     val idRegex = Regex("""/([a-f0-9]{32}|[a-f0-9-]{36})/""")
     val idResult = idRegex.find(uri)
-    val itemId = idResult?.groups?.get(1)?.value.toString()
-    var item = itemId.toUUID().toString()
+    val itemId = idResult?.groups?.get(1)?.value?.toUUIDOrNull()
+        ?: return uri
+    var item = itemId.toString()
 
     val subtitleRegex = Regex("""Subtitles/(\d+)/\d+/Stream.subrip|/(\d+).subrip""")
     val subtitleResult = subtitleRegex.find(uri)

--- a/app/src/test/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilderTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilderTest.kt
@@ -1,0 +1,82 @@
+package org.jellyfin.mobile.player.deviceprofile
+
+import io.mockk.every
+import io.mockk.mockk
+import org.jellyfin.mobile.app.AppPreferences
+import org.jellyfin.sdk.model.api.DlnaProfileType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DeviceProfileBuilderTest {
+    @Test
+    fun `generated device profile advertises mpeg ts direct play aliases`() {
+        val profile = DeviceProfileBuilder(
+            appPreferences = mockk<AppPreferences> {
+                every { exoPlayerDirectPlayAss } returns false
+            },
+            deviceCodecs = DeviceCodecs(
+                video = mapOf("h264" to videoCodec("h264")),
+                audio = emptyMap(),
+            ),
+        ).getDeviceProfile()
+
+        for (container in ExoPlayerDirectPlayProfile.mpegTsContainers) {
+            val directPlayProfile = profile.directPlayProfiles
+                .singleOrNull { directPlayProfile ->
+                    directPlayProfile.type == DlnaProfileType.VIDEO &&
+                        directPlayProfile.container == container
+                }
+
+            assertNotNull(directPlayProfile, "Missing $container direct play profile")
+            assertEquals("h264", directPlayProfile?.videoCodec)
+            assertTrue(
+                directPlayProfile
+                    ?.audioCodec
+                    ?.split(',')
+                    .orEmpty()
+                    .containsAll(listOf("mp1", "mp2", "mp3")),
+            )
+
+            assertTrue(
+                profile.containerProfiles.any { containerProfile ->
+                    containerProfile.type == DlnaProfileType.VIDEO &&
+                        containerProfile.container == container
+                },
+                "Missing $container video container profile",
+            )
+        }
+    }
+
+    @Test
+    fun `generated device profile does not advertise mpeg ts video without compatible device codecs`() {
+        val profile = DeviceProfileBuilder(
+            appPreferences = mockk<AppPreferences> {
+                every { exoPlayerDirectPlayAss } returns false
+            },
+            deviceCodecs = DeviceCodecs(
+                video = emptyMap(),
+                audio = emptyMap(),
+            ),
+        ).getDeviceProfile()
+
+        for (container in ExoPlayerDirectPlayProfile.mpegTsContainers) {
+            assertTrue(
+                profile.directPlayProfiles.none { directPlayProfile ->
+                    directPlayProfile.type == DlnaProfileType.VIDEO &&
+                        directPlayProfile.container == container
+                },
+                "Unexpected $container video direct play profile",
+            )
+        }
+    }
+
+    private fun videoCodec(name: String) = DeviceCodec.Video(
+        name = name,
+        mimeType = "video/$name",
+        profiles = emptySet(),
+        levels = emptySet(),
+        maxBitrate = Int.MAX_VALUE,
+    )
+}

--- a/app/src/test/java/org/jellyfin/mobile/player/deviceprofile/ExoPlayerDirectPlayProfileTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/deviceprofile/ExoPlayerDirectPlayProfileTest.kt
@@ -1,0 +1,45 @@
+package org.jellyfin.mobile.player.deviceprofile
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ExoPlayerDirectPlayProfileTest {
+    @Test
+    fun `recognizes mpeg ts container aliases`() {
+        assertTrue(ExoPlayerDirectPlayProfile.isMpegTsContainer("mpegts"))
+        assertTrue(ExoPlayerDirectPlayProfile.isMpegTsContainer("ts"))
+        assertTrue(ExoPlayerDirectPlayProfile.isMpegTsContainer("mp4, ts"))
+        assertTrue(ExoPlayerDirectPlayProfile.isMpegTsContainer("mp4|mpegts"))
+        assertTrue(ExoPlayerDirectPlayProfile.isMpegTsContainer("MPEGTS"))
+
+        assertFalse(ExoPlayerDirectPlayProfile.isMpegTsContainer("mkv"))
+        assertFalse(ExoPlayerDirectPlayProfile.isMpegTsContainer(null))
+    }
+
+    @Test
+    fun `includes common live tv mpeg ts codecs`() {
+        assertTrue(ExoPlayerDirectPlayProfile.mpegTsContainers.containsAll(listOf("mpegts", "ts")))
+        assertTrue(ExoPlayerDirectPlayProfile.mpegTsVideoCodecs.containsAll(listOf("mpeg2video", "h264", "hevc")))
+        assertTrue(
+            ExoPlayerDirectPlayProfile.mpegTsAudioCodecs.containsAll(
+                listOf("mp1", "mp2", "mp3", "aac", "ac3", "eac3"),
+            ),
+        )
+        assertTrue(ExoPlayerDirectPlayProfile.forcedAudioCodecs.containsAll(listOf("mp1", "mp2", "mp3")))
+    }
+
+    @Test
+    fun `container support matrix keeps mpeg ts aliases aligned`() {
+        val containers = ExoPlayerDirectPlayProfile.containers
+
+        assertEquals(containers.size, containers.distinctBy(ExoPlayerContainerSupport::container).size)
+        for (container in ExoPlayerDirectPlayProfile.mpegTsContainers) {
+            val support = containers.single { support -> support.container == container }
+
+            assertEquals(ExoPlayerDirectPlayProfile.mpegTsVideoCodecs, support.videoCodecs)
+            assertEquals(ExoPlayerDirectPlayProfile.mpegTsAudioCodecs, support.audioCodecs)
+        }
+    }
+}

--- a/app/src/test/java/org/jellyfin/mobile/player/interaction/PlayOptionsTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/interaction/PlayOptionsTest.kt
@@ -1,0 +1,40 @@
+package org.jellyfin.mobile.player.interaction
+
+import io.mockk.every
+import io.mockk.mockk
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class PlayOptionsTest {
+    @Test
+    fun `missing media source id is parsed as null`() {
+        val options = PlayOptions.fromJson(playOptionsJson(mediaSourceId = ""))
+
+        assertNull(options?.mediaSourceId)
+    }
+
+    @Test
+    fun `blank media source id is parsed as null`() {
+        val options = PlayOptions.fromJson(playOptionsJson(mediaSourceId = ""))
+
+        assertNull(options?.mediaSourceId)
+    }
+
+    @Test
+    fun `present media source id is preserved`() {
+        val options = PlayOptions.fromJson(playOptionsJson(mediaSourceId = "live-source"))
+
+        assertEquals("live-source", options?.mediaSourceId)
+    }
+
+    private fun playOptionsJson(mediaSourceId: String): JSONObject = mockk {
+        every { optJSONArray("ids") } returns null
+        every { optString("mediaSourceId") } returns mediaSourceId
+        every { optInt("startIndex") } returns 0
+        every { optLong("startPositionTicks") } returns 0
+        every { optString("audioStreamIndex") } returns ""
+        every { optString("subtitleStreamIndex") } returns ""
+    }
+}

--- a/app/src/test/java/org/jellyfin/mobile/player/queue/DirectPlayHttpMediaSourceTypeTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/queue/DirectPlayHttpMediaSourceTypeTest.kt
@@ -1,0 +1,88 @@
+package org.jellyfin.mobile.player.queue
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DirectPlayHttpMediaSourceTypeTest {
+    @Test
+    fun `mpeg ts direct play uses progressive media source`() {
+        assertEquals(DirectPlayHttpMediaSourceType.PROGRESSIVE, DirectPlayHttpMediaSourceType.fromContainer("mpegts"))
+        assertEquals(DirectPlayHttpMediaSourceType.PROGRESSIVE, DirectPlayHttpMediaSourceType.fromContainer("ts"))
+        assertEquals(DirectPlayHttpMediaSourceType.PROGRESSIVE, DirectPlayHttpMediaSourceType.fromContainer("mp4|ts"))
+    }
+
+    @Test
+    fun `mpeg ts direct play can be detected from source path`() {
+        assertEquals(
+            DirectPlayHttpMediaSourceType.PROGRESSIVE,
+            DirectPlayHttpMediaSourceType.from(
+                container = null,
+                path = "https://jellyfin.test/LiveTv/LiveStreamFiles/source/stream.ts",
+                formats = null,
+            ),
+        )
+        assertEquals(
+            DirectPlayHttpMediaSourceType.PROGRESSIVE,
+            DirectPlayHttpMediaSourceType.from(
+                container = null,
+                path = "/LiveTv/LiveStreamFiles/source/stream.mpegts?static=true",
+                formats = null,
+            ),
+        )
+        assertEquals(
+            DirectPlayHttpMediaSourceType.PROGRESSIVE,
+            DirectPlayHttpMediaSourceType.from(
+                container = null,
+                path = "https://jellyfin.test/LiveTv/LiveStreamFiles/source/STREAM.TS#position",
+                formats = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `mpeg ts direct play can be detected from source formats`() {
+        assertEquals(
+            DirectPlayHttpMediaSourceType.PROGRESSIVE,
+            DirectPlayHttpMediaSourceType.from(
+                container = null,
+                path = "https://iptv.test/live/channel?id=1",
+                formats = listOf("mpegts"),
+            ),
+        )
+        assertEquals(
+            DirectPlayHttpMediaSourceType.PROGRESSIVE,
+            DirectPlayHttpMediaSourceType.from(
+                container = null,
+                path = "https://iptv.test/live/channel?id=1",
+                formats = listOf("mp4|TS"),
+            ),
+        )
+    }
+
+    @Test
+    fun `hls source path keeps hls media source even when stream metadata mentions mpeg ts`() {
+        assertEquals(
+            DirectPlayHttpMediaSourceType.HLS,
+            DirectPlayHttpMediaSourceType.from(
+                container = "mpegts",
+                path = "https://iptv.test/live/channel.m3u8",
+                formats = listOf("mpegts"),
+            ),
+        )
+    }
+
+    @Test
+    fun `non mpeg ts http direct play keeps hls media source`() {
+        assertEquals(DirectPlayHttpMediaSourceType.HLS, DirectPlayHttpMediaSourceType.fromContainer("mp4"))
+        assertEquals(DirectPlayHttpMediaSourceType.HLS, DirectPlayHttpMediaSourceType.fromContainer("mkv"))
+        assertEquals(DirectPlayHttpMediaSourceType.HLS, DirectPlayHttpMediaSourceType.fromContainer(null))
+        assertEquals(
+            DirectPlayHttpMediaSourceType.HLS,
+            DirectPlayHttpMediaSourceType.from(
+                container = null,
+                path = "https://jellyfin.test/video.m3u8",
+                formats = null,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/org/jellyfin/mobile/player/queue/DirectPlayHttpUrlTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/queue/DirectPlayHttpUrlTest.kt
@@ -1,0 +1,133 @@
+package org.jellyfin.mobile.player.queue
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DirectPlayHttpUrlTest {
+    @Test
+    fun `absolute source path is used as is`() {
+        var createServerUrlCalled = false
+        val url = DirectPlayHttpUrl.resolve(
+            path = "https://example.test/live/stream.ts",
+            serverBaseUrl = "https://jellyfin.test",
+            createServerUrl = {
+                createServerUrlCalled = true
+                "https://jellyfin.test$it"
+            },
+        )
+
+        assertEquals("https://example.test/live/stream.ts", url)
+        assertFalse(createServerUrlCalled)
+    }
+
+    @Test
+    fun `relative source path is resolved against the jellyfin server`() {
+        var createServerUrlCalled = false
+        val url = DirectPlayHttpUrl.resolve(
+            path = "/LiveTv/LiveStreamFiles/stream.ts",
+            serverBaseUrl = "https://jellyfin.test",
+            createServerUrl = {
+                createServerUrlCalled = true
+                "https://jellyfin.test$it"
+            },
+        )
+
+        assertEquals("https://jellyfin.test/LiveTv/LiveStreamFiles/stream.ts", url)
+        assertTrue(createServerUrlCalled)
+    }
+
+    @Test
+    fun `absolute jellyfin live tv stream path is resolved against the jellyfin server`() {
+        var resolvedPath = ""
+        val url = DirectPlayHttpUrl.resolve(
+            path = "http://127.0.0.1:8096/LiveTv/LiveStreamFiles/source/stream.ts?static=true",
+            serverBaseUrl = "https://jellyfin.test",
+            createServerUrl = { path ->
+                resolvedPath = path
+                "https://jellyfin.test$path"
+            },
+        )
+
+        assertEquals("/LiveTv/LiveStreamFiles/source/stream.ts?static=true", resolvedPath)
+        assertEquals("https://jellyfin.test/LiveTv/LiveStreamFiles/source/stream.ts?static=true", url)
+    }
+
+    @Test
+    fun `absolute jellyfin live tv stream path strips duplicated server base path`() {
+        var resolvedPath = ""
+        val url = DirectPlayHttpUrl.resolve(
+            path = "http://127.0.0.1:8096/jellyfin/LiveTv/LiveStreamFiles/source/stream.ts",
+            serverBaseUrl = "https://jellyfin.test/jellyfin",
+            createServerUrl = { path ->
+                resolvedPath = path
+                "https://jellyfin.test/jellyfin$path"
+            },
+        )
+
+        assertEquals("/LiveTv/LiveStreamFiles/source/stream.ts", resolvedPath)
+        assertEquals("https://jellyfin.test/jellyfin/LiveTv/LiveStreamFiles/source/stream.ts", url)
+    }
+
+    @Test
+    fun `relative jellyfin live tv stream path strips duplicated server base path`() {
+        var resolvedPath = ""
+        val url = DirectPlayHttpUrl.resolve(
+            path = "/jellyfin/LiveTv/LiveStreamFiles/source/stream.ts?static=true",
+            serverBaseUrl = "https://jellyfin.test/jellyfin",
+            createServerUrl = { path ->
+                resolvedPath = path
+                "https://jellyfin.test/jellyfin$path"
+            },
+        )
+
+        assertEquals("/LiveTv/LiveStreamFiles/source/stream.ts?static=true", resolvedPath)
+        assertEquals("https://jellyfin.test/jellyfin/LiveTv/LiveStreamFiles/source/stream.ts?static=true", url)
+    }
+
+    @Test
+    fun `absolute jellyfin live tv stream path strips server base path case insensitively`() {
+        var resolvedPath = ""
+        val url = DirectPlayHttpUrl.resolve(
+            path = "https://jellyfin.test/jellyfin/LiveTv/LiveStreamFiles/source/stream.ts",
+            serverBaseUrl = "https://jellyfin.test/Jellyfin",
+            createServerUrl = { path ->
+                resolvedPath = path
+                "https://jellyfin.test/Jellyfin$path"
+            },
+        )
+
+        assertEquals("/LiveTv/LiveStreamFiles/source/stream.ts", resolvedPath)
+        assertEquals("https://jellyfin.test/Jellyfin/LiveTv/LiveStreamFiles/source/stream.ts", url)
+    }
+
+    @Test
+    fun `external absolute path containing live tv segment is not rewritten`() {
+        var createServerUrlCalled = false
+        val url = DirectPlayHttpUrl.resolve(
+            path = "https://iptv.test/provider/LiveTv/LiveStreamFiles/source/stream.ts",
+            serverBaseUrl = "https://jellyfin.test",
+            createServerUrl = {
+                createServerUrlCalled = true
+                "https://jellyfin.test$it"
+            },
+        )
+
+        assertEquals("https://iptv.test/provider/LiveTv/LiveStreamFiles/source/stream.ts", url)
+        assertFalse(createServerUrlCalled)
+    }
+
+    @Test
+    fun `relative source path preserves query parameters through server url builder`() {
+        val url = DirectPlayHttpUrl.resolve(
+            path = "/Videos/item/stream?static=true&mediaSourceId=source",
+            serverBaseUrl = "https://jellyfin.test",
+            createServerUrl = {
+                "https://jellyfin.test$it"
+            },
+        )
+
+        assertEquals("https://jellyfin.test/Videos/item/stream?static=true&mediaSourceId=source", url)
+    }
+}

--- a/app/src/test/java/org/jellyfin/mobile/player/source/MediaSourceResolverTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/source/MediaSourceResolverTest.kt
@@ -1,0 +1,48 @@
+package org.jellyfin.mobile.player.source
+
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class MediaSourceResolverTest {
+    @Test
+    fun `keeps requested media source id`() {
+        val itemId = UUID.randomUUID()
+
+        assertEquals(
+            "media-source",
+            playbackInfoMediaSourceId(
+                requestedMediaSourceId = "media-source",
+                itemId = itemId,
+                itemType = BaseItemKind.TV_CHANNEL,
+            ),
+        )
+    }
+
+    @Test
+    fun `omits generated media source id for tv channels`() {
+        assertNull(
+            playbackInfoMediaSourceId(
+                requestedMediaSourceId = null,
+                itemId = UUID.fromString("4aa1ef15-58f5-719c-aa4b-f91ef0112d95"),
+                itemType = BaseItemKind.TV_CHANNEL,
+            ),
+        )
+    }
+
+    @Test
+    fun `generates dashedless item id for non live tv items`() {
+        val itemId = UUID.fromString("4aa1ef15-58f5-719c-aa4b-f91ef0112d95")
+
+        assertEquals(
+            "4aa1ef1558f5719caa4bf91ef0112d95",
+            playbackInfoMediaSourceId(
+                requestedMediaSourceId = null,
+                itemId = itemId,
+                itemType = BaseItemKind.MOVIE,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/org/jellyfin/mobile/player/source/MediaSourceSelectorTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/source/MediaSourceSelectorTest.kt
@@ -1,0 +1,127 @@
+package org.jellyfin.mobile.player.source
+
+import org.jellyfin.sdk.model.api.MediaProtocol
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+import org.jellyfin.sdk.model.api.MediaSourceType
+import org.jellyfin.sdk.model.api.MediaStreamProtocol
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class MediaSourceSelectorTest {
+    @Test
+    fun `selects requested media source before preferring direct play`() {
+        val requested = mediaSource(
+            id = "requested-source",
+            supportsDirectPlay = false,
+            supportsDirectStream = false,
+            supportsTranscoding = true,
+        )
+        val directPlay = mediaSource(
+            id = "direct-play-source",
+            supportsDirectPlay = true,
+            supportsDirectStream = false,
+            supportsTranscoding = false,
+        )
+
+        assertEquals(
+            requested,
+            MediaSourceSelector.select(
+                sources = listOf(directPlay, requested),
+                requestedMediaSourceId = requested.id,
+            ),
+        )
+    }
+
+    @Test
+    fun `prefers direct play source over direct stream and transcode fallbacks`() {
+        val directStream = mediaSource(
+            id = "direct-stream-source",
+            supportsDirectPlay = false,
+            supportsDirectStream = true,
+            supportsTranscoding = true,
+        )
+        val transcode = mediaSource(
+            id = "transcode-source",
+            supportsDirectPlay = false,
+            supportsDirectStream = false,
+            supportsTranscoding = true,
+        )
+        val directPlay = mediaSource(
+            id = "direct-play-source",
+            supportsDirectPlay = true,
+            supportsDirectStream = true,
+            supportsTranscoding = true,
+        )
+
+        assertEquals(
+            directPlay,
+            MediaSourceSelector.select(
+                sources = listOf(directStream, transcode, directPlay),
+                requestedMediaSourceId = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `matches requested media source id even when uuid dash formatting differs`() {
+        val itemId = UUID.randomUUID()
+        val selected = mediaSource(
+            id = itemId.toString().replace("-", ""),
+            supportsDirectPlay = false,
+            supportsDirectStream = true,
+            supportsTranscoding = true,
+        )
+        val directPlay = mediaSource(
+            id = "direct-play-source",
+            supportsDirectPlay = true,
+            supportsDirectStream = true,
+            supportsTranscoding = true,
+        )
+
+        assertEquals(
+            selected,
+            MediaSourceSelector.select(
+                sources = listOf(directPlay, selected),
+                requestedMediaSourceId = itemId.toString(),
+            ),
+        )
+    }
+
+    @Test
+    fun `returns null when playback info contains no media sources`() {
+        assertNull(
+            MediaSourceSelector.select(
+                sources = emptyList(),
+                requestedMediaSourceId = null,
+            ),
+        )
+    }
+
+    private fun mediaSource(
+        id: String,
+        supportsDirectPlay: Boolean,
+        supportsDirectStream: Boolean,
+        supportsTranscoding: Boolean,
+    ) = MediaSourceInfo(
+        protocol = MediaProtocol.FILE,
+        id = id,
+        type = MediaSourceType.DEFAULT,
+        isRemote = false,
+        readAtNativeFramerate = false,
+        ignoreDts = false,
+        ignoreIndex = false,
+        genPtsInput = false,
+        supportsTranscoding = supportsTranscoding,
+        supportsDirectStream = supportsDirectStream,
+        supportsDirectPlay = supportsDirectPlay,
+        isInfiniteStream = true,
+        requiresOpening = false,
+        requiresClosing = false,
+        requiresLooping = false,
+        supportsProbing = false,
+        transcodingSubProtocol = MediaStreamProtocol.HLS,
+        hasSegments = false,
+    )
+}

--- a/app/src/test/java/org/jellyfin/mobile/player/source/RemoteJellyfinMediaSourceTest.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/source/RemoteJellyfinMediaSourceTest.kt
@@ -1,0 +1,133 @@
+package org.jellyfin.mobile.player.source
+
+import org.jellyfin.sdk.model.api.MediaProtocol
+import org.jellyfin.sdk.model.api.MediaSourceInfo
+import org.jellyfin.sdk.model.api.MediaSourceType
+import org.jellyfin.sdk.model.api.MediaStream
+import org.jellyfin.sdk.model.api.MediaStreamProtocol
+import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.api.PlayMethod
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class RemoteJellyfinMediaSourceTest {
+    @Test
+    fun `prefers direct play over remux or transcode fallbacks`() {
+        val source = remoteSource(
+            supportsDirectPlay = true,
+            supportsDirectStream = true,
+            supportsTranscoding = true,
+        )
+
+        assertEquals(PlayMethod.DIRECT_PLAY, source.playMethod)
+    }
+
+    @Test
+    fun `uses direct play for supported http mpegts live sources`() {
+        val source = remoteSource(
+            protocol = MediaProtocol.HTTP,
+            path = "http://example.com/live.ts",
+            container = "ts",
+            mediaStreams = listOf(
+                mediaStream(codec = "h264", type = MediaStreamType.VIDEO),
+                mediaStream(codec = "aac", type = MediaStreamType.AUDIO),
+            ),
+            supportsDirectPlay = false,
+            supportsDirectStream = true,
+            supportsTranscoding = true,
+        )
+
+        assertEquals(PlayMethod.DIRECT_PLAY, source.playMethod)
+    }
+
+    @Test
+    fun `uses direct stream only when direct play is unavailable`() {
+        val source = remoteSource(
+            supportsDirectPlay = false,
+            supportsDirectStream = true,
+            supportsTranscoding = true,
+        )
+
+        assertEquals(PlayMethod.DIRECT_STREAM, source.playMethod)
+    }
+
+    @Test
+    fun `uses transcode only as last available playback method`() {
+        val source = remoteSource(
+            supportsDirectPlay = false,
+            supportsDirectStream = false,
+            supportsTranscoding = true,
+        )
+
+        assertEquals(PlayMethod.TRANSCODE, source.playMethod)
+    }
+
+    @Test
+    fun `throws when no playback method is available`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            remoteSource(
+                supportsDirectPlay = false,
+                supportsDirectStream = false,
+                supportsTranscoding = false,
+            )
+        }
+    }
+
+    private fun remoteSource(
+        supportsDirectPlay: Boolean,
+        supportsDirectStream: Boolean,
+        supportsTranscoding: Boolean,
+        protocol: MediaProtocol = MediaProtocol.FILE,
+        path: String? = null,
+        container: String? = null,
+        mediaStreams: List<MediaStream> = emptyList(),
+    ) = RemoteJellyfinMediaSource(
+        itemId = UUID.randomUUID(),
+        item = null,
+        sourceInfo = MediaSourceInfo(
+            protocol = protocol,
+            id = UUID.randomUUID().toString(),
+            path = path,
+            type = MediaSourceType.DEFAULT,
+            container = container,
+            isRemote = false,
+            readAtNativeFramerate = false,
+            ignoreDts = false,
+            ignoreIndex = false,
+            genPtsInput = false,
+            supportsTranscoding = supportsTranscoding,
+            supportsDirectStream = supportsDirectStream,
+            supportsDirectPlay = supportsDirectPlay,
+            isInfiniteStream = true,
+            requiresOpening = false,
+            requiresClosing = false,
+            requiresLooping = false,
+            supportsProbing = false,
+            mediaStreams = mediaStreams,
+            transcodingSubProtocol = MediaStreamProtocol.HLS,
+            hasSegments = false,
+        ),
+        playSessionId = "play-session",
+        liveStreamId = null,
+        maxStreamingBitrate = null,
+        playbackDetails = null,
+    )
+
+    private fun mediaStream(
+        codec: String,
+        type: MediaStreamType,
+    ) = MediaStream(
+        codec = codec,
+        type = type,
+        index = 0,
+        isInterlaced = false,
+        isDefault = false,
+        isForced = false,
+        isHearingImpaired = false,
+        isExternal = false,
+        isTextSubtitleStream = false,
+        supportsExternalStream = false,
+    )
+}


### PR DESCRIPTION
## Summary

- Advertise ExoPlayer MPEG-TS/TS container support with matching video and audio codec profiles.
- Resolve Live TV `TvChannel` playback info without forcing `MediaSourceId=itemId`, then prefer direct-playable HTTP MPEG-TS sources.
- Route direct-play HTTP TS URLs through a progressive media source and support external-player Live TV stream lifecycle cleanup.

## Root Cause

Live TV channels  can return no playable media sources when the Android client sends a generated `MediaSourceId` based on the item id. When a source is opened, the server can also mark supported HTTP TS streams as `DirectStream` even with no transcode reasons, which makes the app use Jellyfin's remux URL instead of the original transport stream.