### PR TITLE
Refactor from org.json to kotlinx.serialization

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/ExternalPlayer.kt
@@ -32,7 +32,6 @@ import org.jellyfin.sdk.api.client.extensions.videosApi
 import org.jellyfin.sdk.api.operations.VideosApi
 import org.jellyfin.sdk.model.api.DeviceProfile
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
-import org.json.JSONObject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.component.inject
@@ -84,7 +83,7 @@ class ExternalPlayer(
 
     @JavascriptInterface
     fun initPlayer(args: String) {
-        val playOptions = PlayOptions.fromJson(JSONObject(args))
+        val playOptions = PlayOptions.fromJson(args)
         val itemId = playOptions?.run {
             ids.firstOrNull() ?: mediaSourceId?.toUUIDOrNull() // fallback if ids is empty
         }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/JavascriptCallback.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/JavascriptCallback.kt
@@ -1,5 +1,6 @@
 package org.jellyfin.mobile.bridge
 
+import kotlinx.serialization.json.JsonElement
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -9,15 +10,26 @@ abstract class JavascriptCallback {
     @JvmOverloads
     fun success(keep: Boolean = false, result: String? = null) = callback(keep, null, result?.let { """"$it"""" })
 
-    @JvmOverloads
-    fun success(keep: Boolean = false, result: JSONObject?) = callback(keep, null, result.toString())
+    fun success(keep: Boolean, result: JsonElement?) = callback(keep, null, result?.toString())
 
-    @JvmOverloads
-    fun success(keep: Boolean = false, result: JSONArray?) = callback(keep, null, result.toString())
+    fun success(result: JsonElement?) = success(false, result)
+
+    fun success(keep: Boolean, result: JSONObject?) = callback(keep, null, result?.toString())
+
+    fun success(result: JSONObject?) = success(false, result)
+
+    fun success(keep: Boolean, result: JSONArray?) = callback(keep, null, result?.toString())
+
+    fun success(result: JSONArray?) = success(false, result)
 
     @JvmOverloads
     fun error(keep: Boolean = false, message: String) = callback(keep, """"$message"""", null)
 
-    @JvmOverloads
-    fun error(keep: Boolean = false, error: JSONObject) = callback(keep, error.toString(), null)
+    fun error(keep: Boolean, error: JsonElement) = callback(keep, error.toString(), null)
+
+    fun error(error: JsonElement) = error(false, error)
+
+    fun error(keep: Boolean, error: JSONObject) = callback(keep, error.toString(), null)
+
+    fun error(error: JSONObject) = error(false, error)
 }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -6,6 +6,15 @@ import android.content.Intent
 import android.media.session.PlaybackState
 import android.webkit.JavascriptInterface
 import androidx.core.content.ContextCompat
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
 import org.jellyfin.mobile.BuildConfig
 import org.jellyfin.mobile.events.ActivityEvent
 import org.jellyfin.mobile.events.ActivityEventHandler
@@ -28,8 +37,6 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.util.AuthorizationHeaderBuilder
 import org.jellyfin.sdk.model.serializer.toUUID
 import org.json.JSONArray
-import org.json.JSONException
-import org.json.JSONObject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.component.inject
@@ -49,8 +56,8 @@ class NativeInterface(private val context: Context) : KoinComponent {
         val deviceInfo = apiClient.deviceInfo
         val clientInfo = apiClient.clientInfo
 
-        JSONObject().apply {
-            put("deviceId", deviceInfo.id)
+        buildJsonObject {
+            put("deviceId", deviceInfo.id.toString())
             // normalize the name by removing special characters
             // and making sure it's at least 1 character long
             // otherwise the webui will fail to send it to the server
@@ -59,7 +66,7 @@ class NativeInterface(private val context: Context) : KoinComponent {
             put("appName", clientInfo.name)
             put("appVersion", clientInfo.version)
         }.toString()
-    } catch (e: JSONException) {
+    } catch (e: Exception) {
         null
     }
 
@@ -90,24 +97,24 @@ class NativeInterface(private val context: Context) : KoinComponent {
     @JavascriptInterface
     fun updateMediaSession(args: String): Boolean {
         val options = try {
-            JSONObject(args)
-        } catch (e: JSONException) {
+            Json.parseToJsonElement(args).jsonObject
+        } catch (e: Exception) {
             Timber.e("updateMediaSession: %s", e.message)
             return false
         }
         val intent = Intent(context, RemotePlayerService::class.java).apply {
             action = Constants.ACTION_REPORT
-            putExtra(EXTRA_PLAYER_ACTION, options.optString(EXTRA_PLAYER_ACTION))
-            putExtra(EXTRA_ITEM_ID, options.optString(EXTRA_ITEM_ID))
-            putExtra(EXTRA_TITLE, options.optString(EXTRA_TITLE))
-            putExtra(EXTRA_ARTIST, options.optString(EXTRA_ARTIST))
-            putExtra(EXTRA_ALBUM, options.optString(EXTRA_ALBUM))
-            putExtra(EXTRA_IMAGE_URL, options.optString(EXTRA_IMAGE_URL))
-            putExtra(EXTRA_POSITION, options.optLong(EXTRA_POSITION, PlaybackState.PLAYBACK_POSITION_UNKNOWN))
-            putExtra(EXTRA_DURATION, options.optLong(EXTRA_DURATION))
-            putExtra(EXTRA_CAN_SEEK, options.optBoolean(EXTRA_CAN_SEEK))
-            putExtra(EXTRA_IS_LOCAL_PLAYER, options.optBoolean(EXTRA_IS_LOCAL_PLAYER, true))
-            putExtra(EXTRA_IS_PAUSED, options.optBoolean(EXTRA_IS_PAUSED, true))
+            putExtra(EXTRA_PLAYER_ACTION, options[EXTRA_PLAYER_ACTION]?.jsonPrimitive?.contentOrNull ?: "")
+            putExtra(EXTRA_ITEM_ID, options[EXTRA_ITEM_ID]?.jsonPrimitive?.contentOrNull ?: "")
+            putExtra(EXTRA_TITLE, options[EXTRA_TITLE]?.jsonPrimitive?.contentOrNull ?: "")
+            putExtra(EXTRA_ARTIST, options[EXTRA_ARTIST]?.jsonPrimitive?.contentOrNull ?: "")
+            putExtra(EXTRA_ALBUM, options[EXTRA_ALBUM]?.jsonPrimitive?.contentOrNull ?: "")
+            putExtra(EXTRA_IMAGE_URL, options[EXTRA_IMAGE_URL]?.jsonPrimitive?.contentOrNull ?: "")
+            putExtra(EXTRA_POSITION, options[EXTRA_POSITION]?.jsonPrimitive?.longOrNull ?: PlaybackState.PLAYBACK_POSITION_UNKNOWN)
+            putExtra(EXTRA_DURATION, options[EXTRA_DURATION]?.jsonPrimitive?.longOrNull ?: 0L)
+            putExtra(EXTRA_CAN_SEEK, options[EXTRA_CAN_SEEK]?.jsonPrimitive?.booleanOrNull ?: false)
+            putExtra(EXTRA_IS_LOCAL_PLAYER, options[EXTRA_IS_LOCAL_PLAYER]?.jsonPrimitive?.booleanOrNull ?: true)
+            putExtra(EXTRA_IS_PAUSED, options[EXTRA_IS_PAUSED]?.jsonPrimitive?.booleanOrNull ?: true)
         }
 
         ContextCompat.startForegroundService(context, intent)
@@ -135,18 +142,20 @@ class NativeInterface(private val context: Context) : KoinComponent {
     @JavascriptInterface
     fun downloadFiles(args: String): Boolean {
         try {
-            val files = JSONArray(args)
+            val files = Json.parseToJsonElement(args).jsonArray
             val itemIds = mutableSetOf<UUID>()
 
-            repeat(files.length()) { index ->
-                val file = files.getJSONObject(index)
-                val itemId = file.getString("itemId").toUUID()
+            files.forEach { element ->
+                val file = element.jsonObject
+                val itemId = file["itemId"]?.jsonPrimitive?.contentOrNull?.toUUID()
 
-                itemIds.add(itemId)
+                if (itemId != null) {
+                    itemIds.add(itemId)
+                }
             }
 
             emitEvent(ActivityEvent.DownloadItems(itemIds))
-        } catch (e: JSONException) {
+        } catch (e: Exception) {
             Timber.e("Download failed: %s", e.message)
             return false
         }

--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativePlayer.kt
@@ -9,7 +9,6 @@ import org.jellyfin.mobile.player.interaction.PlayOptions
 import org.jellyfin.mobile.player.interaction.PlayerEvent
 import org.jellyfin.mobile.settings.VideoPlayerType
 import org.jellyfin.sdk.model.extensions.ticks
-import org.json.JSONObject
 import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("unused")
@@ -24,7 +23,7 @@ class NativePlayer(
 
     @JavascriptInterface
     fun loadPlayer(args: String) {
-        PlayOptions.fromJson(JSONObject(args))?.let { options ->
+        PlayOptions.fromJson(args)?.let { options ->
             activityEventHandler.emit(ActivityEvent.LaunchNativePlayer(options))
         }
     }

--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceProfileBuilder.kt
@@ -2,9 +2,13 @@ package org.jellyfin.mobile.player.deviceprofile
 
 import android.media.MediaCodecList
 import android.media.MediaFormat
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.jellyfin.mobile.app.AppPreferences
+import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder.Companion.AVAILABLE_AUDIO_CODECS
+import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder.Companion.AVAILABLE_VIDEO_CODECS
+import org.jellyfin.mobile.player.deviceprofile.DeviceProfileBuilder.Companion.SUPPORTED_CONTAINER_FORMATS
 import org.jellyfin.mobile.utils.Constants
-import org.json.JSONObject
 import org.jellyfin.sdk.model.api.CodecProfile
 import org.jellyfin.sdk.model.api.CodecType
 import org.jellyfin.sdk.model.api.ContainerProfile
@@ -227,7 +231,7 @@ class DeviceProfileBuilder(
         musicStreamingTranscodingBitrate = Int.MAX_VALUE,
     )
 
-    fun getWebCodecCapabilitiesJson(): String = JSONObject().apply {
+    fun getWebCodecCapabilitiesJson(): String = buildJsonObject {
         put("h264MaxLevel", CodecHelpers.getVideoLevel("h264", maxAvcRawLevel)?.toString() ?: DEFAULT_H264_MAX_LEVEL)
     }.toString()
 

--- a/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/interaction/PlayOptions.kt
@@ -2,11 +2,15 @@ package org.jellyfin.mobile.player.interaction
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import org.jellyfin.mobile.utils.extensions.size
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 import org.jellyfin.sdk.model.extensions.ticks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
-import org.json.JSONException
-import org.json.JSONObject
 import timber.log.Timber
 import java.util.UUID
 import kotlin.time.Duration
@@ -22,23 +26,18 @@ data class PlayOptions(
     val playFromDownloads: Boolean?,
 ) : Parcelable {
     companion object {
-        fun fromJson(json: JSONObject): PlayOptions? = try {
+        fun fromJson(json: String): PlayOptions? = try {
+            val jsonObject = Json.parseToJsonElement(json).jsonObject
             PlayOptions(
-                ids = json.optJSONArray("ids")?.let { array ->
-                    ArrayList<UUID>().apply {
-                        for (i in 0 until array.size) {
-                            array.getString(i).toUUIDOrNull()?.let(this::add)
-                        }
-                    }
-                } ?: emptyList(),
-                mediaSourceId = json.optString("mediaSourceId"),
-                startIndex = json.optInt("startIndex"),
-                startPosition = (json.optLong("startPositionTicks").takeIf { it > 0 })?.ticks,
-                audioStreamIndex = json.optString("audioStreamIndex").toIntOrNull(),
-                subtitleStreamIndex = json.optString("subtitleStreamIndex").toIntOrNull(),
+                ids = jsonObject["ids"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull?.toUUIDOrNull() } ?: emptyList(),
+                mediaSourceId = jsonObject["mediaSourceId"]?.jsonPrimitive?.contentOrNull,
+                startIndex = jsonObject["startIndex"]?.jsonPrimitive?.intOrNull ?: 0,
+                startPosition = (jsonObject["startPositionTicks"]?.jsonPrimitive?.longOrNull?.takeIf { it > 0 })?.ticks,
+                audioStreamIndex = jsonObject["audioStreamIndex"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
+                subtitleStreamIndex = jsonObject["subtitleStreamIndex"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
                 playFromDownloads = false,
             )
-        } catch (e: JSONException) {
+        } catch (e: Exception) {
             Timber.e(e, "Failed to parse playback options: %s", json)
             null
         }

--- a/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/LocaleUtils.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.res.Configuration
 import android.webkit.WebView
 import kotlinx.serialization.json.Json
-import org.json.JSONException
 import timber.log.Timber
 import java.util.Locale
 import java.util.UUID
@@ -19,7 +18,7 @@ suspend fun WebView.initLocale(userId: UUID) {
         evaluateJavascript("window.localStorage.getItem('$flatUserId-language')") { result ->
             try {
                 continuation.resume(Json.decodeFromString<String?>(result))
-            } catch (e: JSONException) {
+            } catch (e: Exception) {
                 continuation.resume(null)
             }
         }

--- a/app/src/main/java/org/jellyfin/mobile/utils/extensions/JSONArray.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/extensions/JSONArray.kt
@@ -1,5 +1,0 @@
-package org.jellyfin.mobile.utils.extensions
-
-import org.json.JSONArray
-
-val JSONArray.size: Int get() = length()

--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt
@@ -11,14 +11,17 @@ import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewFeature
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.jellyfin.mobile.MainViewModel
 import org.jellyfin.mobile.data.entity.ServerEntity
 import org.jellyfin.mobile.utils.Constants
 import org.jellyfin.mobile.utils.initLocale
 import org.jellyfin.mobile.utils.inject
-import org.jellyfin.sdk.model.serializer.toUUID
-import org.json.JSONException
-import org.json.JSONObject
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import timber.log.Timber
 import java.io.Reader
 import java.util.Locale
@@ -56,17 +59,25 @@ abstract class JellyfinWebViewClient(
                             "JSON.parse(window.localStorage.getItem('jellyfin_credentials'))",
                         ) { result ->
                             try {
-                                continuation.resume(JSONObject(result))
-                            } catch (e: JSONException) {
+                                continuation.resume(Json.parseToJsonElement(result).jsonObject)
+                            } catch (e: Exception) {
                                 val message = "Failed to extract credentials"
                                 Timber.e(e, message)
                                 continuation.resumeWithException(Exception(message, e))
                             }
                         }
                     }
-                    val storedServer = credentials.getJSONArray("Servers").getJSONObject(0)
-                    val user = storedServer.getString("UserId").toUUID()
-                    val token = storedServer.getString("AccessToken")
+
+                    val storedServer = credentials["Servers"]?.jsonArray?.get(0)?.jsonObject
+                    val user = storedServer?.get("UserId")?.jsonPrimitive?.contentOrNull?.toUUIDOrNull()
+                    val token = storedServer?.get("AccessToken")?.jsonPrimitive?.contentOrNull
+
+                    if (user == null || token == null) {
+                        Timber.e("Unable to find user in webview credentials")
+                        onErrorReceived()
+                        return@launch
+                    }
+
                     mainViewModel.setupUser(server.id, user, token)
                     webView.initLocale(user)
                 }


### PR DESCRIPTION
**Changes**

I originally wanted to land this for 2.8 but I'm seeing quite a lot of issues related to our JSON parsing in the Google Play crash reports, so we're going to backport it instead.

This change replaces all (except chromecast which is written in Java) usages of org.json to use kotlinx.serialization instead. In addition it improves the error handling in the WebViewClient when it fails to parse `jellyfin_credentials` (which apparently can happen quite often...).

**Code assistance**

AI was not used but I made this branch a few weeks ago late at night and only rebased it just now. Might contain the same stupidity an LLM can get you. Although I tried to test all code paths and they seemed to work fine.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
