### PR TITLE
Add maximum transcode resolution setting

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
@@ -8,6 +8,7 @@ import org.jellyfin.mobile.downloads.DownloadMethod
 import org.jellyfin.mobile.player.mediasegments.MediaSegmentAction
 import org.jellyfin.mobile.player.mediasegments.toMediaSegmentActionsString
 import org.jellyfin.mobile.settings.ExternalPlayerPackage
+import org.jellyfin.mobile.settings.MaxTranscodeResolution
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.sdk.model.api.MediaSegmentType
@@ -127,6 +128,10 @@ class AppPreferences(context: Context) {
 
     val exoPlayerNetworkBuffer: String
         get() = sharedPreferences.getString(Constants.PREF_EXOPLAYER_NETWORK_BUFFER, Constants.NETWORK_BUFFER_AUTO)!!
+
+    @MaxTranscodeResolution
+    val exoPlayerMaxTranscodeResolution: String
+        get() = sharedPreferences.getString(Constants.PREF_EXOPLAYER_MAX_TRANSCODE_RESOLUTION, MaxTranscodeResolution.AUTO)!!
 
     @ExternalPlayerPackage
     var externalPlayerApp: String

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -3,6 +3,7 @@ package org.jellyfin.mobile.player.deviceprofile
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import org.jellyfin.mobile.app.AppPreferences
+import org.jellyfin.mobile.settings.MaxTranscodeResolution
 import org.jellyfin.mobile.utils.Constants
 import org.json.JSONObject
 import org.jellyfin.sdk.model.api.CodecProfile
@@ -114,10 +115,29 @@ class DeviceProfileBuilder(
         )
     }
 
+    /**
+     * Build a height cap condition from the user's maximum transcode resolution setting.
+     * Applied to the video transcoding profiles only, so it caps the transcode output
+     * without making high-resolution sources ineligible for direct play.
+     */
+    private fun buildMaxResolutionConditions(): List<ProfileCondition> {
+        val maxResolution = appPreferences.exoPlayerMaxTranscodeResolution
+        if (maxResolution == MaxTranscodeResolution.AUTO) return emptyList()
+        return listOf(
+            ProfileCondition(
+                condition = ProfileConditionType.LESS_THAN_EQUAL,
+                property = ProfileConditionValue.HEIGHT,
+                value = maxResolution,
+                isRequired = false,
+            ),
+        )
+    }
+
     fun getDeviceProfile(): DeviceProfile {
         val containerProfiles = ArrayList<ContainerProfile>()
         val directPlayProfiles = ArrayList<DirectPlayProfile>()
         val codecProfiles = ArrayList<CodecProfile>()
+        val maxResolutionConditions = buildMaxResolutionConditions()
 
         for (i in SUPPORTED_CONTAINER_FORMATS.indices) {
             val container = SUPPORTED_CONTAINER_FORMATS[i]
@@ -161,7 +181,15 @@ class DeviceProfileBuilder(
         return DeviceProfile(
             name = Constants.APP_INFO_NAME,
             directPlayProfiles = directPlayProfiles,
-            transcodingProfiles = transcodingProfiles,
+            transcodingProfiles = when {
+                maxResolutionConditions.isEmpty() -> transcodingProfiles
+                else -> transcodingProfiles.map { profile ->
+                    when (profile.type) {
+                        DlnaProfileType.VIDEO -> profile.copy(conditions = maxResolutionConditions)
+                        else -> profile
+                    }
+                }
+            },
             containerProfiles = containerProfiles,
             codecProfiles = codecProfiles,
             subtitleProfiles = subtitleProfiles,

--- a/app/src/main/java/org/jellyfin/mobile/settings/MaxTranscodeResolution.java
+++ b/app/src/main/java/org/jellyfin/mobile/settings/MaxTranscodeResolution.java
@@ -1,0 +1,17 @@
+package org.jellyfin.mobile.settings;
+
+
+import androidx.annotation.StringDef;
+
+@StringDef({
+    MaxTranscodeResolution.AUTO,
+    MaxTranscodeResolution.P1080,
+    MaxTranscodeResolution.P720,
+    MaxTranscodeResolution.P480
+})
+public @interface MaxTranscodeResolution {
+    String AUTO = "auto";
+    String P1080 = "1080";
+    String P720 = "720";
+    String P480 = "480";
+}

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -61,6 +61,7 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
     private lateinit var horizontalGesturePreference: Preference
     private lateinit var directPlayAssPreference: Preference
     private lateinit var networkBufferPreference: Preference
+    private lateinit var maxTranscodeResolutionPreference: Preference
     private lateinit var externalPlayerChoicePreference: Preference
     private lateinit var downloadLocationPreference: Preference
 
@@ -129,6 +130,7 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
                 horizontalGesturePreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 directPlayAssPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 networkBufferPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
+                maxTranscodeResolutionPreference.enabled = selection == VideoPlayerType.EXO_PLAYER
                 externalPlayerChoicePreference.enabled = selection == VideoPlayerType.EXTERNAL_PLAYER
             }
         }
@@ -193,6 +195,18 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
         networkBufferPreference = singleChoice(Constants.PREF_EXOPLAYER_NETWORK_BUFFER, networkBufferOptions) {
             titleRes = R.string.pref_exoplayer_network_buffer
             initialSelection = Constants.NETWORK_BUFFER_AUTO
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
+        }
+        val maxResolutionOptions = listOf(
+            SelectionItem(MaxTranscodeResolution.AUTO, R.string.max_resolution_auto, R.string.max_resolution_auto_description),
+            SelectionItem(MaxTranscodeResolution.P1080, R.string.max_resolution_1080, R.string.max_resolution_1080_description),
+            SelectionItem(MaxTranscodeResolution.P720, R.string.max_resolution_720, R.string.max_resolution_720_description),
+            SelectionItem(MaxTranscodeResolution.P480, R.string.max_resolution_480, R.string.max_resolution_480_description),
+        )
+        maxTranscodeResolutionPreference = singleChoice(Constants.PREF_EXOPLAYER_MAX_TRANSCODE_RESOLUTION, maxResolutionOptions) {
+            titleRes = R.string.pref_exoplayer_max_transcode_resolution_title
+            summaryRes = R.string.pref_exoplayer_max_transcode_resolution_summary
+            initialSelection = MaxTranscodeResolution.AUTO
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
         }
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -44,6 +44,7 @@ object Constants {
     const val NETWORK_BUFFER_AUTO = "auto"
     const val NETWORK_BUFFER_LARGE = "large"
     const val NETWORK_BUFFER_EXTRA_LARGE = "extra_large"
+    const val PREF_EXOPLAYER_MAX_TRANSCODE_RESOLUTION = "pref_exoplayer_max_transcode_resolution"
     const val PREF_EXTERNAL_PLAYER_APP = "pref_external_player_app"
     const val PREF_SUBTITLE_STYLE = "pref_subtitle_style"
     const val PREF_STORAGE_LOCATION = "pref_storage_location"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,16 @@
     <string name="network_buffer_large_description">Larger buffer, may help on moderate or variable connections</string>
     <string name="network_buffer_extra_large">Extra large</string>
     <string name="network_buffer_extra_large_description">Maximum buffer, intended for slow or satellite connections</string>
+    <string name="pref_exoplayer_max_transcode_resolution_title">Maximum resolution</string>
+    <string name="pref_exoplayer_max_transcode_resolution_summary">Resolution cap when the video needs transcoding, independent of the bitrate selection</string>
+    <string name="max_resolution_auto">Automatic</string>
+    <string name="max_resolution_auto_description">Let the server decide based on bitrate (default)</string>
+    <string name="max_resolution_1080">1080p</string>
+    <string name="max_resolution_1080_description">Cap transcodes at Full HD</string>
+    <string name="max_resolution_720">720p</string>
+    <string name="max_resolution_720_description">Cap transcodes at HD</string>
+    <string name="max_resolution_480">480p</string>
+    <string name="max_resolution_480_description">Cap transcodes at SD</string>
 
     <string name="external_player_app">External player app</string>
     <string name="external_player_mpv">MPV Player</string>


### PR DESCRIPTION
**Changes**

Adds a 'Maximum resolution' setting (Automatic/1080p/720p/480p) for the integrated player. When set, a `Height <= x` `ProfileCondition` is attached to the video transcoding profiles of the device profile. The server honors it via `ApplyTranscodingConditions` when transcoding; direct play eligibility is unaffected (the condition is deliberately not added to the codec profiles).

**Motivation**

The in-player quality menu only transmits a bitrate — the resolution in the option label is cosmetic, and the server derives the actual output height from the bitrate alone. Selecting '720p - 4 Mbps' can actually produce a 540p stream, and combinations like 720p at 8 Mbps are impossible. With this setting the user controls the transcode resolution independently of the bitrate selection.

**Testing**

Verified against Jellyfin 10.11: a PlaybackInfo request with the condition returns `MaxHeight` alongside the requested bitrate, and sessions transcode at the capped resolution (e.g. 1280x720 at 4 Mbps where the server previously chose 540p). Feature-tested end-to-end on a v2.6.4-based build; this port to master compiles and passes detekt.

Note: trivially overlaps with #2062 in `Constants`/`SettingsFragment`/`strings.xml` (adjacent lines); happy to rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)