### PR TITLE
Integrated player: inhibit brightness control for external displays

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -208,6 +208,9 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
         // Disable controller animations
         playerView.setControllerAnimationEnabled(false)
 
+        // Prevent the ripple foreground from brightening the video on cursor hover.
+        playerView.setOnHoverListener { _, _ -> true }
+
         playerLockScreenHelper = PlayerLockScreenHelper(this, playerBinding, orientationListener)
         playerGestureHelper = PlayerGestureHelper(this, playerBinding, playerLockScreenHelper)
 

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
@@ -310,6 +310,11 @@ class PlayerGestureHelper(
                     gestureIndicatorOverlayProgress.progress = toSet
                 } else {
                     // Swiping on the left, change brightness
+                    // Except when in desktop mode, when it causes issues.
+                    val uiMode = fragment.requireActivity().resources.configuration.uiMode
+                    if ((uiMode and Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_DESK) {
+                        return false
+                    }
 
                     val window = fragment.requireActivity().window
                     val brightnessRange = BRIGHTNESS_OVERRIDE_OFF..BRIGHTNESS_OVERRIDE_FULL

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -12,7 +12,8 @@
         android:layout_height="match_parent"
         android:foreground="@drawable/ripple_background"
         app:pause_icon="@drawable/ic_pause_black_42dp"
-        app:play_icon="@drawable/ic_play_black_42dp" />
+        app:play_icon="@drawable/ic_play_black_42dp"
+        app:surface_type="texture_view" />
 
     <FrameLayout
         android:id="@+id/player_overlay"


### PR DESCRIPTION
This prevents unwanted brightness setting when using external displays (Android Desktop mode)  - which produces unwanted effects.

**Changes**
Had to use texture_view surface type to get hover listener to work.

**Code assistance**
no

**Issues**
This resolves the second issue described in https://github.com/jellyfin/jellyfin-android/issues/2040  - the first was about web player permanently disabling mouse.  The second about Integrated player.