### PR TITLE
Fix WebView not loading for servers using a non-redirecting path

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/WebViewFragment.kt
@@ -190,7 +190,7 @@ class WebViewFragment : Fragment(), BackPressInterceptor, JellyfinWebChromeClien
         addJavascriptInterface(externalPlayer, "ExternalPlayer")
         addJavascriptInterface(mediaSegments, "MediaSegments")
 
-        loadUrl(server.hostname)
+        loadUrl("${server.hostname.trimEnd('/')}/")
         postDelayed(timeoutRunnable, Constants.INITIAL_CONNECTION_TIMEOUT)
         postDelayed(showLoadingContainerRunnable, Constants.SHOW_PROGRESS_BAR_DELAY)
     }


### PR DESCRIPTION
**Changes**

Due to a mistake in the SDK, server address recommendation would strip ending slashes for input with a path, e.g. `demo.jellyfin.org/stable/` would always be returned as `demo.jellyfin.org/stable`.
While this is perfectly fine for the SDK to work, it caused an issue on the mobile app when it tries to load the webview and there is no redirect in place for the URLs not ending with a slash.
A fix will be added to the 1.9 release of the SDK, but this won't be used to the app in the short term.

Therefor, a similar fix is done here to make sure the app can always deal with ending slashes. With this change we always request the WebView to load with a single slash at the end, no matter if there is a path or not. This fix is safe to keep even when the SDK fix is in.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

"reported" via invalid PR on SDK: jellyfin/jellyfin-sdk-kotlin#1266
