### PR TITLE
Remove mime types from file picker intent

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebChromeClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebChromeClient.kt
@@ -42,7 +42,15 @@ class JellyfinWebChromeClient(
             return true
         }
 
-        fileChooserListener.onShowFileChooser(fileChooserParams.createIntent(), filePathCallback)
+        val intent = fileChooserParams.createIntent().apply {
+            // The file requests from jellyfin-web often use extensions, but Android only allows mime types
+            // the default mapping from most webview implementations is too limited so we remove them
+            // jellyfin-web validates chosen files to avoid wrong file types from being used
+            removeExtra(Intent.EXTRA_MIME_TYPES)
+            type = "*/*"
+        }
+
+        fileChooserListener.onShowFileChooser(intent, filePathCallback)
         return true
     }
 


### PR DESCRIPTION
**Changes**

Lyrics in Jellyfin web use an accept attribute of `accept=".lrc,.txt"`. The `createIntent()` implementation by chrome converts this to just `text/plain`. However, .lrc files on Android are recognized as unknown.

The web UI always validates the selected files, as not all browsers support the `accept` attribute. Therefor it's safe to allow the user to select any file they want and let web deal with it. Thus, this PR removes the mime-type mapping.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #1959