### PR TITLE
Handle null locale when web settings language is not configured

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
@@ -3,8 +3,8 @@ package org.jellyfin.mobile.utils
 import android.content.Context
 import android.content.res.Configuration
 import android.webkit.WebView
+import kotlinx.serialization.json.Json
 import org.json.JSONException
-import org.json.JSONObject
 import timber.log.Timber
 import java.util.Locale
 import java.util.UUID
@@ -18,7 +18,7 @@ suspend fun WebView.initLocale(userId: UUID) {
         val flatUserId = userId.toString().replace("-", "")
         evaluateJavascript("window.localStorage.getItem('$flatUserId-language')") { result ->
             try {
-                continuation.resume(JSONObject("{locale:$result}").getString("locale"))
+                continuation.resume(Json.decodeFromString<String?>(result))
             } catch (e: JSONException) {
                 continuation.resume(null)
             }


### PR DESCRIPTION
**Changes**
When the web settings language is not configured, `localStorage.getItem()` returns `null`, causing locale parsing to fail and preventing the native SettingsFragment from being translated correctly. This change handles nullable locale values by deserializing the result directly with `kotlinx.serialization`, removing the need for the temporary `JSONObject` wrapper and correctly supporting both string and `null` values.

**Code assistance**
The PR description was generated by ChatGPT 5.5 🗿
Coding assistance only happened from Niels his PR review 🫶 

**Issues**
Fixes https://github.com/jellyfin/jellyfin-android/issues/1923