### PR TITLE
(re-)Set ALLOW_CAPTURE_BY_ALL after Chromium loads

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/utils/AudioCapturePolicy.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/AudioCapturePolicy.kt
@@ -1,0 +1,13 @@
+package org.jellyfin.mobile.utils
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioManager
+
+fun Context.allowPlaybackCaptureByAll() {
+    if (AndroidVersion.isAtLeastQ) {
+        getSystemService(AudioManager::class.java)
+            .allowedCapturePolicy = AudioAttributes.ALLOW_CAPTURE_BY_ALL
+    }
+}
+

--- a/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
@@ -37,6 +37,7 @@ import org.jellyfin.mobile.utils.AndroidVersion
 import org.jellyfin.mobile.utils.BackPressInterceptor
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.Constants.FRAGMENT_WEB_VIEW_EXTRA_SERVER
+import org.jellyfin.mobile.utils.allowPlaybackCaptureByAll
 import org.jellyfin.mobile.utils.applyDefault
 import org.jellyfin.mobile.utils.applyWindowInsetsAsMargins
 import org.jellyfin.mobile.utils.dip
@@ -191,6 +192,10 @@ class WebViewFragment : Fragment(), BackPressInterceptor, JellyfinWebChromeClien
         addJavascriptInterface(mediaSegments, "MediaSegments")
 
         loadUrl(server.hostname)
+
+        // WebView/Chromium resets the app playback capture policy during loadUrl().
+        post { requireContext().allowPlaybackCaptureByAll() }
+
         postDelayed(timeoutRunnable, Constants.INITIAL_CONNECTION_TIMEOUT)
         postDelayed(showLoadingContainerRunnable, Constants.SHOW_PROGRESS_BAR_DELAY)
     }


### PR DESCRIPTION
**Changes**

This fixes WebView playback capture for apps that use Android audio playback capture.
Jellyfin already opts into playback capture, but WebView.loadUrl(...) appears to reset the app-wide capture policy back to `ALLOW_CAPTURE_BY_SYSTEM`. Reapplying `ALLOW_CAPTURE_BY_ALL` on the next UI loop keeps WebView-created audio tracks capturable, matching the existing local playback capture policy.

**Code assistance**
I used codex to help me get to the bottom of the problem and provide the minimal fix. 

**Issues**
N/A but happy to create an issue if required.

**Notes**
I have successfully tested the change on my phone (Samsung S20FE).