### PR TITLE
fix: IllegalArgumentException when setting album art on media notification

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -223,13 +223,8 @@ class RemotePlayerService : Service(), CoroutineScope {
 
             // Resolve notification bitmap
             val cachedBitmap = largeItemIcon?.takeIf { itemId == currentItemId }
-            val bitmap = cachedBitmap ?: if (!imageUrl.isNullOrEmpty()) {
-                val request = ImageRequest.Builder(this@RemotePlayerService).data(imageUrl).build()
-                imageLoader.execute(request).image?.toBitmap()?.also { bitmap ->
-                    largeItemIcon = bitmap // Cache bitmap for later use
-                }
-            } else {
-                null
+            val bitmap = cachedBitmap ?: imageUrl?.let { url ->
+                loadNotificationBitmap(url)?.also { largeItemIcon = it }
             }
 
             // Set/update media metadata if item changed
@@ -367,6 +362,16 @@ class RemotePlayerService : Service(), CoroutineScope {
 
             // Activate MediaSession
             mediaSession.isActive = true
+        }
+    }
+
+    private suspend fun loadNotificationBitmap(imageUrl: String): Bitmap? {
+        val request = ImageRequest.Builder(this).data(imageUrl).build()
+        val loadedBitmap = imageLoader.execute(request).image?.toBitmap() ?: return null
+        return if (loadedBitmap.config == Bitmap.Config.HARDWARE) {
+            loadedBitmap.copy(Bitmap.Config.ARGB_8888, false)
+        } else {
+            loadedBitmap
         }
     }
 


### PR DESCRIPTION
MediaMetadata.Builder.putBitmap() throws IllegalArgumentException: software rendering doesn't support hardware bitmaps when the bitmap passed to it is backed by GPU memory
  (Bitmap.Config.HARDWARE).

```
type: crash
osVersion: google/tegu/tegu:17/CP2A.260605.012/2026062301:user/release-keys
package: org.jellyfin.mobile:2060499, targetSdk 34
process: org.jellyfin.mobile
processUptime: 14611 + 531 ms
installer: org.fdroid.fdroid

java.lang.IllegalArgumentException: Software rendering doesn't support hardware bitmaps
 at android.graphics.BaseCanvas.throwIfHwBitmapInSwMode(BaseCanvas.java:732)
 at android.graphics.BaseCanvas.throwIfCannotDraw(BaseCanvas.java:82)
 at android.graphics.BaseCanvas.drawBitmap(BaseCanvas.java:166)
 at android.graphics.Canvas.drawBitmap(Canvas.java:1640)
 at android.graphics.Bitmap.createScaledAshmemBitmap(Bitmap.java:989)
 at android.media.MediaMetadata$Builder.scaleBitmap(MediaMetadata.java:1023)
 at android.media.MediaMetadata$Builder.build(MediaMetadata.java:1002)
 at android.media.session.MediaSession.setMetadata(MediaSession.java:613)
 at org.jellyfin.mobile.webapp.RemotePlayerService$notify$1.invokeSuspend(SourceFile:359)
 at U4.a.resumeWith(SourceFile:9)
 at s5.p.o(SourceFile:7)
 at n5.a.resumeWith(SourceFile:23)
 at U4.a.resumeWith(SourceFile:32)
 at n5.M.run(SourceFile:107)
 at android.os.Handler.handleCallback(Handler.java:1095)
 at android.os.Handler.dispatchMessageImpl(Handler.java:135)
 at android.os.Handler.dispatchMessage(Handler.java:125)
 at android.os.Looper.loopOnce(Looper.java:296)
 at android.os.Looper.loop(Looper.java:397)
 at android.app.ActivityThread.main(ActivityThread.java:9568)
 at java.lang.reflect.Method.invoke(Native Method)
 at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:575)
 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:847)
 Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [s0{Cancelling}@b416e89, Dispatchers.Main]
```

**Changes**
Added loadNotificationBitmap() helper, copying hardware bitmaps to Bitmap.Config.ARGB_8888

**Code assistance**
- generated loadNotificationBitmap and figure out the root cause of problem
- helped to setup android sdk)
