### PR TITLE
Download primary image for offline files and store files in database

### DIFF
--- a/app/schemas/org.jellyfin.mobile.data.JellyfinDatabase/6.json
+++ b/app/schemas/org.jellyfin.mobile.data.JellyfinDatabase/6.json
@@ -1,0 +1,317 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "311b7804b1eb8748f7ddaaf8f483ed22",
+    "entities": [
+      {
+        "tableName": "server",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hostname` TEXT NOT NULL, `last_used_timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedTimestamp",
+            "columnName": "last_used_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_server_hostname",
+            "unique": true,
+            "columnNames": [
+              "hostname"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_server_hostname` ON `${TABLE_NAME}` (`hostname`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `server_id` INTEGER NOT NULL, `user_id` TEXT NOT NULL, `access_token` TEXT, `last_login_timestamp` INTEGER NOT NULL, FOREIGN KEY(`server_id`) REFERENCES `server`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "access_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastLoginTimestamp",
+            "columnName": "last_login_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_server_id_user_id",
+            "unique": true,
+            "columnNames": [
+              "server_id",
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_server_id_user_id` ON `${TABLE_NAME}` (`server_id`, `user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "server_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "download",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `server_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `item_id` TEXT NOT NULL, `path` TEXT NOT NULL, `item` TEXT NOT NULL, `status` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, FOREIGN KEY(`server_id`) REFERENCES `server`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_server_id",
+            "unique": false,
+            "columnNames": [
+              "server_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_server_id` ON `${TABLE_NAME}` (`server_id`)"
+          },
+          {
+            "name": "index_download_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          },
+          {
+            "name": "index_download_item_id",
+            "unique": false,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "server",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "server_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "download_file",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `download_id` INTEGER NOT NULL, `type` TEXT NOT NULL, `size` INTEGER NOT NULL, `file_name` TEXT NOT NULL, `uri` TEXT NOT NULL, `status` TEXT NOT NULL, FOREIGN KEY(`download_id`) REFERENCES `download`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadId",
+            "columnName": "download_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "file_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_file_download_id",
+            "unique": false,
+            "columnNames": [
+              "download_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_file_download_id` ON `${TABLE_NAME}` (`download_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "download",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "download_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '311b7804b1eb8748f7ddaaf8f483ed22')"
+    ]
+  }
+}

--- a/app/src/main/java/org/jellyfin/mobile/app/StorageManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/StorageManager.kt
@@ -7,11 +7,13 @@ import android.os.Environment
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import org.jellyfin.mobile.R
+import org.jellyfin.mobile.data.entity.DownloadFiles
+import org.jellyfin.mobile.downloads.DownloadStatus
 import java.io.File
 
 class StorageManager(
     private val context: Context,
-    private val appPreferences: AppPreferences,
+    private val appPreferences: AppPreferences
 ) {
     private val defaultStorageLocation
         get() = Environment.getExternalStorageDirectory().absolutePath + File.separator + context.getString(R.string.app_name_short)
@@ -34,6 +36,20 @@ class StorageManager(
         )
         ensureNoMedia(documentFile)
         appPreferences.storageLocation = documentFile.uri.toString()
+    }
+
+    fun verify(download: DownloadFiles): Boolean {
+        if (download.files.isEmpty()) return false
+
+        for (file in download.files) {
+            if (file.status != DownloadStatus.DOWNLOADED) return false
+            val documentFile = DocumentFile.fromSingleUri(context, file.uri)
+            if (documentFile == null || !documentFile.exists() || documentFile.length() != file.size) {
+                return false
+            }
+        }
+
+        return true
     }
 
     private fun ensureNoMedia(documentFile: DocumentFile) {

--- a/app/src/main/java/org/jellyfin/mobile/data/JellyfinDatabase.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/JellyfinDatabase.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.mobile.data
 
+import android.net.Uri
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RenameTable
@@ -13,6 +14,7 @@ import org.jellyfin.mobile.data.dao.DownloadDao
 import org.jellyfin.mobile.data.dao.ServerDao
 import org.jellyfin.mobile.data.dao.UserDao
 import org.jellyfin.mobile.data.entity.DownloadEntity
+import org.jellyfin.mobile.data.entity.DownloadFileEntity
 import org.jellyfin.mobile.data.entity.ServerEntity
 import org.jellyfin.mobile.data.entity.UserEntity
 import org.jellyfin.sdk.model.api.BaseItemDto
@@ -25,11 +27,13 @@ import java.util.UUID
         ServerEntity::class,
         UserEntity::class,
         DownloadEntity::class,
+        DownloadFileEntity::class,
     ],
-    version = 5,
+    version = 6,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4, spec = JellyfinDatabase.MigrateV4::class),
+        AutoMigration(from = 5, to = 6),
     ],
 )
 @TypeConverters(JellyfinDatabase.Converters::class)
@@ -52,6 +56,12 @@ abstract class JellyfinDatabase : RoomDatabase() {
 
         @TypeConverter
         fun toBaseItemDto(json: String?): BaseItemDto? = json?.let(Json::decodeFromString)
+
+        @TypeConverter
+        fun fromUri(uri: Uri?): String? = uri?.toString()
+
+        @TypeConverter
+        fun toUri(value: String?): Uri? = value?.let { Uri.parse(it) }
     }
 
     // Migrations

--- a/app/src/main/java/org/jellyfin/mobile/data/dao/DownloadDao.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/dao/DownloadDao.kt
@@ -4,9 +4,12 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 import org.jellyfin.mobile.data.entity.DownloadEntity
+import org.jellyfin.mobile.data.entity.DownloadFileEntity
+import org.jellyfin.mobile.data.entity.DownloadFiles
 import org.jellyfin.sdk.model.UUID
 
 @Dao
@@ -14,8 +17,12 @@ interface DownloadDao {
     @Query("SELECT * FROM download ORDER BY created_at DESC")
     fun getAllDownloads(): Flow<List<DownloadEntity>>
 
+    @Transaction
+    @Query("SELECT * FROM download ORDER BY created_at DESC")
+    fun getAllDownloadsWithFiles(): Flow<List<DownloadFiles>>
+
     @Query("SELECT * FROM download WHERE status = 'QUEUED' OR status = 'DOWNLOADING' ORDER BY created_at ASC")
-    fun getQueuedDownloads(): List<DownloadEntity>
+    fun getQueuedDownloads(): List<DownloadFiles>
 
     @Query("SELECT * FROM download WHERE item_id IN (:itemIds)")
     fun getDownloadsByItemIds(itemIds: Collection<UUID>): List<DownloadEntity>
@@ -34,4 +41,13 @@ interface DownloadDao {
 
     @Query("DELETE FROM download WHERE id = :id")
     suspend fun delete(id: Long)
+
+    @Query("SELECT * FROM download_file WHERE download_id = :downloadId")
+    suspend fun getFiles(downloadId: Long): List<DownloadFileEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertFile(entity: DownloadFileEntity): Long
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun updateFile(entity: DownloadFileEntity): Int
 }

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadEntity.kt
@@ -1,12 +1,15 @@
 package org.jellyfin.mobile.data.entity
 
+import android.content.Context
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.jellyfin.mobile.R
 import org.jellyfin.mobile.downloads.DownloadStatus
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
 import java.util.UUID
 
 @Entity(
@@ -42,4 +45,34 @@ data class DownloadEntity(
 
     @ColumnInfo(name = "created_at") val createdAt: Long = System.currentTimeMillis(),
     @ColumnInfo(name = "modified_at") var modifiedAt: Long = System.currentTimeMillis(),
-)
+) {
+    fun getDisplayName(context: Context) = buildString {
+        val name = if (
+            item.type in arrayOf(BaseItemKind.PROGRAM, BaseItemKind.RECORDING) &&
+            (item.isSeries == true || !item.episodeTitle.isNullOrEmpty())
+        ) {
+            item.episodeTitle
+        } else {
+            item.name
+        }
+
+        val extraInfo = when (item.type) {
+            BaseItemKind.TV_CHANNEL if !item.channelNumber.isNullOrEmpty() -> item.channelNumber
+            BaseItemKind.EPISODE if item.parentIndexNumber == 0 -> context.getString(R.string.special_episode)
+            in arrayOf(BaseItemKind.EPISODE, BaseItemKind.RECORDING) if item.indexNumber != null && item.parentIndexNumber != null ->
+                "S${item.parentIndexNumber}:E${item.indexNumber}${item.indexNumberEnd?.let { n -> "-$n" }.orEmpty()}"
+
+            else -> ""
+        }
+
+        listOf(item.seriesName, extraInfo, name)
+            .filter { str -> !str.isNullOrEmpty() }
+            .joinTo(this, separator = " - ")
+
+        if (item.type == BaseItemKind.MOVIE && item.productionYear != null) {
+            append(" (${item.productionYear})")
+        } else if (item.premiereDate != null) {
+            append(" (${item.premiereDate!!.year})")
+        }
+    }.ifEmpty { item.name }
+}

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadFileEntity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadFileEntity.kt
@@ -1,0 +1,34 @@
+package org.jellyfin.mobile.data.entity
+
+import android.net.Uri
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import org.jellyfin.mobile.downloads.DownloadFileType
+import org.jellyfin.mobile.downloads.DownloadStatus
+
+@Entity(
+    tableName = "download_file",
+    indices = [Index(value = ["download_id"])],
+    foreignKeys = [
+        ForeignKey(
+            entity = DownloadEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["download_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+)
+data class DownloadFileEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id") val id: Long = 0L,
+    @ColumnInfo(name = "download_id") val downloadId: Long,
+    @ColumnInfo(name = "type") val type: DownloadFileType,
+    @ColumnInfo(name = "size") val size: Long,
+    @ColumnInfo(name = "file_name") val fileName: String,
+    @ColumnInfo(name = "uri") val uri: Uri,
+    @ColumnInfo(name = "status") val status: DownloadStatus = DownloadStatus.QUEUED,
+)
+

--- a/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadFiles.kt
+++ b/app/src/main/java/org/jellyfin/mobile/data/entity/DownloadFiles.kt
@@ -1,0 +1,13 @@
+package org.jellyfin.mobile.data.entity
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class DownloadFiles(
+    @Embedded val download: DownloadEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "download_id"
+    )
+    val files: List<DownloadFileEntity>
+)

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadFileType.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadFileType.kt
@@ -1,0 +1,13 @@
+package org.jellyfin.mobile.downloads
+
+enum class DownloadFileType {
+    /**
+     * The main file for an item (e.g. the video file for episodes/movies, or the audio file for music).
+     */
+    ITEM,
+
+    /**
+     * The primary image for the item.
+     */
+    IMAGE_PRIMARY,
+}

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
@@ -1,6 +1,7 @@
 package org.jellyfin.mobile.downloads
 
 import android.content.Context
+import android.net.Uri
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import kotlinx.coroutines.CancellationException
@@ -10,8 +11,11 @@ import org.jellyfin.mobile.app.StorageManager
 import org.jellyfin.mobile.data.dao.DownloadDao
 import org.jellyfin.mobile.data.entity.DownloadEntity
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.libraryApi
 import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.ImageFormat
+import org.jellyfin.sdk.model.api.ImageType
 
 class DownloadQueue(
     private val context: Context,
@@ -58,9 +62,9 @@ class DownloadQueue(
             val api = apiClientController.getApiClient(download.serverId, download.userId)
 
             val storageLocation = storageManager.getStorageLocation()
-            val itemLocation = storageLocation.findFile(download.path) ?: storageLocation.createDirectory(download.path) ?: error("Unable to find or create folder ${download.path}")
+            val itemLocation = storageLocation.findFile(download.path) ?: storageLocation.createDirectory(download.path)
+            ?: error("Unable to find or create folder ${download.path}")
 
-            // TODO: Download all mediastreams, thumbnail etc.
             download(
                 api = api,
                 item = download.item,
@@ -84,16 +88,51 @@ class DownloadQueue(
         itemLocation: DocumentFile,
         progressCallback: FileDownloader.ProgressCallback,
     ) {
-        val filename = item.path?.replace(Regex("^.*[\\\\/]"), "") ?: error("Missing item path")
+        // Main file
+        download(
+            api = api,
+            itemLocation = itemLocation,
+            fileName = item.path?.replace(Regex("^.*[\\\\/]"), "") ?: error("Missing item path"),
+            uri = api.libraryApi.getDownloadUrl(item.id).toUri(),
+            progressCallback = progressCallback,
+        )
 
-        val fileLocation = itemLocation.findFile(filename) ?: itemLocation.createFile("", filename) ?: error("Unable to find or create file $filename")
-        if (!fileLocation.canRead() || !fileLocation.canWrite()) error("Not allowed to read-write $fileLocation")
+        // Primary image
+        item.imageTags?.get(ImageType.PRIMARY)?.let { imageTag ->
+            download(
+                api = api,
+                itemLocation = itemLocation,
+                fileName = "primary.webp",
+                uri = api.imageApi.getItemImageUrl(
+                    itemId = item.id,
+                    imageType = ImageType.PRIMARY,
+                    tag = imageTag,
+                    format = ImageFormat.WEBP
+                ).toUri(),
+                progressCallback = progressCallback,
+            )
+        }
+    }
 
-        val fileDescriptor = context.contentResolver.openFileDescriptor(fileLocation.uri, "rw") ?: error("Unable to open file descriptor for $fileLocation")
+    private suspend fun download(
+        api: ApiClient,
+        itemLocation: DocumentFile,
+        fileName: String,
+        uri: Uri,
+        progressCallback: FileDownloader.ProgressCallback,
+    ) {
+        val documentFile = itemLocation.findFile(fileName)
+            ?: itemLocation.createFile("", fileName)
+            ?: error("Unable to find or create file $fileName")
+
+        if (!documentFile.canRead() || !documentFile.canWrite()) error("Not allowed to read-write $fileName")
+
+        val fileDescriptor = context.contentResolver.openFileDescriptor(documentFile.uri, "rw")
+            ?: error("Unable to open file descriptor for $fileName")
 
         _downloader.downloadAndSave(
-            api,
-            from = api.libraryApi.getDownloadUrl(item.id).toUri(),
+            api = api,
+            from = uri,
             to = fileDescriptor,
             progressCallback = progressCallback,
         )

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
@@ -9,11 +9,11 @@ import okhttp3.OkHttpClient
 import org.jellyfin.mobile.app.ApiClientController
 import org.jellyfin.mobile.app.StorageManager
 import org.jellyfin.mobile.data.dao.DownloadDao
-import org.jellyfin.mobile.data.entity.DownloadEntity
+import org.jellyfin.mobile.data.entity.DownloadFileEntity
+import org.jellyfin.mobile.data.entity.DownloadFiles
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.libraryApi
-import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageType
 
@@ -25,8 +25,10 @@ class DownloadQueue(
     private val storageManager: StorageManager,
     okHttpClient: OkHttpClient,
 ) {
+    private data class QueuedFile(val file: DownloadFileEntity, val remoteUri: Uri)
+
     private val _downloader = FileDownloader(okHttpClient)
-    private val _downloads = mutableListOf<DownloadEntity>()
+    private val _downloads = mutableListOf<DownloadFiles>()
 
     suspend fun prepare(): Boolean {
         val queuedDownloads = downloadDao.getQueuedDownloads()
@@ -39,8 +41,8 @@ class DownloadQueue(
         while (_downloads.any()) {
             val iterator = _downloads.iterator()
             while (iterator.hasNext()) {
-                val download = iterator.next()
-                process(download)
+                val downloadWithFiles = iterator.next()
+                process(downloadWithFiles)
                 iterator.remove()
             }
 
@@ -49,92 +51,160 @@ class DownloadQueue(
         }
     }
 
-    private suspend fun process(download: DownloadEntity) {
+    private suspend fun process(downloadWithFiles: DownloadFiles) {
         // Mark as downloading
-        downloadDao.update(download.copy(status = DownloadStatus.DOWNLOADING))
+        downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.DOWNLOADING))
+        val api = apiClientController.getApiClient(downloadWithFiles.download.serverId, downloadWithFiles.download.userId)
 
         try {
+            val queuedFiles = prepareFiles(api, downloadWithFiles)
+
             val notificationProgressCallback = downloadNotificationManager.downloadFile(
-                download.id,
-                download.id.toString(),
+                downloadWithFiles.download.id,
+                downloadWithFiles.download.getDisplayName(context).orEmpty(),
             )
 
-            val api = apiClientController.getApiClient(download.serverId, download.userId)
-
-            val storageLocation = storageManager.getStorageLocation()
-            val itemLocation = storageLocation.findFile(download.path) ?: storageLocation.createDirectory(download.path)
-            ?: error("Unable to find or create folder ${download.path}")
-
-            download(
-                api = api,
-                item = download.item,
-                itemLocation = itemLocation,
-                progressCallback = notificationProgressCallback,
-            )
+            for (queuedFile in queuedFiles) {
+                download(api, queuedFile, notificationProgressCallback)
+            }
 
             notificationProgressCallback.onEnd()
-            downloadDao.update(download.copy(status = DownloadStatus.DOWNLOADED))
+            downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.DOWNLOADED))
         } catch (_: CancellationException) {
-            downloadDao.update(download.copy(status = DownloadStatus.QUEUED))
+            downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.QUEUED))
         } catch (error: Throwable) {
-            downloadDao.update(download.copy(status = DownloadStatus.ERROR))
+            downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.ERROR))
             throw error
         }
     }
 
     private suspend fun download(
         api: ApiClient,
-        item: BaseItemDto,
-        itemLocation: DocumentFile,
+        queuedFile: QueuedFile,
         progressCallback: FileDownloader.ProgressCallback,
     ) {
-        // Main file
-        download(
-            api = api,
-            itemLocation = itemLocation,
-            fileName = item.path?.replace(Regex("^.*[\\\\/]"), "") ?: error("Missing item path"),
-            uri = api.libraryApi.getDownloadUrl(item.id).toUri(),
-            progressCallback = progressCallback,
-        )
+        val (file, remoteUri) = queuedFile
 
-        // Primary image
-        item.imageTags?.get(ImageType.PRIMARY)?.let { imageTag ->
-            download(
+        // Verify downloaded files and skip if valid
+        if (file.status == DownloadStatus.DOWNLOADED && file.size > 0) {
+            val documentFile = DocumentFile.fromSingleUri(context, file.uri)
+            if (documentFile?.exists() == true && documentFile.length() == file.size) return
+        }
+
+        val fileDescriptor = context.contentResolver.openFileDescriptor(file.uri, "rw")
+            ?: error("Unable to open file descriptor for ${file.fileName}")
+
+        downloadDao.updateFile(file.copy(status = DownloadStatus.DOWNLOADING))
+
+        try {
+            _downloader.downloadAndSave(
                 api = api,
-                itemLocation = itemLocation,
-                fileName = "primary.webp",
-                uri = api.imageApi.getItemImageUrl(
-                    itemId = item.id,
-                    imageType = ImageType.PRIMARY,
-                    tag = imageTag,
-                    format = ImageFormat.WEBP
-                ).toUri(),
+                from = remoteUri,
+                to = fileDescriptor,
                 progressCallback = progressCallback,
             )
+
+            // Update file record with final size and status
+            downloadDao.updateFile(
+                file.copy(
+                    size = DocumentFile.fromSingleUri(context, file.uri)?.length() ?: 0L,
+                    status = DownloadStatus.DOWNLOADED,
+                ),
+            )
+        } catch (e: Exception) {
+            downloadDao.updateFile(file.copy(status = DownloadStatus.ERROR))
+            throw e
         }
     }
 
-    private suspend fun download(
+    private suspend fun prepareFiles(api: ApiClient, downloadWithFiles: DownloadFiles): List<QueuedFile> {
+        val storageLocation = storageManager.getStorageLocation()
+        val itemLocation = storageLocation.findFile(downloadWithFiles.download.path)
+            ?: storageLocation.createDirectory(downloadWithFiles.download.path)
+            ?: error("Unable to find or create folder ${downloadWithFiles.download.path}")
+
+        return buildList {
+            // Add image as first item so it can be shown in UI during downloads
+            preparePrimaryImageFile(api, downloadWithFiles, itemLocation)?.let(::add)
+
+            // Add main item second as it is (often) the largest and important file
+            prepareMainFile(api, downloadWithFiles, itemLocation).let(::add)
+        }
+    }
+
+    private suspend fun prepareMainFile(
         api: ApiClient,
+        downloadWithFiles: DownloadFiles,
         itemLocation: DocumentFile,
-        fileName: String,
-        uri: Uri,
-        progressCallback: FileDownloader.ProgressCallback,
-    ) {
-        val documentFile = itemLocation.findFile(fileName)
-            ?: itemLocation.createFile("", fileName)
-            ?: error("Unable to find or create file $fileName")
+    ) = QueuedFile(
+        file = createOrUpdateFile(
+            filter = { it.type == DownloadFileType.ITEM },
+            downloadWithFiles = downloadWithFiles,
+            itemLocation = itemLocation,
+            type = DownloadFileType.ITEM,
+            fileName = downloadWithFiles.download.item.path?.replace(Regex("^.*[\\\\/]"), "") ?: error("Missing item path"),
+        ),
+        remoteUri = api.libraryApi.getDownloadUrl(downloadWithFiles.download.item.id).toUri()
+    )
 
-        if (!documentFile.canRead() || !documentFile.canWrite()) error("Not allowed to read-write $fileName")
-
-        val fileDescriptor = context.contentResolver.openFileDescriptor(documentFile.uri, "rw")
-            ?: error("Unable to open file descriptor for $fileName")
-
-        _downloader.downloadAndSave(
-            api = api,
-            from = uri,
-            to = fileDescriptor,
-            progressCallback = progressCallback,
+    private suspend fun preparePrimaryImageFile(
+        api: ApiClient,
+        downloadWithFiles: DownloadFiles,
+        itemLocation: DocumentFile
+    ): QueuedFile? = downloadWithFiles.download.item.imageTags?.get(ImageType.PRIMARY)?.let { imageTag ->
+        QueuedFile(
+            file = createOrUpdateFile(
+                filter = { it.type == DownloadFileType.IMAGE_PRIMARY },
+                downloadWithFiles = downloadWithFiles,
+                itemLocation = itemLocation,
+                type = DownloadFileType.IMAGE_PRIMARY,
+                fileName = "primary.webp",
+            ),
+            remoteUri = api.imageApi.getItemImageUrl(
+                itemId = downloadWithFiles.download.item.id,
+                imageType = ImageType.PRIMARY,
+                tag = imageTag,
+                format = ImageFormat.WEBP,
+            ).toUri()
         )
+    }
+
+    private suspend fun createOrUpdateFile(
+        filter: (DownloadFileEntity) -> Boolean,
+        downloadWithFiles: DownloadFiles,
+        itemLocation: DocumentFile,
+        type: DownloadFileType,
+        fileName: String,
+    ): DownloadFileEntity {
+        var downloadFile = downloadWithFiles.files.firstOrNull(filter)
+
+        val file = itemLocation.findFile(fileName)
+            ?: itemLocation.createFile("", fileName)
+            ?: error("Unable to create file $fileName")
+
+        if (downloadFile != null) {
+            downloadFile = downloadFile.copy(
+                type = type,
+                size = 0L,
+                fileName = fileName,
+                uri = file.uri,
+                status = DownloadStatus.QUEUED,
+            )
+            downloadDao.updateFile(downloadFile)
+            return downloadFile
+        } else {
+            downloadFile = DownloadFileEntity(
+                downloadId = downloadWithFiles.download.id,
+                type = type,
+                size = 0L,
+                fileName = fileName,
+                uri = file.uri,
+                status = DownloadStatus.QUEUED,
+            )
+
+            val id = downloadDao.insertFile(downloadFile)
+            downloadFile = downloadFile.copy(id = id)
+            return downloadFile
+        }
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.mobile.app.StorageManager
 import org.jellyfin.mobile.data.dao.DownloadDao
 import org.jellyfin.mobile.data.entity.DownloadEntity
+import org.jellyfin.mobile.data.entity.DownloadFiles
 import org.jellyfin.mobile.events.ActivityEvent
 import org.jellyfin.mobile.events.ActivityEventHandler
 import org.jellyfin.mobile.player.interaction.PlayOptions
@@ -26,8 +27,8 @@ class DownloadsViewModel : ViewModel(), KoinComponent {
     private val activityEventHandler: ActivityEventHandler by inject()
     private val storageManager: StorageManager by inject()
 
-    val downloads: StateFlow<List<DownloadEntity>> = downloadDao
-        .getAllDownloads()
+    val downloads: StateFlow<List<DownloadFiles>> = downloadDao
+        .getAllDownloadsWithFiles()
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -13,8 +13,8 @@ import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.source.SingleSampleMediaSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jellyfin.mobile.app.StorageManager
 import org.jellyfin.mobile.data.dao.DownloadDao
+import org.jellyfin.mobile.downloads.DownloadFileType
 import org.jellyfin.mobile.player.PlayerException
 import org.jellyfin.mobile.player.PlayerViewModel
 import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder
@@ -37,7 +37,6 @@ import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.component.inject
-import java.io.File
 import java.util.UUID
 import kotlin.time.Duration
 
@@ -48,7 +47,6 @@ class QueueManager(
     private val videosApi: VideosApi = apiClient.videosApi
     private val mediaSourceResolver: MediaSourceResolver by inject()
     private val deviceProfileBuilder: DeviceProfileBuilder by inject()
-    private val storageManager: StorageManager by inject()
     private val downloadDao: DownloadDao by inject()
     private val deviceProfile = deviceProfileBuilder.getDeviceProfile()
 
@@ -108,10 +106,11 @@ class QueueManager(
             downloadDao.getDownloadByItemId(itemId)
         } ?: return PlayerException.UnsupportedContent()
 
-        val storageLocation = storageManager.getStorageLocation()
+        val files = withContext(Dispatchers.IO) {
+            downloadDao.getFiles(download.id)
+        }
 
-        val filename = download.item.path?.replace(Regex("^.*[\\\\/]"), "") ?: error("Missing item path")
-        val fileLocation = storageLocation.findFile(download.path)?.findFile(filename)?.uri ?: return PlayerException.NetworkFailure()
+        val mainFile = files.find { it.type == DownloadFileType.ITEM } ?: return PlayerException.NetworkFailure()
 
         val mediaSource = LocalJellyfinMediaSource(
             itemId = download.itemId,
@@ -119,7 +118,7 @@ class QueueManager(
             sourceInfo = download.item.mediaSources!!.first(),
             playSessionId = download.id.toString(),
             playbackDetails = PlaybackDetails(startTime, audioStreamIndex, subtitleStreamIndex),
-            remoteFileUri = fileLocation.toString(),
+            remoteFileUri = mainFile.uri,
         )
         startTime?.let { duration -> mediaSource.startTime = duration }
         audioStreamIndex?.let { index -> mediaSource.selectAudioStream(mediaSource.audioStreams[index]) }
@@ -253,15 +252,7 @@ class QueueManager(
      */
     @CheckResult
     private fun prepareStreams(source: LocalJellyfinMediaSource): MediaSource {
-        val videoSource: MediaSource = createDownloadVideoMediaSource(source.id, source.remoteFileUri)
-        val subtitleSources: Array<MediaSource> = createDownloadExternalSubtitleMediaSources(
-            source,
-            source.remoteFileUri,
-        )
-        return when {
-            subtitleSources.isNotEmpty() -> MergingMediaSource(videoSource, *subtitleSources)
-            else -> videoSource
-        }
+        return createDownloadVideoMediaSource(source.id, source.remoteFileUri)
     }
 
     private fun prepareStreams(source: RemoteJellyfinMediaSource): MediaSource {
@@ -360,35 +351,16 @@ class QueueManager(
     }
 
     @CheckResult
-    private fun createDownloadVideoMediaSource(mediaSourceId: String, fileUri: String): MediaSource {
+    private fun createDownloadVideoMediaSource(mediaSourceId: String, fileUri: Uri): MediaSource {
         val mediaSourceFactory: ProgressiveMediaSource.Factory = get()
 
         val mediaItem = MediaItem.Builder()
             .setMediaId(mediaSourceId)
-            .setUri(fileUri.toUri())
-            .setCustomCacheKey(fileUri)
+            .setUri(fileUri)
+            .setCustomCacheKey(fileUri.toString())
             .build()
 
         return mediaSourceFactory.createMediaSource(mediaItem)
-    }
-
-    @CheckResult
-    private fun createDownloadExternalSubtitleMediaSources(
-        source: JellyfinMediaSource,
-        fileUri: String,
-    ): Array<MediaSource> {
-        val downloadDir = File(fileUri).parent
-        val factory = get<SingleSampleMediaSource.Factory>()
-        return source.externalSubtitleStreams.map { stream ->
-            val uri: Uri = File(downloadDir, "${stream.index}.subrip").toUri()
-            val mediaItem = MediaItem.SubtitleConfiguration.Builder(uri).apply {
-                setId("${ExternalSubtitleStream.ID_PREFIX}${stream.index}")
-                setLabel(stream.displayTitle)
-                setMimeType(stream.mimeType)
-                setLanguage(stream.language)
-            }.build()
-            factory.createMediaSource(mediaItem, source.runTime.inWholeMilliseconds)
-        }.toTypedArray()
     }
 
     /**

--- a/app/src/main/java/org/jellyfin/mobile/player/source/LocalJellyfinMediaSource.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/LocalJellyfinMediaSource.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.mobile.player.source
 
+import android.net.Uri
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.PlayMethod
@@ -11,7 +12,7 @@ class LocalJellyfinMediaSource(
     sourceInfo: MediaSourceInfo,
     playSessionId: String,
     playbackDetails: PlaybackDetails? = null,
-    val remoteFileUri: String,
+    val remoteFileUri: Uri,
 ) : JellyfinMediaSource(itemId, item, sourceInfo, playSessionId, playbackDetails) {
     override val playMethod: PlayMethod = PlayMethod.DIRECT_PLAY
 }

--- a/app/src/main/java/org/jellyfin/mobile/ui/screens/downloads/DownloadsList.kt
+++ b/app/src/main/java/org/jellyfin/mobile/ui/screens/downloads/DownloadsList.kt
@@ -1,14 +1,12 @@
 package org.jellyfin.mobile.ui.screens.downloads
 
-import android.content.Context
-import android.net.Uri
 import android.text.format.Formatter
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.AlertDialog
@@ -28,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -40,12 +39,10 @@ import kotlinx.coroutines.withContext
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.app.StorageManager
 import org.jellyfin.mobile.data.entity.DownloadEntity
+import org.jellyfin.mobile.data.entity.DownloadFiles
+import org.jellyfin.mobile.downloads.DownloadFileType
 import org.jellyfin.mobile.downloads.DownloadStatus
 import org.jellyfin.mobile.downloads.DownloadsViewModel
-import org.jellyfin.mobile.utils.lengthRecursive
-import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.model.api.BaseItemDto
-import org.jellyfin.sdk.model.api.BaseItemKind
 import org.koin.compose.koinInject
 
 @Composable
@@ -66,7 +63,7 @@ fun DownloadsList(
             text = {
                 Column {
                     val name = remember(downloadToRemove, context) {
-                        downloadToRemove?.item?.getDownloadName(context).orEmpty()
+                        downloadToRemove?.getDisplayName(context).orEmpty()
                     }
                     Text(text = stringResource(R.string.download_remove_description, name))
                     Row(
@@ -104,13 +101,13 @@ fun DownloadsList(
     ) {
         items(
             downloads,
-            key = DownloadEntity::id,
-        ) { download ->
+            key = { it.download.id },
+        ) { downloadFiles ->
             DownloadItem(
-                download,
-                onOpen = { viewModel.openDownload(download) },
-                onDownload = { viewModel.download(download) },
-                onRemove = { downloadToRemove = download },
+                downloadFiles,
+                onOpen = { viewModel.openDownload(downloadFiles.download) },
+                onDownload = { viewModel.download(downloadFiles.download) },
+                onRemove = { downloadToRemove = downloadFiles.download },
             )
         }
     }
@@ -119,20 +116,19 @@ fun DownloadsList(
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun DownloadItem(
-    download: DownloadEntity,
+    downloadFiles: DownloadFiles,
     onOpen: () -> Unit,
     onDownload: () -> Unit,
     onRemove: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val (download, files) = downloadFiles
     val context = LocalContext.current
-    val apiClient: ApiClient = koinInject()
     val storageManager: StorageManager = koinInject()
 
-    val fileSize by produceState<Long?>(initialValue = 0L, download) {
+    val isVerified by produceState(initialValue = false, downloadFiles) {
         value = withContext(Dispatchers.IO) {
-            val itemLocation = storageManager.getStorageLocation().findFile(download.path)
-            itemLocation?.lengthRecursive()
+            storageManager.verify(downloadFiles)
         }
     }
 
@@ -140,7 +136,7 @@ fun DownloadItem(
         modifier = modifier
             .combinedClickable(
                 onClick = {
-                    if (fileSize == null) {
+                    if (!isVerified) {
                         onDownload()
                     } else {
                         onOpen()
@@ -149,7 +145,7 @@ fun DownloadItem(
                 onLongClick = { onRemove() },
             ),
         text = {
-            val name = remember(download.item, context) { download.item.getDownloadName(context) }
+            val name = remember(download, context) { download.getDisplayName(context).orEmpty() }
             Text(
                 text = name,
                 overflow = TextOverflow.Ellipsis,
@@ -157,13 +153,8 @@ fun DownloadItem(
             )
         },
         icon = {
-            val uri by produceState<Uri?>(initialValue = null, download) {
-                value = withContext(Dispatchers.IO) {
-                    storageManager.getStorageLocation()
-                        .findFile(download.path)
-                        ?.findFile("primary.webp")
-                        ?.uri
-                }
+            val uri = remember(files) {
+                files.find { it.type == DownloadFileType.IMAGE_PRIMARY }?.uri
             }
 
             AsyncImage(
@@ -171,18 +162,19 @@ fun DownloadItem(
                 placeholder = painterResource(R.drawable.ic_local_movies_white_64),
                 fallback = painterResource(R.drawable.ic_local_movies_white_64),
                 contentDescription = null,
-                modifier = Modifier.sizeIn(
-                    maxWidth = 64.dp,
-                    maxHeight = 64.dp,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.size(
+                    width = 64.dp,
+                    height = 64.dp,
                 )
             )
         },
         secondaryText = {
             if (download.status == DownloadStatus.DOWNLOADING || download.status == DownloadStatus.QUEUED) {
                 LinearProgressIndicator()
-            } else if (fileSize != null) {
+            } else if (isVerified) {
                 Text(
-                    text = Formatter.formatShortFileSize(context, fileSize!!),
+                    text = Formatter.formatShortFileSize(context, files.sumOf { it.size }),
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
                 )
@@ -198,32 +190,3 @@ fun DownloadItem(
         singleLineSecondaryText = true,
     )
 }
-
-private fun BaseItemDto.getDownloadName(context: Context) = buildString {
-    val name = if (
-        type in arrayOf(BaseItemKind.PROGRAM, BaseItemKind.RECORDING) &&
-        (isSeries == true || !episodeTitle.isNullOrEmpty())
-    ) {
-        episodeTitle
-    } else {
-        name
-    }
-
-    val extraInfo = when (type) {
-        BaseItemKind.TV_CHANNEL if !channelNumber.isNullOrEmpty() -> channelNumber
-        BaseItemKind.EPISODE if parentIndexNumber == 0 -> context.getString(R.string.special_episode)
-        in arrayOf(BaseItemKind.EPISODE, BaseItemKind.RECORDING) if indexNumber != null && parentIndexNumber != null ->
-            "S$parentIndexNumber:E${indexNumber}${indexNumberEnd?.let { n -> "-$n" } ?: ""}"
-        else -> ""
-    }
-
-    listOf(seriesName, extraInfo, name)
-        .filter { str -> !str.isNullOrEmpty() }
-        .joinTo(this, separator = " - ")
-
-    if (type == BaseItemKind.MOVIE && productionYear != null) {
-        append(" ($productionYear)")
-    } else if (premiereDate != null) {
-        append(" (${premiereDate!!.year})")
-    }
-}.ifEmpty { name.orEmpty() }

--- a/app/src/main/java/org/jellyfin/mobile/ui/screens/downloads/DownloadsList.kt
+++ b/app/src/main/java/org/jellyfin/mobile/ui/screens/downloads/DownloadsList.kt
@@ -1,12 +1,14 @@
 package org.jellyfin.mobile.ui.screens.downloads
 
 import android.content.Context
+import android.net.Uri
 import android.text.format.Formatter
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.AlertDialog
@@ -27,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,10 +44,8 @@ import org.jellyfin.mobile.downloads.DownloadStatus
 import org.jellyfin.mobile.downloads.DownloadsViewModel
 import org.jellyfin.mobile.utils.lengthRecursive
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ImageType
 import org.koin.compose.koinInject
 
 @Composable
@@ -158,21 +157,24 @@ fun DownloadItem(
             )
         },
         icon = {
-            val maxSize = LocalResources.current.getDimensionPixelSize(R.dimen.movie_thumbnail_list_size)
-            val url = remember(apiClient, download.itemId, maxSize) {
-                apiClient.imageApi.getItemImageUrl(
-                    itemId = download.itemId,
-                    imageType = ImageType.PRIMARY,
-                    maxWidth = maxSize,
-                    maxHeight = maxSize,
-                )
+            val uri by produceState<Uri?>(initialValue = null, download) {
+                value = withContext(Dispatchers.IO) {
+                    storageManager.getStorageLocation()
+                        .findFile(download.path)
+                        ?.findFile("primary.webp")
+                        ?.uri
+                }
             }
 
             AsyncImage(
-                model = url,
+                model = uri,
                 placeholder = painterResource(R.drawable.ic_local_movies_white_64),
                 fallback = painterResource(R.drawable.ic_local_movies_white_64),
                 contentDescription = null,
+                modifier = Modifier.sizeIn(
+                    maxWidth = 64.dp,
+                    maxHeight = 64.dp,
+                )
             )
         },
         secondaryText = {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

This PR contains two changes in two separate commits. The first commit adds support for downloading the primary image of an item in addition to the item itself. This is used by the DownloadList for display instead of loading the image over the network, because that may not be available when offline.

The second commit is the bigger one, it adds a new entity "DownloadFile" used to indicate where the different file types of a download are stored so we don't have to look them up on the file system when we want to use them. This is also a preparation for downloading external subtitles of videos.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
