### PR TITLE
Add preferred audio transcoding codec setting

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
@@ -8,6 +8,7 @@ import org.jellyfin.mobile.downloads.DownloadMethod
 import org.jellyfin.mobile.player.mediasegments.MediaSegmentAction
 import org.jellyfin.mobile.player.mediasegments.toMediaSegmentActionsString
 import org.jellyfin.mobile.settings.ExternalPlayerPackage
+import org.jellyfin.mobile.settings.PreferredAudioCodec
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.api.MediaSegmentType
@@ -127,6 +128,10 @@ class AppPreferences(context: Context) {
 
     val exoPlayerNetworkBuffer: String
         get() = sharedPreferences.getString(Constants.PREF_EXOPLAYER_NETWORK_BUFFER, Constants.NETWORK_BUFFER_AUTO)!!
+
+    @PreferredAudioCodec
+    val exoPlayerPreferredAudioCodec: String
+        get() = sharedPreferences.getString(Constants.PREF_EXOPLAYER_PREFERRED_AUDIO_CODEC, PreferredAudioCodec.AUTO)!!
 
     @ExternalPlayerPackage
     var externalPlayerApp: String

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -3,6 +3,7 @@ package org.jellyfin.mobile.player.deviceprofile
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import org.jellyfin.mobile.app.AppPreferences
+import org.jellyfin.mobile.settings.PreferredAudioCodec
 import org.jellyfin.mobile.utils.Constants
 import org.json.JSONObject
 import org.jellyfin.sdk.model.api.CodecProfile
@@ -26,8 +27,6 @@ class DeviceProfileBuilder(
     private val supportedAudioCodecs: Array<Array<String>>
     private val videoCodecsProfiles: Map<String, Set<String>>
     private val maxAvcRawLevel: Int
-
-    private val transcodingProfiles: List<TranscodingProfile>
 
     init {
         require(
@@ -85,34 +84,48 @@ class DeviceProfileBuilder(
             }.toTypedArray()
         }
         videoCodecsProfiles = videoCodecs.entries.associate { (k, v) -> k to v.profiles }
-
-        transcodingProfiles = listOf(
-            TranscodingProfile(
-                type = DlnaProfileType.VIDEO,
-                container = "ts",
-                videoCodec = "h264",
-                audioCodec = "mp1,mp2,mp3,aac,ac3,eac3,dts,mlp,truehd",
-                protocol = MediaStreamProtocol.HLS,
-                conditions = emptyList(),
-            ),
-            TranscodingProfile(
-                type = DlnaProfileType.VIDEO,
-                container = "mkv",
-                videoCodec = "h264",
-                audioCodec = AVAILABLE_AUDIO_CODECS[SUPPORTED_CONTAINER_FORMATS.indexOf("mkv")].joinToString(","),
-                protocol = MediaStreamProtocol.HLS,
-                conditions = emptyList(),
-            ),
-            TranscodingProfile(
-                type = DlnaProfileType.AUDIO,
-                container = "mp3",
-                videoCodec = "",
-                audioCodec = "mp3",
-                protocol = MediaStreamProtocol.HTTP,
-                conditions = emptyList(),
-            ),
-        )
     }
+
+    /**
+     * Reorder a comma-separated codec priority list so the user's preferred audio codec comes first.
+     * Returns the list unchanged for [PreferredAudioCodec.AUTO] or if the preferred codec isn't in the list.
+     */
+    private fun applyPreferredAudioCodec(codecs: String): String {
+        val preferred = appPreferences.exoPlayerPreferredAudioCodec
+        if (preferred == PreferredAudioCodec.AUTO) return codecs
+        val list = codecs.split(',').map(String::trim).filter(String::isNotEmpty)
+        if (preferred !in list) return codecs
+        return (listOf(preferred) + list.filter { it != preferred }).joinToString(",")
+    }
+
+    private fun buildTranscodingProfiles(): List<TranscodingProfile> = listOf(
+        TranscodingProfile(
+            type = DlnaProfileType.VIDEO,
+            container = "ts",
+            videoCodec = "h264",
+            audioCodec = applyPreferredAudioCodec("mp1,mp2,mp3,aac,ac3,eac3,dts,mlp,truehd"),
+            protocol = MediaStreamProtocol.HLS,
+            conditions = emptyList(),
+        ),
+        TranscodingProfile(
+            type = DlnaProfileType.VIDEO,
+            container = "mkv",
+            videoCodec = "h264",
+            audioCodec = applyPreferredAudioCodec(
+                AVAILABLE_AUDIO_CODECS[SUPPORTED_CONTAINER_FORMATS.indexOf("mkv")].joinToString(","),
+            ),
+            protocol = MediaStreamProtocol.HLS,
+            conditions = emptyList(),
+        ),
+        TranscodingProfile(
+            type = DlnaProfileType.AUDIO,
+            container = "mp3",
+            videoCodec = "",
+            audioCodec = "mp3",
+            protocol = MediaStreamProtocol.HTTP,
+            conditions = emptyList(),
+        ),
+    )
 
     fun getDeviceProfile(): DeviceProfile {
         val containerProfiles = ArrayList<ContainerProfile>()
@@ -161,7 +174,7 @@ class DeviceProfileBuilder(
         return DeviceProfile(
             name = Constants.APP_INFO_NAME,
             directPlayProfiles = directPlayProfiles,
-            transcodingProfiles = transcodingProfiles,
+            transcodingProfiles = buildTranscodingProfiles(),
             containerProfiles = containerProfiles,
             codecProfiles = codecProfiles,
             subtitleProfiles = subtitleProfiles,

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -47,7 +47,6 @@ class QueueManager(
     private val mediaSourceResolver: MediaSourceResolver by inject()
     private val deviceProfileBuilder: DeviceProfileBuilder by inject()
     private val downloadDao: DownloadDao by inject()
-    private val deviceProfile = deviceProfileBuilder.getDeviceProfile()
 
     private var currentQueue: List<UUID> = emptyList()
     private var currentQueueIndex: Int = 0
@@ -154,7 +153,7 @@ class QueueManager(
         mediaSourceResolver.resolveMediaSource(
             itemId = itemId,
             mediaSourceId = mediaSourceId,
-            deviceProfile = deviceProfile,
+            deviceProfile = deviceProfileBuilder.getDeviceProfile(),
             maxStreamingBitrate = maxStreamingBitrate,
             startTime = startTime,
             audioStreamIndex = audioStreamIndex,

--- a/app/src/main/java/org/jellyfin/mobile/settings/PreferredAudioCodec.java
+++ b/app/src/main/java/org/jellyfin/mobile/settings/PreferredAudioCodec.java
@@ -1,0 +1,17 @@
+package org.jellyfin.mobile.settings;
+
+
+import androidx.annotation.StringDef;
+
+@StringDef({
+    PreferredAudioCodec.AUTO,
+    PreferredAudioCodec.AAC,
+    PreferredAudioCodec.AC3,
+    PreferredAudioCodec.MP3
+})
+public @interface PreferredAudioCodec {
+    String AUTO = "auto";
+    String AAC = "aac";
+    String AC3 = "ac3";
+    String MP3 = "mp3";
+}

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -61,6 +61,7 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
     private lateinit var horizontalGesturePreference: Preference
     private lateinit var directPlayAssPreference: Preference
     private lateinit var networkBufferPreference: Preference
+    private lateinit var preferredAudioCodecPreference: Preference
     private lateinit var externalPlayerChoicePreference: Preference
     private lateinit var downloadLocationPreference: Preference
 
@@ -129,6 +130,7 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
                 horizontalGesturePreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 directPlayAssPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 networkBufferPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
+                preferredAudioCodecPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 externalPlayerChoicePreference.enabled = selection == VideoPlayerType.EXTERNAL_PLAYER
             }
         }
@@ -193,6 +195,18 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
         networkBufferPreference = singleChoice(Constants.PREF_EXOPLAYER_NETWORK_BUFFER, networkBufferOptions) {
             titleRes = R.string.pref_exoplayer_network_buffer
             initialSelection = Constants.NETWORK_BUFFER_AUTO
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
+        }
+        val audioCodecOptions = listOf(
+            SelectionItem(PreferredAudioCodec.AUTO, R.string.audio_codec_auto, R.string.audio_codec_auto_description),
+            SelectionItem(PreferredAudioCodec.AAC, R.string.audio_codec_aac, R.string.audio_codec_aac_description),
+            SelectionItem(PreferredAudioCodec.AC3, R.string.audio_codec_ac3, R.string.audio_codec_ac3_description),
+            SelectionItem(PreferredAudioCodec.MP3, R.string.audio_codec_mp3, R.string.audio_codec_mp3_description),
+        )
+        preferredAudioCodecPreference = singleChoice(Constants.PREF_EXOPLAYER_PREFERRED_AUDIO_CODEC, audioCodecOptions) {
+            titleRes = R.string.pref_exoplayer_preferred_audio_codec_title
+            summaryRes = R.string.pref_exoplayer_preferred_audio_codec_summary
+            initialSelection = PreferredAudioCodec.AUTO
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
         }
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -44,6 +44,7 @@ object Constants {
     const val NETWORK_BUFFER_AUTO = "auto"
     const val NETWORK_BUFFER_LARGE = "large"
     const val NETWORK_BUFFER_EXTRA_LARGE = "extra_large"
+    const val PREF_EXOPLAYER_PREFERRED_AUDIO_CODEC = "pref_exoplayer_preferred_audio_codec"
     const val PREF_EXTERNAL_PLAYER_APP = "pref_external_player_app"
     const val PREF_SUBTITLE_STYLE = "pref_subtitle_style"
     const val PREF_STORAGE_LOCATION = "pref_storage_location"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,16 @@
     <string name="network_buffer_large_description">Larger buffer, may help on moderate or variable connections</string>
     <string name="network_buffer_extra_large">Extra large</string>
     <string name="network_buffer_extra_large_description">Maximum buffer, intended for slow or satellite connections</string>
+    <string name="pref_exoplayer_preferred_audio_codec_title">Preferred audio codec</string>
+    <string name="pref_exoplayer_preferred_audio_codec_summary">Codec to request when the audio track needs transcoding</string>
+    <string name="audio_codec_auto">Automatic</string>
+    <string name="audio_codec_auto_description">Let the server decide (default)</string>
+    <string name="audio_codec_aac">AAC</string>
+    <string name="audio_codec_aac_description">Best quality and compatibility for mobile</string>
+    <string name="audio_codec_ac3">AC3 (Dolby Digital)</string>
+    <string name="audio_codec_ac3_description">For receivers/devices that prefer AC3</string>
+    <string name="audio_codec_mp3">MP3</string>
+    <string name="audio_codec_mp3_description">Maximum compatibility, lower quality</string>
 
     <string name="external_player_app">External player app</string>
     <string name="external_player_mpv">MPV Player</string>


### PR DESCRIPTION
**Changes**

Adds a 'Preferred audio codec' setting (Automatic/AAC/AC3/MP3) for the integrated player. The chosen codec is moved to the front of the HLS/ts and mkv transcoding profiles, so the server transcodes audio to it. 'Automatic' keeps the original codec order (unchanged behaviour). The device profile is built fresh per playback, so the setting applies without an app restart.

**Motivation**

When the audio track needs transcoding, the server always picks MP3, because it is the first supported codec in the hardcoded profile list (`mp1,mp2,mp3,aac,...`). AAC would offer better quality/compatibility on mobile, but is never chosen. This makes the codec user-configurable instead of reordering the list for everyone.

**Testing**

Feature-tested end-to-end on a v2.6.4-based build against Jellyfin 10.11 (sessions report `aac` after selecting AAC). This port to master compiles and passes detekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)