### PR TITLE
Fix fullscreen on large screens where orientation requests are ignored

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -49,6 +49,7 @@ import org.jellyfin.mobile.utils.brightness
 import org.jellyfin.mobile.utils.extensions.aspectRational
 import org.jellyfin.mobile.utils.extensions.getParcelableCompat
 import org.jellyfin.mobile.utils.extensions.isLandscape
+import org.jellyfin.mobile.utils.extensions.isOrientationRequestIgnored
 import org.jellyfin.mobile.utils.extensions.keepScreenOn
 import org.jellyfin.mobile.utils.toast
 import org.jellyfin.sdk.model.api.MediaSegmentDto
@@ -122,8 +123,14 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
                 // For portrait videos, immediately enable fullscreen
                 playerFullscreenHelper.enableFullscreen()
             } else if (appPreferences.exoPlayerStartLandscapeVideoInLandscape) {
-                // Auto-switch to landscape for landscape videos if enabled
-                requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                if (requireActivity().isOrientationRequestIgnored) {
+                    // On large screens, where the orientation request would be ignored,
+                    // enable fullscreen in the current orientation instead
+                    playerFullscreenHelper.enableFullscreen()
+                } else {
+                    // Auto-switch to landscape for landscape videos if enabled
+                    requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                }
             }
 
             // Update title and player menus
@@ -253,7 +260,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
                 // Landscape orientation is always fullscreen
                 playerFullscreenHelper.enableFullscreen()
             }
-            currentVideoStream?.isLandscape != false -> {
+            currentVideoStream?.isLandscape != false && !requireActivity().isOrientationRequestIgnored -> {
                 // Disable fullscreen for landscape video in portrait orientation
                 playerFullscreenHelper.disableFullscreen()
             }
@@ -265,10 +272,12 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
      *
      * If playing a portrait video, this just hides the status and navigation bars.
      * For landscape videos, additionally the screen gets rotated.
+     * On large screens, where the system ignores orientation requests,
+     * only the status and navigation bars are toggled instead.
      */
     private fun toggleFullscreen() {
         val videoTrack = currentVideoStream
-        if (videoTrack == null || videoTrack.isLandscape) {
+        if ((videoTrack == null || videoTrack.isLandscape) && !requireActivity().isOrientationRequestIgnored) {
             val current = resources.configuration.orientation
             requireActivity().requestedOrientation = when (current) {
                 Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE

--- a/app/src/main/java/org/jellyfin/mobile/utils/AndroidVersion.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/AndroidVersion.kt
@@ -89,4 +89,12 @@ object AndroidVersion {
      */
     inline val isAtLeastT: Boolean
         get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+    /**
+     * Checks whether the current Android version is at least Android 16 Baklava, API 36.
+     *
+     * @see Build.VERSION_CODES.BAKLAVA
+     */
+    inline val isAtLeastB: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
 }

--- a/app/src/main/java/org/jellyfin/mobile/utils/extensions/Activity.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/extensions/Activity.kt
@@ -4,6 +4,18 @@ import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.graphics.Point
 import android.view.Surface
+import org.jellyfin.mobile.utils.AndroidVersion
+
+private const val LARGE_SCREEN_SMALLEST_WIDTH_DP = 600
+
+/**
+ * Checks whether requests via [Activity.setRequestedOrientation] are ignored by the system.
+ *
+ * Starting with Android 16, orientation requests of apps targeting SDK 36 are ignored
+ * on displays with a smallest width of at least 600dp, such as tablets and unfolded foldables.
+ */
+val Activity.isOrientationRequestIgnored: Boolean
+    get() = AndroidVersion.isAtLeastB && resources.configuration.smallestScreenWidthDp >= LARGE_SCREEN_SMALLEST_WIDTH_DP
 
 @Suppress("DEPRECATION")
 fun Activity.lockOrientation() {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Android 16 made a change where setRequestedOrientation() is ignored on apps targeting SDK 36 and above whilst on a device that has a smallest width of at least 600dp. This is an issue for foldable phones particularly. The player's fullscreen logic would not activate when I had my foldable open so the bars were permanently stuck on my screen like in my attached issue. The change is to toggle the system bars directly when orientation requests are ignored and start playback in fullscreen instead of rotating when "Start landscape mode videos in landscape orientation" is enabled. On large screens, rotating from landscape back to portrait no longer re-shows the bars.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
Code was written with assistance from Claude. It read over the codebase and found the problem location along with suggesting a fix. I tested all the code on an emulator along with my physical device (Google Pixel 10 Pro Fold). I tested functionality on the cover display along with the interior display on both setting options.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2069
