### PR TITLE
Fix crash in PlayerFragment onConfigurationChanged handler

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -242,7 +242,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
      */
     private fun updateFullscreenState(configuration: Configuration) {
         // Do not handle any orientation changes while being in Picture-in-Picture mode
-        if (AndroidVersion.isAtLeastN && requireActivity().isInPictureInPictureMode) {
+        if (AndroidVersion.isAtLeastN && activity?.isInPictureInPictureMode == true) {
             return
         }
 
@@ -408,6 +408,8 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         Handler(Looper.getMainLooper()).post {
+            if (!isAdded) return@post
+
             updateFullscreenState(newConfig)
             playerGestureHelper.handleConfiguration(newConfig)
         }


### PR DESCRIPTION
**Changes**

The `onConfigurationChanged` function delays its handling of fullscreen state updating to avoid race conditions, but this in turn created a race condition where the fragment might have been detached and `requireActivity()` (inside the `updateFullscreenState` fun) would cause an NPE.

This fix changes to requireActivity call to null-check the activity getter instead and verifies if the fragment is still attached before calling the updateFullscreenState function.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes an extremely common crash visible in Google Play console.

```
Exception java.lang.IllegalStateException:
  at androidx.fragment.app.Fragment.requireActivity (Fragment.java:1005)
  at org.jellyfin.mobile.player.ui.PlayerFragment.updateFullscreenState (PlayerFragment.kt:245)
  at org.jellyfin.mobile.player.ui.PlayerFragment.onConfigurationChanged$lambda$0 (PlayerFragment.kt:411)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:206)
  at android.os.Looper.loop (Looper.java:295)
  at android.app.ActivityThread.main (ActivityThread.java:8695)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:577)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1062)
```