### PR TITLE
Report the actual playback speed in the media session state

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -667,6 +667,23 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
     }
 
     /**
+     * Update the media session playback state, including the current playback speed,
+     * so the notification and lock screen extrapolate the position at the correct rate.
+     */
+    private fun updateMediaSessionPlaybackState() {
+        val player = playerOrNull ?: return
+
+        var playbackActions = SUPPORTED_VIDEO_PLAYER_PLAYBACK_ACTIONS
+        if (queueManager.hasPrevious()) {
+            playbackActions = playbackActions or PlaybackState.ACTION_SKIP_TO_PREVIOUS
+        }
+        if (queueManager.hasNext()) {
+            playbackActions = playbackActions or PlaybackState.ACTION_SKIP_TO_NEXT
+        }
+        mediaSession.setPlaybackState(player, playbackActions)
+    }
+
+    /**
      * Set the playback speed to [speed]
      *
      * @return true if the speed was changed
@@ -677,6 +694,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
         val parameters = player.playbackParameters
         if (parameters.speed != speed) {
             player.playbackParameters = parameters.withSpeed(speed)
+            updateMediaSessionPlaybackState()
             return true
         }
         return false
@@ -739,14 +757,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
         }
 
         // Update media session
-        var playbackActions = SUPPORTED_VIDEO_PLAYER_PLAYBACK_ACTIONS
-        if (queueManager.hasPrevious()) {
-            playbackActions = playbackActions or PlaybackState.ACTION_SKIP_TO_PREVIOUS
-        }
-        if (queueManager.hasNext()) {
-            playbackActions = playbackActions or PlaybackState.ACTION_SKIP_TO_NEXT
-        }
-        mediaSession.setPlaybackState(player, playbackActions)
+        updateMediaSessionPlaybackState()
 
         // Force update playback state and position
         viewModelScope.launch {

--- a/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/MediaExtensions.kt
@@ -38,9 +38,9 @@ fun JellyfinMediaSource.toMediaMetadata(): MediaMetadata = MediaMetadata.Builder
     putString(MediaMetadata.METADATA_KEY_ART_URI, imageUri.toString())
 }.build()
 
-fun MediaSession.setPlaybackState(playbackState: Int, position: Long, playbackActions: Long) {
+fun MediaSession.setPlaybackState(playbackState: Int, position: Long, playbackActions: Long, speed: Float = 1.0f) {
     val state = PlaybackState.Builder().apply {
-        setState(playbackState, position, 1.0f)
+        setState(playbackState, position, speed)
         setActions(playbackActions)
     }.build()
     setPlaybackState(state)
@@ -61,7 +61,7 @@ fun MediaSession.setPlaybackState(player: Player, playbackActions: Long) {
         Player.STATE_BUFFERING -> PlaybackState.STATE_BUFFERING
         else -> error("Invalid player playbackState $playerState")
     }
-    setPlaybackState(playbackState, player.currentPosition, playbackActions)
+    setPlaybackState(playbackState, player.currentPosition, playbackActions, player.playbackParameters.speed)
 }
 
 fun AudioManager.getVolumeRange(streamType: Int): IntRange {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The playback state handed to the media session hardcoded a speed of 1.0, so whenever the integrated player ran at another rate, through the speed menu or the hold to speed up gesture, the notification and lock screen extrapolated the position at 1x and drifted out of sync with playback.

Pass the player's real speed instead. The overload taking an explicit speed defaults to 1.0 so the web player's media session, which has no way to know the rate, keeps its current behaviour.

Reading the speed is not enough on its own, because the playback state was only refreshed from onPlayerStateChanged and changing speed does not change the player state. Extract the update into a helper and also call it when the speed changes, so the session reflects the new rate immediately.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

I used an LLM to find the exact timing discrepancies in the code base and ensure any changes would be consistent across the board / across different files, and to ensure I follow all contribution guidelines.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

related to upstream fix in [jellyfin-web](https://github.com/jellyfin/jellyfin-web/pull/8340) and https://github.com/jellyfin/jellyfin-web/pull/8339