### PR TITLE
Fallback to suggested music when no search results are found in Android Auto voice search

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
@@ -417,6 +417,14 @@ class SessionBrowserCallback(
         }
 
         expandedItems = onAddMediaItems(mediaSession, controller, expandedItems).await()
+
+        Timber.d("onSetMediaItems resulted in ${expandedItems.size} items")
+        if (expandedItems.isEmpty()) {
+            mediaSession.sendError(
+                controller,
+                SessionError(SessionError.ERROR_BAD_VALUE, context.getString(R.string.media_service_no_items))
+            )
+        }
         MediaSession.MediaItemsWithStartPosition(expandedItems, newStartIndex, newStartPositionMs)
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/sessionbrowser/SessionBrowserCallback.kt
@@ -383,6 +383,17 @@ class SessionBrowserCallback(
                         ?.getContent(route, 0, MAX_PAGE_SIZE)
                         ?.toMediaItems(route)
                         .orEmpty()
+
+                    // Android Auto does not support session error reporting
+                    // but Google Play requires feedback on all search requests
+                    // so fallback to random item playback if no search results are found
+                    if (expandedItems.isEmpty()) {
+                        @Suppress("UNCHECKED_CAST")
+                        expandedItems = (LibraryRoute.Suggested.page as LibraryPage<LibraryRoute>)
+                            .getContent(LibraryRoute.Suggested, 0, MAX_PAGE_SIZE)
+                            .toMediaItems(route)
+                    }
+
                     newStartIndex = 0
                 }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Implement error handling for empty results in the session browser. This doesn't matter because media3 ignores these for legacy media sessions. Guess what Android Auto uses? Legacy media sessions! So we also implement terrible UX so Google Play won't reject our app and play "random" (suggested) music when no search results are found. Because that's what the user wants, obviously.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
