### PR TITLE
Show Google Cast streaming quality setting on Chromecast-capable builds

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -16,6 +16,12 @@ const features = [
     "subtitleburnsettings"
 ];
 
+// Chromecast only works in the proprietary flavor; the libre build ships a no-op
+// cast stub, so only advertise support when the native bridge confirms it.
+if (window.NativeInterface.hasChromecast()) {
+    features.push("chromecast");
+}
+
 const plugins = [
     'NavigationPlugin',
     'ExoPlayerPlugin',

--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -154,8 +154,6 @@ window.NativeShell.AppHost = {
     },
     supports(command) {
         command = command.toLowerCase();
-        // Chromecast only works in the proprietary flavor (libre ships a no-op cast
-        // stub), so query the native side instead of advertising it statically.
         if (command === "chromecast") {
             return window.NativeInterface.hasChromecast();
         }

--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -16,12 +16,6 @@ const features = [
     "subtitleburnsettings"
 ];
 
-// Chromecast only works in the proprietary flavor; the libre build ships a no-op
-// cast stub, so only advertise support when the native bridge confirms it.
-if (window.NativeInterface.hasChromecast()) {
-    features.push("chromecast");
-}
-
 const plugins = [
     'NavigationPlugin',
     'ExoPlayerPlugin',
@@ -159,7 +153,13 @@ window.NativeShell.AppHost = {
         return "mobile";
     },
     supports(command) {
-        return features.includes(command.toLowerCase());
+        command = command.toLowerCase();
+        // Chromecast only works in the proprietary flavor (libre ships a no-op cast
+        // stub), so query the native side instead of advertising it statically.
+        if (command === "chromecast") {
+            return window.NativeInterface.hasChromecast();
+        }
+        return features.includes(command);
     },
     getDeviceProfile,
     getSyncProfile: getDeviceProfile,

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -66,8 +66,6 @@ class NativeInterface(private val context: Context) : KoinComponent {
     @JavascriptInterface
     fun getCodecCapabilities(): String = deviceProfileBuilder.getWebCodecCapabilitiesJson()
 
-    // Only the proprietary flavor bundles the Cast SDK (libre ships a no-op stub), so the web
-    // client should only surface Cast options like the Google Cast streaming quality setting.
     @JavascriptInterface
     fun hasChromecast(): Boolean = BuildConfig.IS_PROPRIETARY
 

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.media.session.PlaybackState
 import android.webkit.JavascriptInterface
 import androidx.core.content.ContextCompat
+import org.jellyfin.mobile.BuildConfig
 import org.jellyfin.mobile.events.ActivityEvent
 import org.jellyfin.mobile.events.ActivityEventHandler
 import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder
@@ -64,6 +65,11 @@ class NativeInterface(private val context: Context) : KoinComponent {
 
     @JavascriptInterface
     fun getCodecCapabilities(): String = deviceProfileBuilder.getWebCodecCapabilitiesJson()
+
+    // Only the proprietary flavor bundles the Cast SDK (libre ships a no-op stub), so the web
+    // client should only surface Cast options like the Google Cast streaming quality setting.
+    @JavascriptInterface
+    fun hasChromecast(): Boolean = BuildConfig.IS_PROPRIETARY
 
     @JavascriptInterface
     fun enableFullscreen(): Boolean {


### PR DESCRIPTION
**Why**
I have an old chromecast and the option to set the bitrate is available in the web app but not on the andoid one. The cast feature was added in 2020 but the settings where not updated to show it is compatible with casting therefore settings the bitrate was not available.

**Changes**
I added `BuildConfig.IS_PROPRIETARY` as a way to identify casting capability and showing the setting.

**Code assistance**
I Used an AI assistant (Claude) for investigating the git log to try to find out why this feature was left behind. I then ask it to code the fix and tested it on my phone. 

This pr description is not written by an llm.
Thanks for all you do ! 