### PR TITLE
Sync playback between Android Phone and Android Auto

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppModule.kt
@@ -40,6 +40,7 @@ import org.jellyfin.mobile.player.mediasegments.MediaSegmentRepository
 import org.jellyfin.mobile.player.qualityoptions.QualityOptionsProvider
 import org.jellyfin.mobile.player.source.MediaSourceResolver
 import org.jellyfin.mobile.player.ui.PlayerFragment
+import org.jellyfin.mobile.sessionbrowser.SharedPlaybackStateRepository
 import org.jellyfin.mobile.setup.ConnectionHelper
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.PermissionRequestHelper
@@ -90,6 +91,9 @@ val applicationModule = module {
 
     // Connection helper
     single { ConnectionHelper(get(), get()) }
+
+    // Shared playback state bridge between webapp and Android Auto
+    single { SharedPlaybackStateRepository() }
 
     // Media player helpers
     single { MediaSourceResolver(get()) }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -112,7 +112,7 @@ class NativeInterface(private val context: Context) : KoinComponent {
     fun hideMediaSession(): Boolean {
         val intent = Intent(context, RemotePlayerService::class.java).apply {
             action = Constants.ACTION_REPORT
-            putExtra(EXTRA_PLAYER_ACTION, "playbackstop")
+            putExtra(EXTRA_PLAYER_ACTION, Constants.PLAYER_ACTION_PLAYBACK_STOP)
         }
         context.startService(intent)
         return true

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryService.kt
@@ -1,18 +1,39 @@
 package org.jellyfin.mobile.sessionbrowser
 
+import android.content.Intent
+import android.os.Looper
+import androidx.core.content.ContextCompat
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.jellyfin.mobile.app.ApiClientController
+import org.jellyfin.mobile.utils.Constants
+import org.jellyfin.mobile.webapp.RemotePlayerService
+import org.jellyfin.mobile.webapp.WebappFunctionChannel
 import org.jellyfin.sdk.api.client.ApiClient
 import org.koin.android.ext.android.inject
+import kotlin.coroutines.CoroutineContext
 
-class LibraryService : MediaLibraryService() {
+class LibraryService : MediaLibraryService(), CoroutineScope {
+
+    private lateinit var job: Job
+    override val coroutineContext: CoroutineContext
+        get() = job + Dispatchers.Main
+
     private val apiClientController: ApiClientController by inject()
     private val apiClient: ApiClient by inject()
+    private val sharedPlaybackStateRepository: SharedPlaybackStateRepository by inject()
+    private val webappFunctionChannel: WebappFunctionChannel by inject()
 
     private val playerAudioAttributes = AudioAttributes.Builder()
         .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
@@ -26,6 +47,10 @@ class LibraryService : MediaLibraryService() {
         }
     }
 
+    private val remoteStatePlayer: RemoteStatePlayer by lazy {
+        RemoteStatePlayer(Looper.getMainLooper(), webappFunctionChannel)
+    }
+
     private val mediaLibrarySession: MediaLibrarySession by lazy {
         MediaLibrarySession.Builder(this, exoPlayer, callback)
             .build()
@@ -35,17 +60,125 @@ class LibraryService : MediaLibraryService() {
         SessionBrowserCallback(this, apiClient)
     }
 
+    private var isAutoReportActive = false
+
+    private val exoPlayerListener = object : Player.Listener {
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (exoPlayer.playbackState == Player.STATE_READY) {
+                if (mediaLibrarySession.player !== exoPlayer) {
+                    mediaLibrarySession.setPlayer(exoPlayer)
+                    remoteStatePlayer.clearState()
+                }
+                sendAutoPlaybackReport()
+            }
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            when (playbackState) {
+                Player.STATE_READY -> {
+                    if (mediaLibrarySession.player !== exoPlayer) {
+                        mediaLibrarySession.setPlayer(exoPlayer)
+                        remoteStatePlayer.clearState()
+                    }
+                    sendAutoPlaybackReport()
+                }
+                Player.STATE_IDLE, Player.STATE_ENDED -> {
+                    sendAutoPlaybackStop()
+                    val webappState = sharedPlaybackStateRepository.webappPlaybackState.value
+                    if (webappState != null) {
+                        remoteStatePlayer.updateState(webappState)
+                        mediaLibrarySession.setPlayer(remoteStatePlayer)
+                    }
+                }
+            }
+        }
+
+        override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+            if (exoPlayer.playbackState == Player.STATE_READY) {
+                sendAutoPlaybackReport()
+            }
+        }
+    }
+
     override fun onGetSession(
         controllerInfo: MediaSession.ControllerInfo,
     ): MediaLibrarySession = mediaLibrarySession
 
     override fun onCreate() {
         super.onCreate()
+        job = Job()
 
         runBlocking { apiClientController.loadSavedServerUser() }
+
+        exoPlayer.addListener(exoPlayerListener)
+        launch { observeWebappPlaybackState() }
+        launch { collectAutoPlaybackCommands() }
+    }
+
+    private suspend fun observeWebappPlaybackState() {
+        sharedPlaybackStateRepository.webappPlaybackState.collectLatest { data ->
+            if (data != null && exoPlayer.playbackState == Player.STATE_IDLE) {
+                remoteStatePlayer.updateState(data)
+                mediaLibrarySession.setPlayer(remoteStatePlayer)
+            } else if (data == null) {
+                mediaLibrarySession.setPlayer(exoPlayer)
+                remoteStatePlayer.clearState()
+            }
+        }
+    }
+
+    private suspend fun collectAutoPlaybackCommands() {
+        sharedPlaybackStateRepository.autoPlaybackCommands.collect { command ->
+            when (command) {
+                is AutoPlaybackCommand.Play -> exoPlayer.play()
+                is AutoPlaybackCommand.Pause -> exoPlayer.pause()
+                is AutoPlaybackCommand.Stop -> exoPlayer.stop()
+                is AutoPlaybackCommand.SkipToPrevious -> exoPlayer.seekToPreviousMediaItem()
+                is AutoPlaybackCommand.SkipToNext -> exoPlayer.seekToNextMediaItem()
+                is AutoPlaybackCommand.Rewind -> exoPlayer.seekBack()
+                is AutoPlaybackCommand.FastForward -> exoPlayer.seekForward()
+                is AutoPlaybackCommand.SeekTo -> exoPlayer.seekTo(command.positionMs)
+            }
+        }
+    }
+
+    private fun sendAutoPlaybackReport() {
+        val currentItem = exoPlayer.currentMediaItem ?: return
+        val metadata = exoPlayer.mediaMetadata
+        val durationMs = exoPlayer.duration.takeIf { it != C.TIME_UNSET } ?: 0L
+
+        val intent = Intent(this, RemotePlayerService::class.java).apply {
+            action = Constants.ACTION_REPORT
+            putExtra(Constants.EXTRA_ITEM_ID, currentItem.mediaId)
+            putExtra(Constants.EXTRA_TITLE, metadata.title?.toString())
+            putExtra(Constants.EXTRA_ARTIST, metadata.artist?.toString())
+            putExtra(Constants.EXTRA_ALBUM, metadata.albumTitle?.toString())
+            putExtra(Constants.EXTRA_IMAGE_URL, metadata.artworkUri?.toString())
+            putExtra(Constants.EXTRA_POSITION, exoPlayer.currentPosition)
+            putExtra(Constants.EXTRA_DURATION, durationMs)
+            putExtra(Constants.EXTRA_CAN_SEEK, true)
+            putExtra(Constants.EXTRA_IS_LOCAL_PLAYER, true)
+            putExtra(Constants.EXTRA_IS_PAUSED, !exoPlayer.isPlaying)
+            putExtra(Constants.EXTRA_IS_AUTO_PLAYER, true)
+        }
+        ContextCompat.startForegroundService(this, intent)
+        isAutoReportActive = true
+    }
+
+    private fun sendAutoPlaybackStop() {
+        if (!isAutoReportActive) return
+        isAutoReportActive = false
+        val intent = Intent(this, RemotePlayerService::class.java).apply {
+            action = Constants.ACTION_REPORT
+            putExtra(Constants.EXTRA_PLAYER_ACTION, Constants.PLAYER_ACTION_PLAYBACK_STOP)
+        }
+        startService(intent)
     }
 
     override fun onDestroy() {
+        job.cancel()
+        exoPlayer.removeListener(exoPlayerListener)
+        remoteStatePlayer.release()
         exoPlayer.release()
         mediaLibrarySession.release()
 

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/RemoteStatePlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/RemoteStatePlayer.kt
@@ -1,0 +1,113 @@
+package org.jellyfin.mobile.sessionbrowser
+
+import android.os.Looper
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.common.SimpleBasePlayer
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import org.jellyfin.mobile.utils.Constants
+import org.jellyfin.mobile.webapp.WebappFunctionChannel
+
+private const val MS_TO_US = 1000L
+
+class RemoteStatePlayer(
+    looper: Looper,
+    private val webappFunctionChannel: WebappFunctionChannel,
+) : SimpleBasePlayer(looper) {
+
+    private var currentState: State = buildIdleState()
+
+    override fun getState(): State = currentState
+
+    fun updateState(data: PlaybackStateData) {
+        currentState = buildActiveState(data)
+        invalidateState()
+    }
+
+    fun clearState() {
+        currentState = buildIdleState()
+        invalidateState()
+    }
+
+    private fun buildIdleState(): State = State.Builder()
+        .setAvailableCommands(Player.Commands.Builder().build())
+        .build()
+
+    private fun buildActiveState(data: PlaybackStateData): State {
+        val mediaMetadata = MediaMetadata.Builder()
+            .setTitle(data.title)
+            .setArtist(data.artist)
+            .setAlbumTitle(data.album)
+            .setArtworkUri(data.artworkUri)
+            .setIsPlayable(true)
+            .setIsBrowsable(false)
+            .build()
+
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(data.itemId)
+            .setMediaMetadata(mediaMetadata)
+            .build()
+
+        val durationUs = if (data.durationMs > 0) data.durationMs * MS_TO_US else C.TIME_UNSET
+
+        val mediaItemData = MediaItemData.Builder(data.itemId)
+            .setMediaItem(mediaItem)
+            .setDurationUs(durationUs)
+            .build()
+
+        val commands = Player.Commands.Builder()
+            .addAll(
+                Player.COMMAND_PLAY_PAUSE,
+                Player.COMMAND_STOP,
+                Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_GET_TIMELINE,
+                Player.COMMAND_GET_METADATA,
+                Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+                Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+            )
+            .apply {
+                if (data.canSeek) add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+            }
+            .build()
+
+        return State.Builder()
+            .setAvailableCommands(commands)
+            .setPlaybackState(Player.STATE_READY)
+            .setPlayWhenReady(data.isPlaying, Player.PLAY_WHEN_READY_CHANGE_REASON_REMOTE)
+            .setPlaylist(ImmutableList.of(mediaItemData))
+            .setCurrentMediaItemIndex(0)
+            .setContentPositionMs(PositionSupplier.getConstant(data.positionMs))
+            .build()
+    }
+
+    override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
+        val command = if (playWhenReady) {
+            Constants.PLAYBACK_MANAGER_COMMAND_PLAY
+        } else {
+            Constants.PLAYBACK_MANAGER_COMMAND_PAUSE
+        }
+        webappFunctionChannel.callPlaybackManagerAction(command)
+        return Futures.immediateVoidFuture()
+    }
+
+    override fun handleStop(): ListenableFuture<*> {
+        webappFunctionChannel.callPlaybackManagerAction(Constants.PLAYBACK_MANAGER_COMMAND_STOP)
+        return Futures.immediateVoidFuture()
+    }
+
+    override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: Int): ListenableFuture<*> {
+        when (seekCommand) {
+            Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM ->
+                webappFunctionChannel.seekTo(positionMs)
+            Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM, Player.COMMAND_SEEK_TO_NEXT ->
+                webappFunctionChannel.callPlaybackManagerAction(Constants.PLAYBACK_MANAGER_COMMAND_NEXT)
+            Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM, Player.COMMAND_SEEK_TO_PREVIOUS ->
+                webappFunctionChannel.callPlaybackManagerAction(Constants.PLAYBACK_MANAGER_COMMAND_PREVIOUS)
+        }
+        return Futures.immediateVoidFuture()
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SharedPlaybackStateRepository.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SharedPlaybackStateRepository.kt
@@ -1,0 +1,52 @@
+package org.jellyfin.mobile.sessionbrowser
+
+import android.net.Uri
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+data class PlaybackStateData(
+    val itemId: String,
+    val title: String?,
+    val artist: String?,
+    val album: String?,
+    val artworkUri: Uri?,
+    val positionMs: Long,
+    val durationMs: Long,
+    val isPlaying: Boolean,
+    val canSeek: Boolean,
+)
+
+sealed class AutoPlaybackCommand {
+    object Play : AutoPlaybackCommand()
+    object Pause : AutoPlaybackCommand()
+    object Stop : AutoPlaybackCommand()
+    object SkipToPrevious : AutoPlaybackCommand()
+    object SkipToNext : AutoPlaybackCommand()
+    object Rewind : AutoPlaybackCommand()
+    object FastForward : AutoPlaybackCommand()
+    data class SeekTo(val positionMs: Long) : AutoPlaybackCommand()
+}
+
+class SharedPlaybackStateRepository {
+    companion object {
+        private const val COMMAND_BUFFER_CAPACITY = 10
+    }
+
+    private val _webappPlaybackState = MutableStateFlow<PlaybackStateData?>(null)
+    val webappPlaybackState: StateFlow<PlaybackStateData?> = _webappPlaybackState
+
+    val autoPlaybackCommands = MutableSharedFlow<AutoPlaybackCommand>(
+        extraBufferCapacity = COMMAND_BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    fun updateWebappState(data: PlaybackStateData) {
+        _webappPlaybackState.value = data
+    }
+
+    fun clearWebappState() {
+        _webappPlaybackState.value = null
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -101,6 +101,10 @@ object Constants {
     const val EXTRA_CAN_SEEK = "canSeek"
     const val EXTRA_IS_LOCAL_PLAYER = "isLocalPlayer"
     const val EXTRA_IS_PAUSED = "isPaused"
+    const val EXTRA_IS_AUTO_PLAYER = "isAutoPlayer"
+
+    // Player action values sent via EXTRA_PLAYER_ACTION
+    const val PLAYER_ACTION_PLAYBACK_STOP = "playbackstop"
 
     // Video player constants
     const val LANGUAGE_UNDEFINED = "und"

--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -19,6 +19,7 @@ import android.media.MediaMetadata
 import android.media.session.MediaController
 import android.media.session.MediaSession
 import android.media.session.PlaybackState
+import android.net.Uri
 import android.os.Binder
 import android.os.IBinder
 import android.os.PowerManager
@@ -36,6 +37,9 @@ import kotlinx.coroutines.launch
 import org.jellyfin.mobile.MainActivity
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.app.AppPreferences
+import org.jellyfin.mobile.sessionbrowser.AutoPlaybackCommand
+import org.jellyfin.mobile.sessionbrowser.PlaybackStateData
+import org.jellyfin.mobile.sessionbrowser.SharedPlaybackStateRepository
 import org.jellyfin.mobile.utils.AndroidVersion
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.Constants.EXTRA_ALBUM
@@ -43,6 +47,7 @@ import org.jellyfin.mobile.utils.Constants.EXTRA_ARTIST
 import org.jellyfin.mobile.utils.Constants.EXTRA_CAN_SEEK
 import org.jellyfin.mobile.utils.Constants.EXTRA_DURATION
 import org.jellyfin.mobile.utils.Constants.EXTRA_IMAGE_URL
+import org.jellyfin.mobile.utils.Constants.EXTRA_IS_AUTO_PLAYER
 import org.jellyfin.mobile.utils.Constants.EXTRA_IS_LOCAL_PLAYER
 import org.jellyfin.mobile.utils.Constants.EXTRA_IS_PAUSED
 import org.jellyfin.mobile.utils.Constants.EXTRA_ITEM_ID
@@ -58,6 +63,7 @@ import org.jellyfin.mobile.utils.Constants.PLAYBACK_MANAGER_COMMAND_PLAY
 import org.jellyfin.mobile.utils.Constants.PLAYBACK_MANAGER_COMMAND_PREVIOUS
 import org.jellyfin.mobile.utils.Constants.PLAYBACK_MANAGER_COMMAND_REWIND
 import org.jellyfin.mobile.utils.Constants.PLAYBACK_MANAGER_COMMAND_STOP
+import org.jellyfin.mobile.utils.Constants.PLAYER_ACTION_PLAYBACK_STOP
 import org.jellyfin.mobile.utils.Constants.SUPPORTED_MUSIC_PLAYER_PLAYBACK_ACTIONS
 import org.jellyfin.mobile.utils.applyDefaultLocalAudioAttributes
 import org.jellyfin.mobile.utils.createMediaNotificationChannel
@@ -75,6 +81,7 @@ class RemotePlayerService : Service(), CoroutineScope {
     private val appPreferences: AppPreferences by inject()
     private val notificationManager: NotificationManager by lazy { getSystemService()!! }
     private val imageLoader: ImageLoader by inject()
+    private val sharedPlaybackStateRepository: SharedPlaybackStateRepository by inject()
 
     private val binder = ServiceBinder(this)
     private val webappFunctionChannel: WebappFunctionChannel by inject()
@@ -85,6 +92,7 @@ class RemotePlayerService : Service(), CoroutineScope {
     private var mediaController: MediaController? = null
     private var largeItemIcon: Bitmap? = null
     private var currentItemId: String? = null
+    private var isAutoPlayer = false
 
     val playbackState: PlaybackState? get() = mediaSession?.controller?.playbackState
 
@@ -195,7 +203,7 @@ class RemotePlayerService : Service(), CoroutineScope {
 
     @Suppress("ComplexMethod", "LongMethod")
     private fun notify(handledIntent: Intent) {
-        if (handledIntent.getStringExtra(EXTRA_PLAYER_ACTION) == "playbackstop") {
+        if (handledIntent.getStringExtra(EXTRA_PLAYER_ACTION) == PLAYER_ACTION_PLAYBACK_STOP) {
             onStopped()
             return
         }
@@ -213,6 +221,24 @@ class RemotePlayerService : Service(), CoroutineScope {
             val canSeek = handledIntent.getBooleanExtra(EXTRA_CAN_SEEK, false)
             val isLocalPlayer = handledIntent.getBooleanExtra(EXTRA_IS_LOCAL_PLAYER, true)
             val isPaused = handledIntent.getBooleanExtra(EXTRA_IS_PAUSED, false)
+            val isAutoPlayerValue = handledIntent.getBooleanExtra(EXTRA_IS_AUTO_PLAYER, false)
+            isAutoPlayer = isAutoPlayerValue
+
+            if (!isAutoPlayerValue) {
+                sharedPlaybackStateRepository.updateWebappState(
+                    PlaybackStateData(
+                        itemId = itemId,
+                        title = title,
+                        artist = artist,
+                        album = album,
+                        artworkUri = if (!imageUrl.isNullOrEmpty()) Uri.parse(imageUrl) else null,
+                        positionMs = if (position != PlaybackState.PLAYBACK_POSITION_UNKNOWN) position else 0L,
+                        durationMs = duration,
+                        isPlaying = !isPaused,
+                        canSeek = canSeek,
+                    )
+                )
+            }
 
             // Resolve notification bitmap
             val cachedBitmap = largeItemIcon?.takeIf { itemId == currentItemId }
@@ -413,36 +439,68 @@ class RemotePlayerService : Service(), CoroutineScope {
                 @SuppressLint("MissingOnPlayFromSearch")
                 object : MediaSession.Callback() {
                     override fun onPlay() {
-                        webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_PLAY)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.Play)
+                        } else {
+                            webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_PLAY)
+                        }
                     }
 
                     override fun onPause() {
-                        webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_PAUSE)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.Pause)
+                        } else {
+                            webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_PAUSE)
+                        }
                     }
 
                     override fun onSkipToPrevious() {
-                        webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_PREVIOUS)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.SkipToPrevious)
+                        } else {
+                            webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_PREVIOUS)
+                        }
                     }
 
                     override fun onSkipToNext() {
-                        webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_NEXT)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.SkipToNext)
+                        } else {
+                            webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_NEXT)
+                        }
                     }
 
                     override fun onRewind() {
-                        webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_REWIND)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.Rewind)
+                        } else {
+                            webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_REWIND)
+                        }
                     }
 
                     override fun onFastForward() {
-                        webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_FAST_FORWARD)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.FastForward)
+                        } else {
+                            webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_FAST_FORWARD)
+                        }
                     }
 
                     override fun onStop() {
-                        webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_STOP)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.Stop)
+                        } else {
+                            webappFunctionChannel.callPlaybackManagerAction(PLAYBACK_MANAGER_COMMAND_STOP)
+                        }
                         onStopped()
                     }
 
                     override fun onSeekTo(pos: Long) {
-                        webappFunctionChannel.seekTo(pos)
+                        if (isAutoPlayer) {
+                            sharedPlaybackStateRepository.autoPlaybackCommands.tryEmit(AutoPlaybackCommand.SeekTo(pos))
+                        } else {
+                            webappFunctionChannel.seekTo(pos)
+                        }
                         val currentState = playbackState ?: return
                         val isPlaying = currentState.state == PlaybackState.STATE_PLAYING
                         val canSeek = (currentState.actions and PlaybackState.ACTION_SEEK_TO) != 0L
@@ -456,6 +514,10 @@ class RemotePlayerService : Service(), CoroutineScope {
     private fun onStopped() {
         notificationManager.cancel(MEDIA_PLAYER_NOTIFICATION_ID)
         mediaSession?.isActive = false
+        if (!isAutoPlayer) {
+            sharedPlaybackStateRepository.clearWebappState()
+        }
+        isAutoPlayer = false
         stopWakelock()
         stopSelf()
     }


### PR DESCRIPTION
Sync position and state for music & audiobooks for Android on your phone along with Android Auto. Currently these 2 use independent players. This change syncs the two. So if you are listening to a song on your phone at 2:00 and turn on Android Auto, and press play it will continue playing at 2:00. Both devices will also sync whether the audio is paused or playing.

**Code assistance**
I worked with Opus to identify the underlying issue and point me to where the underlying code is bugged and what would need to be created.

**Issues**
Doesn't depend on my [audiobook support PR](https://github.com/jellyfin/jellyfin-android/pull/2017), however it will work to support audiobooks whenever that is merged in.