### PR TITLE
Reduce API calls when starting playback on Android Auto

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryMediaId.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/LibraryMediaId.kt
@@ -12,10 +12,7 @@ import java.util.UUID
 sealed interface LibraryMediaId {
     @Serializable
     @SerialName("item")
-    data class Item(
-        val itemId: UUID,
-        val route: LibraryRoute,
-    ) : LibraryMediaId
+    data class Item(val itemId: UUID, val route: LibraryRoute) : LibraryMediaId
 
     @Serializable
     @SerialName("route")

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
@@ -54,6 +54,7 @@ class SessionBrowserCallback(
 ) : MediaLibrarySession.Callback {
     companion object {
         const val MAX_PAGE_SIZE = 250
+        const val MEDIA_ITEM_EXTRA_START_POSITION = "start_position"
     }
 
     val pages = listOf(
@@ -100,6 +101,9 @@ class SessionBrowserCallback(
             setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Route(action.route)))
         } else if (action is LibraryItemAction.Play) {
             setMediaId(Json.encodeToString<LibraryMediaId>(LibraryMediaId.Item(action.item.id, route)))
+            action.item.userData?.playbackPositionTicks?.ticks?.inWholeMilliseconds?.let {
+                extras.putLong(MEDIA_ITEM_EXTRA_START_POSITION, it)
+            }
         }
 
         setMediaMetadata(
@@ -375,17 +379,17 @@ class SessionBrowserCallback(
             }
         }
 
-        var resumePositionMs = startPositionMs
-        val currentLibraryMediaId = expandedItems.getOrNull(newStartIndex)?.mediaId?.let {
-            runCatching { Json.decodeFromString<LibraryMediaId>(it) }.getOrNull()
-        }
-        if (currentLibraryMediaId is LibraryMediaId.Item && (startPositionMs == 0L || startPositionMs == C.TIME_UNSET)) {
-            val item by api.userLibraryApi.getItem(itemId = currentLibraryMediaId.itemId)
-            val positionMs = item.userData?.playbackPositionTicks?.ticks?.inWholeMilliseconds ?: 0L
-            if (positionMs > 0L) resumePositionMs = positionMs
+        // Use the server-side stored position if there is no requested start position
+        val newStartPositionMs = when (startPositionMs) {
+            0L, C.TIME_UNSET -> expandedItems.firstOrNull()?.mediaMetadata?.extras?.getLong(
+                MEDIA_ITEM_EXTRA_START_POSITION,
+                startPositionMs
+            ) ?: startPositionMs
+
+            else -> startPositionMs
         }
 
         expandedItems = onAddMediaItems(mediaSession, controller, expandedItems).await()
-        MediaSession.MediaItemsWithStartPosition(expandedItems, newStartIndex, resumePositionMs)
+        MediaSession.MediaItemsWithStartPosition(expandedItems, newStartIndex, newStartPositionMs)
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Followup to #2017 as the author did not allow me to push to their branch.

- Undo formatting changes to LibraryMediaId
- Avoid API call when playing Android Auto media items by storing the start position within media item metadata

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
