### PR TITLE
Clear stuck playback notification when the "playback stopped" event is missed

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/RemotePlayerService.kt
@@ -35,6 +35,7 @@ import coil3.toBitmap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jellyfin.mobile.MainActivity
 import org.jellyfin.mobile.R
@@ -69,6 +70,7 @@ import org.jellyfin.mobile.utils.setPlaybackState
 import org.koin.android.ext.android.inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 class RemotePlayerService : Service(), CoroutineScope {
 
@@ -89,6 +91,7 @@ class RemotePlayerService : Service(), CoroutineScope {
     private var mediaController: MediaController? = null
     private var largeItemIcon: Bitmap? = null
     private var currentItemId: String? = null
+    private var staleNotificationWatchdog: Job? = null
 
     val playbackState: PlaybackState? get() = mediaSession?.controller?.playbackState
 
@@ -371,6 +374,22 @@ class RemotePlayerService : Service(), CoroutineScope {
 
             // Activate MediaSession
             mediaSession.isActive = true
+
+            // If the web app never reports that playback stopped (e.g. a Cast/remote
+            // session is ended externally and the event is missed), this notification
+            // and media session would otherwise linger forever, non-dismissible, until
+            // the app is force quit. Only the "playing" state is non-dismissible
+            // (see setOngoing below), so only guard that state; a paused notification
+            // can already be swiped away and may legitimately sit idle for a long time.
+            staleNotificationWatchdog?.cancel()
+            staleNotificationWatchdog = if (!isPaused) {
+                launch {
+                    delay(STALE_NOTIFICATION_TIMEOUT)
+                    onStopped()
+                }
+            } else {
+                null
+            }
         }
     }
 
@@ -490,6 +509,7 @@ class RemotePlayerService : Service(), CoroutineScope {
     }
 
     private fun onStopped() {
+        staleNotificationWatchdog?.cancel()
         notificationManager.cancel(MEDIA_PLAYER_NOTIFICATION_ID)
         mediaSession?.isActive = false
         stopWakelock()
@@ -497,11 +517,19 @@ class RemotePlayerService : Service(), CoroutineScope {
     }
 
     override fun onDestroy() {
+        staleNotificationWatchdog?.cancel()
         unregisterReceiver(receiver)
         job.cancel()
         mediaSession?.release()
         mediaSession = null
         super.onDestroy()
+    }
+
+    private companion object {
+        // Web app sends periodic progress updates during active playback (well under a
+        // minute apart); if none arrive for this long, assume the session ended without
+        // us being told and clear the stuck notification/media session ourselves.
+        val STALE_NOTIFICATION_TIMEOUT = 5.minutes
     }
 
     class ServiceBinder(private val service: RemotePlayerService) : Binder() {


### PR DESCRIPTION
Fixes #1851

## Root cause
`RemotePlayerService` only clears its foreground notification and media session when the web app's JS bridge sends an explicit `playbackstop` action (via `hideMediaSession()`). If that message is never sent — e.g. a Cast/remote-control session ends on the receiver side rather than through this app's own UI — nothing on the native side ever finds out, and the notification stays stuck in its non-dismissible "playing" state indefinitely. Force-quitting the app is the only known way to clear it.

## Fix
Added a self-resetting watchdog in `RemotePlayerService`: it restarts on every playback update while the state is not paused, and if 5 minutes pass with no update, it runs the same cleanup path as an explicit `playbackstop`. Scoped to the non-paused state only, since a paused notification is already swipe-dismissible (`setOngoing(!isPaused && ...)`) and can legitimately sit idle for a long time.

## Test evidence
`./gradlew :app:compileLibreDebugKotlin` builds clean, no new warnings.
Reproduced the underlying stuck-notification symptom on my own device (`dumpsys notification`/`dumpsys media_session` showing a `PLAYING` state and `NO_DISMISS` notification over 38+ hours after a Kodi remote-control session ended) — matches the mechanism described in #1851, though I don't have a Chromecast to test the exact repro steps end-to-end.

---
Prepared with AI assistance (Claude Code, Anthropic) — used to diagnose the root cause via `dumpsys`, locate the missing cleanup path in `RemotePlayerService.kt`, and implement the watchdog. Reviewed the diff and build output myself before submission.