### PR TITLE
Fix media session crash when playing audio

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayerNotificationHelper.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
 import coil3.ImageLoader
 import coil3.request.ImageRequest
+import coil3.request.allowHardware
 import coil3.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -162,7 +163,10 @@ class PlayerNotificationHelper(private val viewModel: PlayerViewModel) : KoinCom
                 tag = mediaSource.item?.imageTags?.get(ImageType.PRIMARY),
             )
 
-            val imageRequest = ImageRequest.Builder(context).data(imageUrl).build()
+            val imageRequest = ImageRequest.Builder(context)
+                .data(imageUrl)
+                .allowHardware(false)
+                .build()
             imageLoader.execute(imageRequest).image?.toBitmap()
         }
     }

--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -30,6 +30,7 @@ import androidx.core.content.getSystemService
 import androidx.core.text.HtmlCompat
 import coil3.ImageLoader
 import coil3.request.ImageRequest
+import coil3.request.allowHardware
 import coil3.toBitmap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -224,7 +225,10 @@ class RemotePlayerService : Service(), CoroutineScope {
             // Resolve notification bitmap
             val cachedBitmap = largeItemIcon?.takeIf { itemId == currentItemId }
             val bitmap = cachedBitmap ?: if (!imageUrl.isNullOrEmpty()) {
-                val request = ImageRequest.Builder(this@RemotePlayerService).data(imageUrl).build()
+                val request = ImageRequest.Builder(this@RemotePlayerService)
+                    .data(imageUrl)
+                    .allowHardware(false)
+                    .build()
                 imageLoader.execute(request).image?.toBitmap()?.also { bitmap ->
                     largeItemIcon = bitmap // Cache bitmap for later use
                 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

I can't find anything about this in the Android 17 changelog but starting with that release the music notification will crash the app due to the use of hardware bitmaps. Fortunately the fix was easy.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #2044