### PR TITLE
Opt-out of Android 16 restricted resizability behavior

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,5 +116,8 @@
         <meta-data
             android:name="android.webkit.WebView.EnableSafeBrowsing"
             android:value="false" />
+
+        <!-- Temporarily opt-out of new Android 16 behavior to allow setRequestedOrientation() calls -->
+        <property android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY" android:value="true" />
     </application>
 </manifest>


### PR DESCRIPTION
**Changes**

Opt-out of Android 16 restricted resizability behavior to keep automatic landscape mode functionality working.

See discussion in #2085 for more info.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
