### PR TITLE
Fix external subtitle selection

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/TrackSelectionHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/TrackSelectionHelper.kt
@@ -153,7 +153,11 @@ class TrackSelectionHelper(
             SubtitleDeliveryMethod.EXTERNAL -> {
                 // For external subtitles, we can simply match the ID that we set when creating the player media source.
                 for (group in player.currentTracks.groups) {
-                    if (group.getTrackFormat(0).id == "${ExternalSubtitleStream.ID_PREFIX}${subtitleStream.index}") {
+                    val formatId = group.getTrackFormat(0).id ?: continue
+                    val originalFormatPrefixIndex = formatId.indexOf(ExternalSubtitleStream.ID_PREFIX)
+                    if (originalFormatPrefixIndex < 0) continue
+                    val originalFormatId = formatId.substring(originalFormatPrefixIndex)
+                    if (originalFormatId == "${ExternalSubtitleStream.ID_PREFIX}${subtitleStream.index}") {
                         return trackSelector.selectTrackByTypeAndGroup(C.TRACK_TYPE_TEXT, group.mediaTrackGroup)
                     }
                 }


### PR DESCRIPTION
**Changes**
A recent (?) AndroidX Media3 update caused MergingMediaPeriod to prepend the period ID to the track format's id, breaking the actual track selection. Only matching the substring fixes selecting external subtitles.

**Code assistance**
None.