### PR TITLE
Add foldable tabletop / Flex Mode support for native player

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,6 +148,7 @@ dependencies {
     // UI
     implementation(libs.google.material)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.window)
     implementation(libs.androidx.webkit)
     implementation(libs.modernandroidpreferences)
 
@@ -201,7 +202,7 @@ tasks {
 
     // Testing
     withType<Test> {
-        useJUnit()
+        useJUnitPlatform()
         testLogging {
             events(
                 org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
 
+    <!-- androidx.window 1.5+ requires minSdk 23; foldables are far above that. Keep app minSdk 21. -->
+    <uses-sdk tools:overrideLibrary="androidx.window.core,androidx.window" />
+
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/FoldPosture.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/FoldPosture.kt
@@ -1,0 +1,40 @@
+package org.jellyfin.mobile.player.ui
+
+import android.view.View
+import androidx.window.layout.FoldingFeature
+
+/**
+ * Helpers for foldable tabletop / Flex Mode posture detection and hinge geometry.
+ */
+object FoldPosture {
+    /**
+     * Tabletop (Samsung Flex Mode): device half-open with a horizontal hinge.
+     */
+    fun isTabletop(feature: FoldingFeature?): Boolean =
+        feature != null &&
+            feature.state == FoldingFeature.State.HALF_OPENED &&
+            feature.orientation == FoldingFeature.Orientation.HORIZONTAL
+
+    /**
+     * Y offset of the fold within [view], in view-local coordinates.
+     * Returns null when the hinge does not intersect the view.
+     */
+    fun foldOffsetY(view: View, feature: FoldingFeature): Int? {
+        val viewLocation = IntArray(2)
+        view.getLocationInWindow(viewLocation)
+        val viewTop = viewLocation[1]
+        val viewBottom = viewTop + view.height
+        val foldTop = feature.bounds.top
+        val foldBottom = feature.bounds.bottom
+        if (foldBottom <= viewTop || foldTop >= viewBottom) {
+            return null
+        }
+        return foldOffsetY(viewTop, view.height, foldTop)
+    }
+
+    /**
+     * Pure geometry helper for tests: fold Y relative to a view's window top.
+     */
+    fun foldOffsetY(viewTopInWindow: Int, viewHeight: Int, featureBoundsTop: Int): Int =
+        (featureBoundsTop - viewTopInWindow).coerceIn(0, viewHeight)
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFoldHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFoldHelper.kt
@@ -1,0 +1,152 @@
+package org.jellyfin.mobile.player.ui
+
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.media3.ui.PlayerView
+import androidx.window.layout.FoldingFeature
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowLayoutInfo
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.jellyfin.mobile.databinding.FragmentPlayerBinding
+import org.jellyfin.mobile.utils.AndroidVersion
+import org.jellyfin.mobile.utils.Constants
+import androidx.media3.ui.R as Media3R
+
+/**
+ * Observes foldable window layout and applies tabletop (Flex Mode) player chrome:
+ * video above the hinge, controls in the lower pane.
+ */
+class PlayerFoldHelper(
+    private val fragment: PlayerFragment,
+    private val playerBinding: FragmentPlayerBinding,
+    private val playerControlsView: View,
+    private val onTabletopChanged: (Boolean) -> Unit,
+) {
+    private val playerView: PlayerView get() = playerBinding.playerView
+    private val playerOverlay: View get() = playerBinding.playerOverlay
+
+    var isTabletop: Boolean = false
+        private set
+
+    /** Height of the video pane in tabletop mode; 0 when not tabletop. */
+    var videoPaneHeight: Int = 0
+        private set
+
+    private var collectJob: Job? = null
+    private var savedControllerTimeoutMs: Int = Constants.DEFAULT_CONTROLS_TIMEOUT_MS
+
+    fun start(lifecycleOwner: LifecycleOwner) {
+        collectJob?.cancel()
+        val activity = fragment.requireActivity()
+        collectJob = lifecycleOwner.lifecycleScope.launch {
+            lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                WindowInfoTracker.getOrCreate(activity)
+                    .windowLayoutInfo(activity)
+                    .collect(::onLayoutInfoChanged)
+            }
+        }
+    }
+
+    fun stop() {
+        collectJob?.cancel()
+        collectJob = null
+        if (isTabletop) {
+            restoreFullBleedLayout()
+        }
+    }
+
+    private fun onLayoutInfoChanged(layoutInfo: WindowLayoutInfo) {
+        if (!fragment.isAdded) return
+        // PiP should stay full-bleed embedded controls
+        if (AndroidVersion.isAtLeastN && fragment.requireActivity().isInPictureInPictureMode) {
+            if (isTabletop) restoreFullBleedLayout()
+            return
+        }
+
+        val feature = layoutInfo.displayFeatures
+            .filterIsInstance<FoldingFeature>()
+            .firstOrNull()
+
+        if (FoldPosture.isTabletop(feature) && feature != null) {
+            val root = playerBinding.root
+            if (root.height == 0) {
+                root.post { applyTabletopIfPossible(feature) }
+            } else {
+                applyTabletopIfPossible(feature)
+            }
+        } else if (isTabletop) {
+            restoreFullBleedLayout()
+        }
+    }
+
+    private fun applyTabletopIfPossible(feature: FoldingFeature) {
+        val foldY = FoldPosture.foldOffsetY(playerBinding.root, feature) ?: return
+        val rootHeight = playerBinding.root.height
+        if (foldY <= 0 || foldY >= rootHeight) return
+        applyTabletopLayout(foldY)
+    }
+
+    private fun applyTabletopLayout(foldY: Int) {
+        val wasTabletop = isTabletop
+        isTabletop = true
+        videoPaneHeight = foldY
+        val bottomHeight = playerBinding.root.height - foldY
+
+        val contentFrame = playerView.findViewById<View>(Media3R.id.exo_content_frame)
+        setPaneLayoutParams(contentFrame, foldY, Gravity.TOP)
+        setPaneLayoutParams(playerControlsView, bottomHeight, Gravity.BOTTOM)
+        setPaneLayoutParams(playerOverlay, foldY, Gravity.TOP)
+
+        if (!wasTabletop) {
+            savedControllerTimeoutMs = playerView.controllerShowTimeoutMs
+        }
+        playerView.controllerShowTimeoutMs = -1
+        playerView.showController()
+
+        if (!wasTabletop) {
+            onTabletopChanged(true)
+        }
+    }
+
+    private fun restoreFullBleedLayout() {
+        val wasTabletop = isTabletop
+        isTabletop = false
+        videoPaneHeight = 0
+
+        val contentFrame = playerView.findViewById<View>(Media3R.id.exo_content_frame)
+        setPaneLayoutParams(contentFrame, ViewGroup.LayoutParams.MATCH_PARENT, Gravity.CENTER)
+        setPaneLayoutParams(playerControlsView, ViewGroup.LayoutParams.MATCH_PARENT, Gravity.TOP)
+        setPaneLayoutParams(playerOverlay, ViewGroup.LayoutParams.MATCH_PARENT, Gravity.TOP)
+
+        playerView.controllerShowTimeoutMs = savedControllerTimeoutMs
+
+        if (wasTabletop) {
+            onTabletopChanged(false)
+        }
+    }
+
+    private fun setPaneLayoutParams(view: View?, height: Int, gravity: Int) {
+        if (view == null) return
+        val params = view.layoutParams
+        if (params is FrameLayout.LayoutParams) {
+            params.width = ViewGroup.LayoutParams.MATCH_PARENT
+            params.height = height
+            params.gravity = gravity
+            params.topMargin = 0
+            view.layoutParams = params
+        } else {
+            view.layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                height,
+                gravity,
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -75,6 +75,14 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     private lateinit var playerFullscreenHelper: PlayerFullscreenHelper
     lateinit var playerLockScreenHelper: PlayerLockScreenHelper
     lateinit var playerGestureHelper: PlayerGestureHelper
+    private var playerFoldHelper: PlayerFoldHelper? = null
+
+    val isTabletopMode: Boolean
+        get() = playerFoldHelper?.isTabletop == true
+
+    /** Height of the video region in tabletop mode; 0 when not in tabletop. */
+    val tabletopVideoPaneHeight: Int
+        get() = playerFoldHelper?.videoPaneHeight ?: 0
 
     private val currentVideoStream: MediaStream?
         get() = viewModel.mediaSourceOrNull?.selectedVideoStream
@@ -119,7 +127,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
             if (mediaSource.selectedVideoStream?.isLandscape == false) {
                 // For portrait videos, immediately enable fullscreen
                 playerFullscreenHelper.enableFullscreen()
-            } else if (appPreferences.exoPlayerStartLandscapeVideoInLandscape) {
+            } else if (appPreferences.exoPlayerStartLandscapeVideoInLandscape && !isTabletopMode) {
                 // Auto-switch to landscape for landscape videos if enabled
                 requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             }
@@ -212,6 +220,23 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
         playerLockScreenHelper = PlayerLockScreenHelper(this, playerBinding, orientationListener)
         playerGestureHelper = PlayerGestureHelper(this, playerBinding, playerLockScreenHelper)
 
+        playerFoldHelper = PlayerFoldHelper(
+            fragment = this,
+            playerBinding = playerBinding,
+            playerControlsView = playerControlsView,
+            onTabletopChanged = { tabletop ->
+                if (tabletop) {
+                    // Prefer unlocked orientation so Flex Mode can settle naturally
+                    requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                    playerFullscreenHelper.enableFullscreen()
+                    playerGestureHelper.onTabletopChanged(true)
+                } else {
+                    playerGestureHelper.onTabletopChanged(false)
+                    updateFullscreenState(resources.configuration)
+                }
+            },
+        ).also { it.start(viewLifecycleOwner) }
+
         // Handle fullscreen switcher
         fullscreenSwitcher.setOnClickListener {
             toggleFullscreen()
@@ -227,7 +252,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
         super.onResume()
 
         // When returning from another app, fullscreen mode for landscape orientation has to be set again
-        if (isLandscape()) {
+        if (!isTabletopMode && isLandscape()) {
             playerFullscreenHelper.enableFullscreen()
         }
 
@@ -243,6 +268,12 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     private fun updateFullscreenState(configuration: Configuration) {
         // Do not handle any orientation changes while being in Picture-in-Picture mode
         if (AndroidVersion.isAtLeastN && activity?.isInPictureInPictureMode == true) {
+            return
+        }
+
+        // Tabletop / Flex Mode manages its own chrome; don't force landscape fullscreen
+        if (isTabletopMode) {
+            playerFullscreenHelper.enableFullscreen()
             return
         }
 
@@ -263,8 +294,14 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
      *
      * If playing a portrait video, this just hides the status and navigation bars.
      * For landscape videos, additionally the screen gets rotated.
+     * In tabletop / Flex Mode, only system bars are toggled (no orientation lock).
      */
     private fun toggleFullscreen() {
+        if (isTabletopMode) {
+            playerFullscreenHelper.toggleFullscreen()
+            return
+        }
+
         val videoTrack = currentVideoStream
         if (videoTrack == null || videoTrack.isLandscape) {
             val current = resources.configuration.orientation
@@ -422,6 +459,8 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        playerFoldHelper?.stop()
+        playerFoldHelper = null
         // Detach player from PlayerView
         playerView.player = null
 

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
@@ -59,6 +59,11 @@ class PlayerGestureHelper(
     private var isZoomEnabled = false
 
     /**
+     * When true, gestures are limited to the video pane above the hinge (tabletop / Flex Mode).
+     */
+    private var isTabletopMode = false
+
+    /**
      * Tracks a value during a swipe gesture (between multiple onScroll calls).
      * When the gesture starts it's reset to an initial value and gets increased or decreased
      * (depending on the direction) as the gesture progresses.
@@ -137,8 +142,11 @@ class PlayerGestureHelper(
         playerView.context,
         object : GestureDetector.SimpleOnGestureListener() {
             override fun onDoubleTap(e: MotionEvent): Boolean {
+                // Ignore double-taps on the controls pane in tabletop / Flex Mode
+                if (isOutsideVideoPane(e.y)) return false
+
                 val viewWidth = playerView.measuredWidth
-                val viewHeight = playerView.measuredHeight
+                val viewHeight = gestureHeight()
                 val viewCenterX = viewWidth / 2
                 val viewCenterY = viewHeight / 2
                 val isFastForward = e.x.toInt() > viewCenterX
@@ -158,11 +166,11 @@ class PlayerGestureHelper(
                 // Fast-forward/rewind
                 with(fragment) { if (isFastForward) onFastForward() else onRewind() }
 
-                // Cancel previous runnable to not hide controller while seeking
-                playerView.removeCallbacks(hidePlayerViewControllerAction)
-
-                // Ensure controller gets hidden after seeking
-                playerView.postDelayed(hidePlayerViewControllerAction, Constants.DEFAULT_CONTROLS_TIMEOUT_MS.toLong())
+                // Keep controls open in tabletop; otherwise restore normal auto-hide
+                if (!isTabletopMode) {
+                    playerView.removeCallbacks(hidePlayerViewControllerAction)
+                    playerView.postDelayed(hidePlayerViewControllerAction, Constants.DEFAULT_CONTROLS_TIMEOUT_MS.toLong())
+                }
                 return true
             }
 
@@ -192,11 +200,15 @@ class PlayerGestureHelper(
             ): Boolean {
                 if (firstEvent == null) return false
 
+                // Gestures only apply on the video pane in tabletop / Flex Mode
+                if (isOutsideVideoPane(firstEvent.y)) return false
+
                 // Check whether swipe was started in excluded region (vertical)
                 val exclusionSizeVertical = playerView.resources.dip(Constants.SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL)
+                val paneHeight = gestureHeight()
                 if (
                     firstEvent.y < exclusionSizeVertical ||
-                    firstEvent.y > playerView.height - exclusionSizeVertical
+                    firstEvent.y > paneHeight - exclusionSizeVertical
                 ) {
                     return false
                 }
@@ -314,7 +326,7 @@ class PlayerGestureHelper(
                 val viewCenterX = playerView.measuredWidth / 2
 
                 // Distance to swipe to go from min to max
-                val distanceFull = playerView.measuredHeight * Constants.FULL_SWIPE_RANGE_SCREEN_RATIO
+                val distanceFull = gestureHeight() * Constants.FULL_SWIPE_RANGE_SCREEN_RATIO
                 val ratioChange = distanceY / distanceFull
 
                 if (firstEvent.x.toInt() > viewCenterX) {
@@ -376,7 +388,8 @@ class PlayerGestureHelper(
     private val zoomGestureDetector = ScaleGestureDetector(
         playerView.context,
         object : ScaleGestureDetector.OnScaleGestureListener {
-            override fun onScaleBegin(detector: ScaleGestureDetector): Boolean = fragment.isLandscape()
+            override fun onScaleBegin(detector: ScaleGestureDetector): Boolean =
+                !isTabletopMode && fragment.isLandscape()
 
             override fun onScale(detector: ScaleGestureDetector): Boolean {
                 val scaleFactor = detector.scaleFactor
@@ -444,7 +457,28 @@ class PlayerGestureHelper(
     }
 
     fun handleConfiguration(newConfig: Configuration) {
-        updateZoomMode(fragment.isLandscape(newConfig) && isZoomEnabled)
+        updateZoomMode(!isTabletopMode && fragment.isLandscape(newConfig) && isZoomEnabled)
+    }
+
+    fun onTabletopChanged(enabled: Boolean) {
+        isTabletopMode = enabled
+        if (enabled) {
+            // Pinch-zoom assumes a full-bleed landscape surface
+            updateZoomMode(false)
+        } else {
+            updateZoomMode(fragment.isLandscape() && isZoomEnabled)
+        }
+    }
+
+    private fun gestureHeight(): Int {
+        val tabletopHeight = fragment.tabletopVideoPaneHeight
+        return if (isTabletopMode && tabletopHeight > 0) tabletopHeight else playerView.measuredHeight
+    }
+
+    private fun isOutsideVideoPane(y: Float): Boolean {
+        if (!isTabletopMode) return false
+        val paneHeight = fragment.tabletopVideoPaneHeight
+        return paneHeight > 0 && y > paneHeight
     }
 
     private fun updateZoomMode(enabled: Boolean) {

--- a/app/src/test/java/org/jellyfin/mobile/player/ui/FoldPostureTests.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/ui/FoldPostureTests.kt
@@ -1,0 +1,18 @@
+package org.jellyfin.mobile.player.ui
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FoldPostureTests {
+    @Test
+    fun foldOffsetYClampsToViewBounds() {
+        assertEquals(1000, FoldPosture.foldOffsetY(viewTopInWindow = 100, viewHeight = 2000, featureBoundsTop = 1100))
+        assertEquals(0, FoldPosture.foldOffsetY(viewTopInWindow = 100, viewHeight = 2000, featureBoundsTop = 50))
+        assertEquals(2000, FoldPosture.foldOffsetY(viewTopInWindow = 100, viewHeight = 2000, featureBoundsTop = 5000))
+    }
+
+    @Test
+    fun foldOffsetYHandlesViewAlignedWithWindow() {
+        assertEquals(540, FoldPosture.foldOffsetY(viewTopInWindow = 0, viewHeight = 1080, featureBoundsTop = 540))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androidx-lifecycle = "2.9.4"
 
 # UI
 androidx-constraintlayout = "2.2.2"
+androidx-window = "1.5.1"
 google-material = "1.13.0"
 androidx-webkit = "1.14.0"
 modernandroidpreferences = "2.4.0-beta2"
@@ -106,6 +107,7 @@ androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-p
 # UI
 google-material = { group = "com.google.android.material", name = "material", version.ref = "google-material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidx-webkit" }
 modernandroidpreferences = { group = "de.maxr1998", name = "modernandroidpreferences", version.ref = "modernandroidpreferences" }
 


### PR DESCRIPTION
## Summary
- Detect Samsung Flex Mode / tabletop posture (`FoldingFeature` HALF_OPENED + horizontal hinge) via Jetpack WindowManager
- Split native ExoPlayer UI so video stays above the hinge and controls sit in the lower pane, without forcing landscape
- Scope brightness/volume/seek gestures to the video pane and keep controls visible while tabletop; restore full-bleed layout when flat/folded

## Test plan
- [ ] Build `assembleLibreDebug` / install on a foldable (Z Fold or Pixel Fold)
- [ ] Closed / cover display: playback unchanged
- [ ] Fully open flat: full-bleed player unchanged
- [ ] Half-open tabletop (~90°): video on top, controls below; no forced landscape flip
- [ ] Exit tabletop: layout restores cleanly
- [ ] PiP / lock screen / skip-segment still usable
- [ ] Unit tests: `./gradlew :app:testLibreDebugUnitTest`

Verified locally: `assembleLibreDebug` and `testLibreDebugUnitTest` succeed. Physical Fold Flex Mode checklist still needs a connected device.


Made with [Cursor](https://cursor.com)