### PR TITLE
Request download folder if unset

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,15 +19,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        tools:ignore="ScopedStorage"
-        tools:node="remove" />
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28"
-        tools:ignore="ScopedStorage" />
-
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <queries>

--- a/app/src/main/java/org/jellyfin/mobile/app/StorageManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/StorageManager.kt
@@ -9,33 +9,33 @@ import androidx.documentfile.provider.DocumentFile
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.data.entity.DownloadFiles
 import org.jellyfin.mobile.downloads.DownloadStatus
-import java.io.File
+import timber.log.Timber
 
 class StorageManager(
     private val context: Context,
     private val appPreferences: AppPreferences
 ) {
-    private val defaultStorageLocation
-        get() = Environment.getExternalStorageDirectory().absolutePath + File.separator + context.getString(R.string.app_name_short)
+    val defaultStorageLocation
+        get() = Environment.getExternalStorageDirectory().resolve(context.getString(R.string.app_name_short)).toUri()
 
-    init {
-        ensureNoMedia(getStorageLocation())
+    fun getStorageLocation() = appPreferences.storageLocation?.toUri()?.let {
+        DocumentFile.fromTreeUri(context, it)
     }
 
-    fun getStorageLocation(): DocumentFile = appPreferences.storageLocation?.toUri()?.let {
-        DocumentFile.fromTreeUri(context, it)
-    } ?: DocumentFile.fromFile(File(defaultStorageLocation))
+    fun changeStorageLocation(location: Uri): Boolean {
+        if (appPreferences.storageLocation?.toUri() == location) return true
 
-    fun changeStorageLocation(location: Uri) {
-        if (appPreferences.storageLocation?.toUri() == location) return
+        return runCatching {
+            context.contentResolver.takePersistableUriPermission(
+                location,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            )
 
-        val documentFile = DocumentFile.fromTreeUri(context, location) ?: error("Invalid location $location")
-        context.contentResolver.takePersistableUriPermission(
-            documentFile.uri,
-            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
-        )
-        ensureNoMedia(documentFile)
-        appPreferences.storageLocation = documentFile.uri.toString()
+            appPreferences.storageLocation = location.toString()
+            getStorageLocation()?.let(::ensureNoMedia)
+        }.onFailure { err ->
+            Timber.e(err, "Failed to change storage location to $location")
+        }.isFailure
     }
 
     fun verify(download: DownloadFiles): Boolean {

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadManager.kt
@@ -110,7 +110,7 @@ class DownloadManager(
 
         if (deleteFiles) {
             val storageLocation = storageManager.getStorageLocation()
-            storageLocation.findFile(download.path)?.delete()
+            storageLocation?.findFile(download.path)?.delete()
         }
 
         downloadDao.delete(id)

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
@@ -119,8 +119,8 @@ class DownloadQueue(
 
     private suspend fun prepareFiles(api: ApiClient, downloadWithFiles: DownloadFiles): List<QueuedFile> {
         val storageLocation = storageManager.getStorageLocation()
-        val itemLocation = storageLocation.findFile(downloadWithFiles.download.path)
-            ?: storageLocation.createDirectory(downloadWithFiles.download.path)
+        val itemLocation = storageLocation?.findFile(downloadWithFiles.download.path)
+            ?: storageLocation?.createDirectory(downloadWithFiles.download.path)
             ?: error("Unable to find or create folder ${downloadWithFiles.download.path}")
 
         return buildList {

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsViewModel.kt
@@ -56,7 +56,7 @@ class DownloadsViewModel : ViewModel(), KoinComponent {
                 viewModelScope.launch {
                     val fileUri = withContext(Dispatchers.IO) {
                         val storageLocation = storageManager.getStorageLocation()
-                        val itemLocation = storageLocation.findFile(download.path)
+                        val itemLocation = storageLocation?.findFile(download.path)
                         if (itemLocation != null && itemLocation.isDirectory) {
                             val filename = download.item.path?.replace(Regex("^.*[\\\\/]"), "")
                             if (filename != null) itemLocation.findFile(filename)?.uri else null

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -42,11 +42,11 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
 
     private val storageLocationPicker = registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
         if (uri != null) {
-            storageManager.changeStorageLocation(uri)
+            val changed = storageManager.changeStorageLocation(uri)
 
             // Update preference
-            if (::downloadLocationPreference.isInitialized) {
-                downloadLocationPreference.summary = storageManager.getStorageLocation().name
+            if (changed && ::downloadLocationPreference.isInitialized) {
+                downloadLocationPreference.summary = storageManager.getStorageLocation()?.name
                 downloadLocationPreference.requestRebindAndHighlight()
             }
         }
@@ -273,10 +273,10 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
             val location = storageManager.getStorageLocation()
 
             titleRes = R.string.pref_download_location
-            summary = location.name
+            summary = location?.name ?: getString(R.string.menu_item_none)
 
             onClick {
-                storageLocationPicker.launch(location.uri)
+                storageLocationPicker.launch(location?.uri ?: storageManager.defaultStorageLocation)
                 false
             }
         }

--- a/app/src/main/java/org/jellyfin/mobile/ui/utils/DownloadSettingsDialog.kt
+++ b/app/src/main/java/org/jellyfin/mobile/ui/utils/DownloadSettingsDialog.kt
@@ -1,0 +1,110 @@
+package org.jellyfin.mobile.ui.utils
+
+import androidx.activity.ComponentActivity
+import androidx.activity.ComponentDialog
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.jellyfin.mobile.R
+import org.jellyfin.mobile.app.StorageManager
+import org.koin.android.ext.android.get
+import org.koin.compose.koinInject
+import kotlin.coroutines.resume
+
+@Composable
+fun DownloadSettingsDialogContent(onClose: () -> Unit) {
+    val storageManager: StorageManager = koinInject()
+
+    var storageLocation by remember { mutableStateOf(storageManager.getStorageLocation()) }
+
+    val storageLocationPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        if (uri != null) {
+            storageManager.changeStorageLocation(uri)
+            storageLocation = storageManager.getStorageLocation()
+            onClose()
+        }
+    }
+
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colors.surface,
+        contentColor = MaterialTheme.colors.onSurface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.download_settings_dialog_title),
+                style = MaterialTheme.typography.h6,
+            )
+
+            Text(
+                text = stringResource(R.string.download_settings_dialog_message),
+                style = MaterialTheme.typography.body2,
+            )
+
+            Button(
+                onClick = {
+                    storageLocationPicker.launch(storageLocation?.uri ?: storageManager.defaultStorageLocation)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = stringResource(R.string.select_folder))
+            }
+        }
+    }
+}
+
+fun ComponentActivity.shouldShowDownloadSettingsDialog(): Boolean {
+    val storageManager = get<StorageManager>()
+    return storageManager.getStorageLocation() == null
+}
+
+suspend fun ComponentActivity.showDownloadSettingsDialog() {
+    suspendCancellableCoroutine { continuation ->
+        ComponentDialog(this).apply {
+            setContentView(
+                ComposeView(this@showDownloadSettingsDialog).apply {
+                    setContent {
+                        AppTheme {
+                            DownloadSettingsDialogContent(
+                                onClose = { dismiss() },
+                            )
+                        }
+                    }
+                },
+            )
+
+            setOnDismissListener {
+                if (continuation.isActive) {
+                    continuation.resume(Unit)
+                }
+            }
+            show()
+            continuation.invokeOnCancellation { dismiss() }
+        }
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -13,7 +13,6 @@ import android.net.Uri
 import android.os.PowerManager
 import android.provider.Settings
 import android.provider.Settings.System.ACCELEROMETER_ROTATION
-import androidx.appcompat.app.AlertDialog
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.getSystemService
 import com.google.android.material.snackbar.Snackbar
@@ -23,8 +22,9 @@ import org.jellyfin.mobile.MainActivity
 import org.jellyfin.mobile.R
 import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.mobile.downloads.DownloadManager
-import org.jellyfin.mobile.downloads.DownloadMethod
 import org.jellyfin.mobile.settings.ExternalPlayerPackage
+import org.jellyfin.mobile.ui.utils.shouldShowDownloadSettingsDialog
+import org.jellyfin.mobile.ui.utils.showDownloadSettingsDialog
 import org.jellyfin.mobile.webapp.WebViewFragment
 import org.jellyfin.sdk.model.serializer.toUUID
 import org.koin.android.ext.android.get
@@ -63,7 +63,17 @@ suspend fun MainActivity.requestDownload(itemIds: Collection<UUID>) {
     val appPreferences: AppPreferences = get()
     val downloadManager: DownloadManager = get()
 
-    val permissionResult: Boolean = suspendCancellableCoroutine { continuation ->
+    // Show dialog to choose download location for first download
+    if (shouldShowDownloadSettingsDialog()) {
+        showDownloadSettingsDialog()
+    }
+
+    // If no storage location is set the request for choosing a download folder
+    // so we'll cancel the download too
+    if (appPreferences.storageLocation == null) return
+
+    // Request permissions to send notifications about download progress
+    suspendCancellableCoroutine { continuation ->
         requestPermission("android.permission.POST_NOTIFICATIONS") { permissionsMap ->
             if (permissionsMap[Manifest.permission.POST_NOTIFICATIONS] == PackageManager.PERMISSION_GRANTED) {
                 continuation.resume(true)
@@ -73,42 +83,10 @@ suspend fun MainActivity.requestDownload(itemIds: Collection<UUID>) {
         }
     }
 
-    // First time download, ask for network constraint preference
-    if (appPreferences.downloadMethod == null) {
-        suspendCancellableCoroutine { continuation ->
-            AlertDialog.Builder(this)
-                .setTitle(R.string.network_title)
-                .setMessage(R.string.network_message)
-                .setPositiveButton(R.string.wifi_only) { _, _ ->
-                    val selectedDownloadMethod = DownloadMethod.WIFI_ONLY
-                    appPreferences.downloadMethod = selectedDownloadMethod
-                    continuation.resume(selectedDownloadMethod)
-                }
-                .setNegativeButton(R.string.mobile_data) { _, _ ->
-                    val selectedDownloadMethod = DownloadMethod.MOBILE_DATA
-                    appPreferences.downloadMethod = selectedDownloadMethod
-                    continuation.resume(selectedDownloadMethod)
-                }
-                .setNeutralButton(R.string.mobile_data_and_roaming) { _, _ ->
-                    val selectedDownloadMethod = DownloadMethod.MOBILE_AND_ROAMING
-                    appPreferences.downloadMethod = selectedDownloadMethod
-                    continuation.resume(selectedDownloadMethod)
-                }
-                .setOnDismissListener {
-                    continuation.cancel(null)
-                }
-                .setCancelable(false)
-                .show()
-        }
-    }
-
-    // Automatically use a default download location
-    if (appPreferences.storageLocation == null) {
-
-    }
-
+    // Add actual download
     val server = mainViewModel.serverState.value.server ?: return
     val user = mainViewModel.userState.value.user ?: return
+
     downloadManager.enqueueItems(server, user, itemIds)
 }
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -102,11 +102,14 @@ suspend fun MainActivity.requestDownload(itemIds: Collection<UUID>) {
         }
     }
 
-    if (permissionResult) {
-        val server = mainViewModel.serverState.value.server ?: return
-        val user = mainViewModel.userState.value.user ?: return
-        downloadManager.enqueueItems(server, user, itemIds)
+    // Automatically use a default download location
+    if (appPreferences.storageLocation == null) {
+
     }
+
+    val server = mainViewModel.serverState.value.server ?: return
+    val user = mainViewModel.userState.value.user ?: return
+    downloadManager.enqueueItems(server, user, itemIds)
 }
 
 fun Activity.isAutoRotateOn() = Settings.System.getInt(contentResolver, ACCELEROMETER_ROTATION, 0) == 1

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,4 +160,7 @@
     <string name="download_remove_keep_local">Keep local file(s)</string>
     <string name="download_remove_description">Do you want to remove "%1$s" from your downloads?</string>
     <string name="download_incomplete">Download incomplete</string>
+    <string name="download_settings_dialog_title">Choose download location</string>
+    <string name="download_settings_dialog_message">Please choose where downloaded media should be saved. Downloads use WiFi only by default.</string>
+    <string name="select_folder">Select folder</string>
 </resources>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

We cannot use a default download folder when using the storage access framework because Android does not have any API's for that. Instead, when the user has not configured any folder yet we'll show a popup when they attempt to download something to ask for a folder to be configured.

Additional changes:
- Default to wifi-only downloads, don't ask user for their preference on first download anymore
- Remove storage read/write permissions as we no longer need those for SAF
- Fix download code failing when no folder configured - now just waits until one is
  - This situation can happen when storage access is revoked from the system settings

**Screenshots**

<img width="452" height="339" src="https://github.com/user-attachments/assets/11b1ea52-5e71-4cae-acf2-4463ee92d389" />

<!-- Describe your changes here in 1-5 sentences. -->

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
