### PR TITLE
Fix crash when double tapping connect button

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/ui/screens/connect/ServerSelection.kt
+++ b/app/src/main/java/org/jellyfin/mobile/ui/screens/connect/ServerSelection.kt
@@ -110,6 +110,8 @@ fun ServerSelection(
     }
 
     fun onSubmit() {
+        if (checkUrlState == CheckUrlState.Pending) return
+
         externalError = false
         checkUrlState = CheckUrlState.Pending
         coroutineScope.launch {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

It is possible to call the `onSubmit` fun twice which can cause the `onConnected` callback to be called twice, which then in turn causes two duplicate servers to be added to the database. Because of the UNIQUE constraint this fails and crashes the app.

Check if we're already pending before running the connection logic to avoid this.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
