### PR TITLE
Fix player title positioning

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -16,7 +16,6 @@ import android.view.ViewGroup
 import android.view.WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
 import android.widget.ImageButton
 import androidx.annotation.RequiresApi
-import androidx.appcompat.widget.AppCompatTextView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -70,7 +69,6 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     private val playerControlsBinding: ExoPlayerControlViewBinding get() = _playerControlsBinding!!
     private val playerControlsView: View get() = playerControlsBinding.root
     private val toolbar: Toolbar get() = playerControlsBinding.toolbar
-    private val toolbarTitle: AppCompatTextView get() = playerControlsBinding.toolbarTitle
     private val fullscreenSwitcher: ImageButton get() = playerControlsBinding.fullscreenSwitcher
     private var playerMenus: PlayerMenus? = null
 
@@ -127,7 +125,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
             }
 
             // Update title and player menus
-            toolbarTitle.text = mediaSource.getName(requireContext())
+            toolbar.title = mediaSource.getName(requireContext())
             playerMenus?.onQueueItemChanged(mediaSource, viewModel.queueManager.hasNext())
         }
 

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -16,22 +16,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:navigationIcon="?attr/homeAsUpIndicator">
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/toolbar_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginHorizontal="56dp"
-            android:ellipsize="end"
-            android:gravity="center"
-            android:maxLines="3"
-            android:textAppearance="@style/TextAppearance.Widget.AppCompat.Toolbar.Title"
-            android:textColor="?android:textColorPrimary"
-            android:breakStrategy="high_quality"
-            tools:text="Star Wars: A New Hope" />
-    </androidx.appcompat.widget.Toolbar>
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        tools:title="Star Wars: A New Hope" />
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/previous_button"
@@ -127,30 +113,29 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/chapter_marking_container"
-            android:orientation="horizontal"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginStart="11dp"
             android:layout_marginEnd="11dp"
-            app:layout_constraintTop_toTopOf="parent"
+            android:orientation="horizontal"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_constraintTop_toTopOf="parent"></androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.media3.ui.DefaultTimeBar
             android:id="@+id/exo_progress"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             app:played_color="?colorAccent"
             app:scrubber_color="?colorAccent"
-            app:unplayed_color="@color/playback_timebar_unplayed"
             app:scrubber_dragged_size="24dp"
-            app:scrubber_enabled_size="16dp" />
+            app:scrubber_enabled_size="16dp"
+            app:unplayed_color="@color/playback_timebar_unplayed" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -284,8 +269,8 @@
             android:layout_gravity="bottom"
             android:orientation="vertical"
             android:paddingStart="8dp"
-            android:paddingEnd="8dp"
             android:paddingTop="4dp"
+            android:paddingEnd="8dp"
             android:paddingBottom="8dp">
 
             <androidx.appcompat.widget.AppCompatTextView


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Fix the positioning of the item title within the video player UI to be left-aligned again, instead of weirdly centered+cut. Effectively reverts #1920.

Android Studio also decided to reorder all XML attributes.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #2083