### PR TITLE
Improve error handling on download failure

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadBroadcastReceiver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadBroadcastReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -24,6 +25,7 @@ class DownloadBroadcastReceiver : BroadcastReceiver(), KoinComponent {
     }
 
     private val downloadManager by inject<DownloadManager>()
+    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == ACTION_DOWNLOAD_CANCEL) {
@@ -31,12 +33,10 @@ class DownloadBroadcastReceiver : BroadcastReceiver(), KoinComponent {
             if (id == -1L) return
 
             val pendingResult = goAsync()
-            CoroutineScope(SupervisorJob()).launch {
-                try {
-                    downloadManager.cancel(id)
-                } finally {
-                    pendingResult.finish()
-                }
+            coroutineScope.launch {
+                downloadManager.cancel(id)
+            }.invokeOnCompletion {
+                pendingResult.finish()
             }
         }
     }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadManager.kt
@@ -95,24 +95,26 @@ class DownloadManager(
     }
 
     suspend fun cancel(id: Long) = withContext(Dispatchers.IO) {
-        val download = downloadDao.getDownload(id)
-        if (download != null) {
-            DownloadWorker.stop(context)
-            downloadDao.update(download.copy(status = DownloadStatus.CANCELLED))
-            DownloadWorker.start(context, appPreferences)
+        val download = downloadDao.getDownload(id) ?: return@withContext
+        downloadDao.update(download.copy(status = DownloadStatus.CANCELLED))
+
+        if (download.status == DownloadStatus.DOWNLOADING) {
+            DownloadWorker.restart(context, appPreferences)
         }
     }
 
     suspend fun delete(id: Long, deleteFiles: Boolean) = withContext(Dispatchers.IO) {
         val download = downloadDao.getDownload(id) ?: return@withContext
 
-        if (download.status == DownloadStatus.DOWNLOADING) DownloadWorker.stop(context)
+        downloadDao.delete(id)
+
+        if (download.status == DownloadStatus.DOWNLOADING) {
+            DownloadWorker.restart(context, appPreferences)
+        }
 
         if (deleteFiles) {
             val storageLocation = storageManager.getStorageLocation()
             storageLocation?.findFile(download.path)?.delete()
         }
-
-        downloadDao.delete(id)
     }
 }

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
@@ -72,7 +72,11 @@ class DownloadQueue(
             notificationProgressCallback.onEnd()
             downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.DOWNLOADED))
         } catch (e: CancellationException) {
-            downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.QUEUED))
+            // The download could've been canceled by the app, in which case we need to refresh it before making changes
+            val download = downloadDao.getDownload(downloadWithFiles.download.id)
+            if (download?.status == DownloadStatus.DOWNLOADING) {
+                downloadDao.update(download.copy(status = DownloadStatus.QUEUED))
+            }
             throw e
         } catch (e: IOException) {
             downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.QUEUED))

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadQueue.kt
@@ -16,6 +16,7 @@ import org.jellyfin.sdk.api.client.extensions.imageApi
 import org.jellyfin.sdk.api.client.extensions.libraryApi
 import org.jellyfin.sdk.model.api.ImageFormat
 import org.jellyfin.sdk.model.api.ImageType
+import java.io.IOException
 
 class DownloadQueue(
     private val context: Context,
@@ -70,11 +71,15 @@ class DownloadQueue(
 
             notificationProgressCallback.onEnd()
             downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.DOWNLOADED))
-        } catch (_: CancellationException) {
+        } catch (e: CancellationException) {
             downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.QUEUED))
-        } catch (error: Throwable) {
+            throw e
+        } catch (e: IOException) {
+            downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.QUEUED))
+            throw e
+        } catch (e: Exception) {
             downloadDao.update(downloadWithFiles.download.copy(status = DownloadStatus.ERROR))
-            throw error
+            throw e
         }
     }
 
@@ -111,6 +116,9 @@ class DownloadQueue(
                     status = DownloadStatus.DOWNLOADED,
                 ),
             )
+        } catch (e: IOException) {
+            downloadDao.updateFile(file.copy(status = DownloadStatus.QUEUED))
+            throw e
         } catch (e: Exception) {
             downloadDao.updateFile(file.copy(status = DownloadStatus.ERROR))
             throw e

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadWorker.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadWorker.kt
@@ -48,6 +48,11 @@ class DownloadWorker(
             WorkManager.getInstance(context).cancelUniqueWork(tag).await()
         }
 
+        suspend fun restart(context: Context, appPreferences: AppPreferences) {
+            stop(context)
+            start(context, appPreferences)
+        }
+
         suspend fun isActive(context: Context): Boolean = WorkManager.getInstance(context)
             .getWorkInfosForUniqueWork(tag)
             .await()

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadWorker.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadWorker.kt
@@ -11,7 +11,9 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import androidx.work.await
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.guava.await
 import org.jellyfin.mobile.app.AppPreferences
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -24,7 +26,7 @@ class DownloadWorker(
     companion object {
         private val tag = DownloadWorker::class.qualifiedName!!
 
-        fun start(context: Context, appPreferences: AppPreferences) {
+        suspend fun start(context: Context, appPreferences: AppPreferences) {
             val request = OneTimeWorkRequestBuilder<DownloadWorker>().apply {
                 addTag(tag)
                 setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
@@ -39,16 +41,16 @@ class DownloadWorker(
                 )
             }.build()
 
-            WorkManager.getInstance(context).enqueueUniqueWork(tag, ExistingWorkPolicy.REPLACE, request)
+            WorkManager.getInstance(context).enqueueUniqueWork(tag, ExistingWorkPolicy.REPLACE, request).await()
         }
 
-        fun stop(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(tag)
+        suspend fun stop(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(tag).await()
         }
 
-        fun isActive(context: Context): Boolean = WorkManager.getInstance(context)
+        suspend fun isActive(context: Context): Boolean = WorkManager.getInstance(context)
             .getWorkInfosForUniqueWork(tag)
-            .get()
+            .await()
             .any { workInfo -> workInfo.state == WorkInfo.State.RUNNING }
     }
 

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadWorker.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadWorker.kt
@@ -11,9 +11,11 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import kotlinx.coroutines.CancellationException
 import org.jellyfin.mobile.app.AppPreferences
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.io.IOException
 
 class DownloadWorker(
     context: Context,
@@ -57,11 +59,18 @@ class DownloadWorker(
 
     override suspend fun doWork(): Result {
         val canProcess = downloadQueue.prepare()
-        if (!canProcess) return Result.failure()
+        if (!canProcess) return Result.success()
 
         setForeground(getForegroundInfo())
-        downloadQueue.process()
-
-        return Result.success()
+        return try {
+            downloadQueue.process()
+            Result.success()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: IOException) {
+            Result.retry()
+        } catch (_: Exception) {
+            Result.failure()
+        }
     }
 }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

I got a report that downloads can get stuck when a phone switches between networks, after looking into the code I found a few spots that could cause the items download state become "ERROR", even when it's a "normal" cancellation.
With this change we forward cancellation up to the worker so it's properly handled, we also add a special case for IOErrors, as those can happen when the current network becomes unavailable before androidx.work cancels the job due to network change. This would also help with other network issues like the server going offline etc.
Finally, when the worker starts without any downloads in the queue it should signal a success, not a failure. As the job itself completed fine.

After testing I discovered some more issue where cancelling didn't work properly which was solved by rechecking the item status when the worker is cancelled.

Still needs testing.

**Code assistance**

Gemini 3 Flash was used to investigate the initial issue

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
