### PR TITLE
Play downloaded audio in external app

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadsViewModel.kt
@@ -34,9 +34,7 @@ class DownloadsViewModel : ViewModel(), KoinComponent {
 
     fun openDownload(download: DownloadEntity) {
         when (download.item.mediaType) {
-            MediaType.VIDEO,
-            MediaType.AUDIO,
-            -> {
+            MediaType.VIDEO -> {
                 val playOptions = PlayOptions(
                     ids = listOf(download.itemId),
                     mediaSourceId = download.itemId.toString(),
@@ -49,12 +47,12 @@ class DownloadsViewModel : ViewModel(), KoinComponent {
                 activityEventHandler.emit(ActivityEvent.LaunchNativePlayer(playOptions))
             }
 
+            MediaType.AUDIO,
             MediaType.PHOTO,
             MediaType.BOOK,
-            MediaType.UNKNOWN,
-            -> {
+            MediaType.UNKNOWN -> {
                 viewModelScope.launch {
-                    val fileUri = withContext(Dispatchers.IO) {
+                    withContext(Dispatchers.IO) {
                         val storageLocation = storageManager.getStorageLocation()
                         val itemLocation = storageLocation?.findFile(download.path)
                         if (itemLocation != null && itemLocation.isDirectory) {
@@ -63,8 +61,9 @@ class DownloadsViewModel : ViewModel(), KoinComponent {
                         } else {
                             null
                         }
+                    }?.let {
+                        activityEventHandler.emit(ActivityEvent.OpenUrl(it.toString(), true))
                     }
-                    fileUri?.let { activityEventHandler.emit(ActivityEvent.OpenUrl(it.toString(), true)) }
                 }
             }
         }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Although our video player can play audio-only items, the experience isn't great. It will still auto-hide controls and for items without any embedded cover art that would result in a black screen.

Use external apps for audio playback for now, we can change this back when we have better audio playback capabilities.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
