### PR TITLE
Fix PiP behavior

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -100,7 +100,10 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
         // Observe ViewModel
         viewModel.player.observe(this) { player ->
             playerView.player = player
-            if (player == null) parentFragmentManager.popBackStack()
+            // Automatically close fragment, unless we're in PiP mode
+            if (player == null && !(AndroidVersion.isAtLeastN && requireActivity().isInPictureInPictureMode)) {
+                parentFragmentManager.popBackStack()
+            }
         }
         viewModel.playerState.observe(this) { playerState ->
             val isPlaying = viewModel.playerOrNull?.isPlaying == true
@@ -228,6 +231,11 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
         // When returning from another app, fullscreen mode for landscape orientation has to be set again
         if (isLandscape()) {
             playerFullscreenHelper.enableFullscreen()
+        }
+
+        // If playback ended during picture in picture we'll return to the main app when PiP is closed
+        if (viewModel.playerOrNull == null) {
+            parentFragmentManager.popBackStack()
         }
     }
 
@@ -359,7 +367,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     }
 
     fun onUserLeaveHint() {
-        if (AndroidVersion.isAtLeastN && viewModel.playerOrNull?.isPlaying == true) {
+        if (AndroidVersion.isAtLeastN && viewModel.playerOrNull != null) {
             requireActivity().enterPictureInPicture()
         }
     }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

- Only navigate back when playback ends if not in PiP mode
  - This avoids the normal app being rendered in the PiP window (e.g. downloads screen or webview)
- Navigate back when player is released in resume
  - This way when PiP is made fullscreen again we still go back as expected
- Activate PiP when player exists, no matter what the play/pause state is
  - This fixes issues where buffering video won't activate PiP

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
