### PR TITLE
Improve audiobook support to Android Auto

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryMediaId.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryMediaId.kt
@@ -15,7 +15,6 @@ sealed interface LibraryMediaId {
     data class Item(
         val itemId: UUID,
         val route: LibraryRoute,
-        val startPositionMs: Long = 0L,
     ) : LibraryMediaId
 
     @Serializable

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryMediaId.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryMediaId.kt
@@ -12,7 +12,11 @@ import java.util.UUID
 sealed interface LibraryMediaId {
     @Serializable
     @SerialName("item")
-    data class Item(val itemId: UUID, val route: LibraryRoute) : LibraryMediaId
+    data class Item(
+        val itemId: UUID,
+        val route: LibraryRoute,
+        val startPositionMs: Long = 0L,
+    ) : LibraryMediaId
 
     @Serializable
     @SerialName("route")

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
@@ -42,6 +42,7 @@ import org.jellyfin.mobile.sessionbrowser.page.UserViewLibraryPage
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.universalAudioApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.MediaStreamProtocol
 import timber.log.Timber
 
@@ -373,7 +374,21 @@ class SessionBrowserCallback(
             }
         }
 
+        var resumePositionMs = startPositionMs
+        val currentLibraryMediaId = expandedItems.getOrNull(newStartIndex)?.mediaId?.let {
+            runCatching { Json.decodeFromString<LibraryMediaId>(it) }.getOrNull()
+        }
+        if (currentLibraryMediaId is LibraryMediaId.Item) {
+            runCatching {
+                val item by api.userLibraryApi.getItem(itemId = currentLibraryMediaId.itemId)
+                if (item.type == BaseItemKind.AUDIO_BOOK) {
+                    val positionTicks = item.userData?.playbackPositionTicks ?: 0L
+                    if (positionTicks > 0L) resumePositionMs = positionTicks / 10000L
+                }
+            }
+        }
+
         expandedItems = onAddMediaItems(mediaSession, controller, expandedItems).await()
-        MediaSession.MediaItemsWithStartPosition(expandedItems, newStartIndex, startPositionMs)
+        MediaSession.MediaItemsWithStartPosition(expandedItems, newStartIndex, resumePositionMs)
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
@@ -53,6 +53,7 @@ class SessionBrowserCallback(
 ) : MediaLibrarySession.Callback {
     companion object {
         const val MAX_PAGE_SIZE = 250
+        private const val TICKS_PER_MILLISECOND = 10_000L
     }
 
     val pages = listOf(
@@ -383,7 +384,7 @@ class SessionBrowserCallback(
                 val item by api.userLibraryApi.getItem(itemId = currentLibraryMediaId.itemId)
                 if (item.type == BaseItemKind.AUDIO_BOOK) {
                     val positionTicks = item.userData?.playbackPositionTicks ?: 0L
-                    if (positionTicks > 0L) resumePositionMs = positionTicks / 10000L
+                    if (positionTicks > 0L) resumePositionMs = positionTicks / TICKS_PER_MILLISECOND
                 }
             }
         }

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import androidx.core.os.bundleOf
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.session.LibraryResult
@@ -42,8 +43,8 @@ import org.jellyfin.mobile.sessionbrowser.page.UserViewLibraryPage
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.universalAudioApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
-import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.MediaStreamProtocol
+import org.jellyfin.sdk.model.extensions.ticks
 import timber.log.Timber
 
 @Suppress("InjectDispatcher")
@@ -53,7 +54,6 @@ class SessionBrowserCallback(
 ) : MediaLibrarySession.Callback {
     companion object {
         const val MAX_PAGE_SIZE = 250
-        private const val TICKS_PER_MILLISECOND = 10_000L
     }
 
     val pages = listOf(
@@ -99,7 +99,8 @@ class SessionBrowserCallback(
             extras.putInt(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE, contentStyle)
             setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Route(action.route)))
         } else if (action is LibraryItemAction.Play) {
-            setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Item(action.item.id, route)))
+            val positionMs = action.item.userData?.playbackPositionTicks?.ticks?.inWholeMilliseconds ?: 0L
+            setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Item(action.item.id, route, positionMs)))
         }
 
         setMediaMetadata(
@@ -379,14 +380,9 @@ class SessionBrowserCallback(
         val currentLibraryMediaId = expandedItems.getOrNull(newStartIndex)?.mediaId?.let {
             runCatching { Json.decodeFromString<LibraryMediaId>(it) }.getOrNull()
         }
-        if (currentLibraryMediaId is LibraryMediaId.Item) {
-            runCatching {
-                val item by api.userLibraryApi.getItem(itemId = currentLibraryMediaId.itemId)
-                if (item.type == BaseItemKind.AUDIO_BOOK) {
-                    val positionTicks = item.userData?.playbackPositionTicks ?: 0L
-                    if (positionTicks > 0L) resumePositionMs = positionTicks / TICKS_PER_MILLISECOND
-                }
-            }
+        if (currentLibraryMediaId is LibraryMediaId.Item && (startPositionMs == 0L || startPositionMs == C.TIME_UNSET)) {
+            val positionMs = currentLibraryMediaId.startPositionMs
+            if (positionMs > 0L) resumePositionMs = positionMs
         }
 
         expandedItems = onAddMediaItems(mediaSession, controller, expandedItems).await()

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
@@ -99,8 +99,7 @@ class SessionBrowserCallback(
             extras.putInt(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE, contentStyle)
             setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Route(action.route)))
         } else if (action is LibraryItemAction.Play) {
-            val positionMs = action.item.userData?.playbackPositionTicks?.ticks?.inWholeMilliseconds ?: 0L
-            setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Item(action.item.id, route, positionMs)))
+            setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Item(action.item.id, route)))
         }
 
         setMediaMetadata(
@@ -381,7 +380,8 @@ class SessionBrowserCallback(
             runCatching { Json.decodeFromString<LibraryMediaId>(it) }.getOrNull()
         }
         if (currentLibraryMediaId is LibraryMediaId.Item && (startPositionMs == 0L || startPositionMs == C.TIME_UNSET)) {
-            val positionMs = currentLibraryMediaId.startPositionMs
+            val item by api.userLibraryApi.getItem(itemId = currentLibraryMediaId.itemId)
+            val positionMs = item.userData?.playbackPositionTicks?.ticks?.inWholeMilliseconds ?: 0L
             if (positionMs > 0L) resumePositionMs = positionMs
         }
 

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/FavoritesLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/FavoritesLibraryPage.kt
@@ -13,7 +13,7 @@ val FavoritesLibraryPage = { api: ApiClient ->
     libraryPage<LibraryRoute.Favorites> { route, offset, limit ->
         val result by api.itemsApi.getItems(
             parentId = route.libraryId,
-            includeItemTypes = listOf(BaseItemKind.AUDIO),
+            includeItemTypes = listOf(BaseItemKind.AUDIO, BaseItemKind.AUDIO_BOOK),
             isFavorite = true,
             sortBy = listOf(ItemSortBy.SORT_NAME),
             recursive = true,

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/GenreLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/GenreLibraryPage.kt
@@ -13,7 +13,7 @@ import org.jellyfin.sdk.model.api.ItemSortBy
 val GenreLibraryPage = { api: ApiClient ->
     libraryPage<LibraryRoute.Genre>(grid = true) { route, offset, limit ->
         val result by api.itemsApi.getItems(
-            includeItemTypes = listOf(BaseItemKind.MUSIC_ALBUM),
+            includeItemTypes = listOf(BaseItemKind.MUSIC_ALBUM, BaseItemKind.AUDIO_BOOK),
             sortBy = listOf(ItemSortBy.SORT_NAME),
             genreIds = listOf(route.genreId),
             recursive = true,
@@ -27,7 +27,10 @@ val GenreLibraryPage = { api: ApiClient ->
             LibraryPageElement.baseItem(
                 api = api,
                 item = it,
-                action = LibraryItemAction.Navigate(LibraryRoute.Album(it.id)),
+                action = when (it.type) {
+                    BaseItemKind.AUDIO_BOOK -> LibraryItemAction.Play(it)
+                    else -> LibraryItemAction.Navigate(LibraryRoute.Album(it.id))
+                },
             )
         }
     }

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/GenreLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/GenreLibraryPage.kt
@@ -29,7 +29,8 @@ val GenreLibraryPage = { api: ApiClient ->
                 item = it,
                 action = when (it.type) {
                     BaseItemKind.AUDIO_BOOK -> LibraryItemAction.Play(it)
-                    else -> LibraryItemAction.Navigate(LibraryRoute.Album(it.id))
+                    BaseItemKind.MUSIC_ALBUM -> LibraryItemAction.Navigate(LibraryRoute.Album(it.id))
+                    else -> error("Unknown item type ${it.type}")
                 },
             )
         }

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/RecentLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/RecentLibraryPage.kt
@@ -15,7 +15,7 @@ val RecentLibraryPage = { api: ApiClient ->
     libraryPage<LibraryRoute.Recent>(grid = true) { route, offset, limit ->
         val result by api.itemsApi.getItems(
             parentId = route.libraryId,
-            includeItemTypes = listOf(BaseItemKind.AUDIO),
+            includeItemTypes = listOf(BaseItemKind.AUDIO, BaseItemKind.AUDIO_BOOK),
             filters = listOf(ItemFilter.IS_PLAYED),
             sortBy = listOf(ItemSortBy.DATE_PLAYED),
             sortOrder = listOf(SortOrder.DESCENDING),

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/SearchLibraryPage.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/page/SearchLibraryPage.kt
@@ -36,7 +36,7 @@ val SearchLibraryPage = { context: Context, api: ApiClient ->
     libraryPage<LibraryRoute.Search>(grid = true) { route, offset, limit ->
         if (route.query.isNullOrBlank()) return@libraryPage emptyList()
 
-        val (playlists, albums, artists) = listOf(
+        val (playlists, albums, artists, audioBooks) = listOf(
             search(api, route.query, setOf(BaseItemKind.PLAYLIST)) to { item: BaseItemDto ->
                 LibraryPageElement.baseItem(api, item, action = LibraryItemAction.Navigate(LibraryRoute.Playlist(item.id)))
             },
@@ -46,6 +46,9 @@ val SearchLibraryPage = { context: Context, api: ApiClient ->
             search(api, route.query, setOf(BaseItemKind.MUSIC_ARTIST)) to { item: BaseItemDto ->
                 LibraryPageElement.baseItem(api, item, action = LibraryItemAction.Navigate(LibraryRoute.Artist(item.id)))
             },
+            search(api, route.query, setOf(BaseItemKind.AUDIO_BOOK)) to { item: BaseItemDto ->
+                LibraryPageElement.baseItem(api, item, action = LibraryItemAction.Play(item))
+            },
         ).map { (deferred, mapper) ->
             deferred.await().content.items.map(mapper)
         }
@@ -54,6 +57,7 @@ val SearchLibraryPage = { context: Context, api: ApiClient ->
             LibraryPageElement.Group(context.getString(R.string.media_service_car_section_playlists), playlists),
             LibraryPageElement.Group(context.getString(R.string.media_service_car_section_albums), albums),
             LibraryPageElement.Group(context.getString(R.string.media_service_car_section_artists), artists),
+            LibraryPageElement.Group(context.getString(R.string.media_service_car_section_audiobooks), audioBooks),
         )
     }
 }


### PR DESCRIPTION

**Changes**
  Extends the existing Android Auto audiobook browsing (added in upstream PR #1984) with several missing pieces:

  - Include audiobooks in Favorites and Recently Played sections
  - Include audiobooks in Genre browsing with direct playback action
  - Add Audiobooks group to search results
  - Resume audiobook playback from saved position (playbackPositionTicks) rather than always starting from the beginning


**Code assistance**
Opus used to help me understand where the underlying code needed to be ammended

**Issues**
- https://github.com/jellyfin/jellyfin-android/issues/247
- https://github.com/jellyfin/jellyfin-android/issues/314

**Testing**
I have tested this with my Android Auto device and confirmed all playing, pausing, selecting, etc of audiobook books works as intended. It also resumes the audiobook from where the server tells it to.
