### PR TITLE
Add foldable tabletop / Flex Mode support for native player

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,6 +148,7 @@ dependencies {
     // UI
     implementation(libs.google.material)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.window)
     implementation(libs.androidx.webkit)
     implementation(libs.modernandroidpreferences)
 
@@ -201,7 +202,7 @@ tasks {
 
     // Testing
     withType<Test> {
-        useJUnit()
+        useJUnitPlatform()
         testLogging {
             events(
                 org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
 
+    <!-- androidx.window 1.5+ requires minSdk 23; foldables are far above that. Keep app minSdk 21. -->
+    <uses-sdk tools:overrideLibrary="androidx.window.core,androidx.window" />
+
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/FoldPosture.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/FoldPosture.kt
@@ -1,0 +1,34 @@
+package org.jellyfin.mobile.player.ui
+
+import android.view.View
+import androidx.window.layout.FoldingFeature
+
+/**
+ * Foldable tabletop / Flex Mode posture helpers.
+ */
+object FoldPosture {
+    fun isTabletop(feature: FoldingFeature?): Boolean =
+        feature != null &&
+            feature.state == FoldingFeature.State.HALF_OPENED &&
+            feature.orientation == FoldingFeature.Orientation.HORIZONTAL
+
+    /**
+     * Y offset of the fold within [view], or null if the hinge does not intersect.
+     *
+     * @param useFoldBottom use the hinge bottom edge (immersive) instead of the top edge
+     */
+    fun foldOffsetY(view: View, feature: FoldingFeature, useFoldBottom: Boolean = false): Int? {
+        val viewLocation = IntArray(2)
+        view.getLocationInWindow(viewLocation)
+        val viewTop = viewLocation[1]
+        val viewBottom = viewTop + view.height
+        val foldTop = feature.bounds.top
+        val foldBottom = feature.bounds.bottom
+        if (foldBottom <= viewTop || foldTop >= viewBottom) return null
+        val edge = if (useFoldBottom) foldBottom else foldTop
+        return foldOffsetY(viewTop, view.height, edge)
+    }
+
+    fun foldOffsetY(viewTopInWindow: Int, viewHeight: Int, featureBoundsTop: Int): Int =
+        (featureBoundsTop - viewTopInWindow).coerceIn(0, viewHeight)
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFoldHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFoldHelper.kt
@@ -1,0 +1,301 @@
+package org.jellyfin.mobile.player.ui
+
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+import androidx.window.layout.FoldingFeature
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowLayoutInfo
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.jellyfin.mobile.R
+import org.jellyfin.mobile.databinding.FragmentPlayerBinding
+import org.jellyfin.mobile.utils.AndroidVersion
+import org.jellyfin.mobile.utils.Constants
+import androidx.media3.ui.R as Media3R
+
+/**
+ * Applies tabletop / Flex Mode layout for the native player:
+ * video above the hinge, controls below. Optional immersive mode fills the hinge band
+ * and peeks translucent controls.
+ */
+class PlayerFoldHelper(
+    private val fragment: PlayerFragment,
+    private val playerBinding: FragmentPlayerBinding,
+    private val playerControlsView: View,
+    private val toolbar: Toolbar,
+    private val onTabletopChanged: (Boolean) -> Unit,
+) {
+    private val playerView: PlayerView by playerBinding::playerView
+    private val playerOverlay: FrameLayout by playerBinding::playerOverlay
+
+    var isTabletop: Boolean = false
+        private set
+
+    var isFlexExpanded: Boolean = false
+        private set
+
+    var videoPaneHeight: Int = 0
+        private set
+
+    private var collectJob: Job? = null
+    private var savedControllerTimeoutMs: Int = Constants.DEFAULT_CONTROLS_TIMEOUT_MS
+    private var savedResizeMode: Int = AspectRatioFrameLayout.RESIZE_MODE_FIT
+    private var savedClipChildren: Boolean = true
+    private var savedClipToPadding: Boolean = true
+    private var lastFoldingFeature: FoldingFeature? = null
+
+    private var toolbarHost: ViewGroup? = null
+    private var toolbarHostIndex: Int = -1
+    private var toolbarHostLayoutParams: ViewGroup.LayoutParams? = null
+    private var titleOnOverlay: Boolean = false
+
+    private val controllerVisibilityListener = PlayerView.ControllerVisibilityListener { visibility ->
+        if (titleOnOverlay) {
+            toolbar.isVisible = visibility == View.VISIBLE
+        }
+    }
+
+    fun start(lifecycleOwner: LifecycleOwner) {
+        collectJob?.cancel()
+        val activity = fragment.requireActivity()
+        collectJob = lifecycleOwner.lifecycleScope.launch {
+            lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                WindowInfoTracker.getOrCreate(activity)
+                    .windowLayoutInfo(activity)
+                    .collect(::onLayoutInfoChanged)
+            }
+        }
+    }
+
+    fun stop() {
+        collectJob?.cancel()
+        collectJob = null
+        if (isTabletop) {
+            restoreFullBleedLayout()
+        }
+    }
+
+    fun toggleFlexExpanded(): Boolean {
+        if (!isTabletop) return false
+        isFlexExpanded = !isFlexExpanded
+        lastFoldingFeature?.let(::applyTabletopIfPossible)
+        return isFlexExpanded
+    }
+
+    private fun onLayoutInfoChanged(layoutInfo: WindowLayoutInfo) {
+        if (!fragment.isAdded) return
+        if (AndroidVersion.isAtLeastN && fragment.requireActivity().isInPictureInPictureMode) {
+            if (isTabletop) restoreFullBleedLayout()
+            return
+        }
+
+        val feature = layoutInfo.displayFeatures
+            .filterIsInstance<FoldingFeature>()
+            .firstOrNull()
+
+        if (FoldPosture.isTabletop(feature) && feature != null) {
+            lastFoldingFeature = feature
+            val root = playerBinding.root
+            if (root.width == 0 || root.height == 0) {
+                root.post { applyTabletopIfPossible(feature) }
+            } else {
+                applyTabletopIfPossible(feature)
+            }
+        } else if (isTabletop) {
+            restoreFullBleedLayout()
+        }
+    }
+
+    private fun applyTabletopIfPossible(feature: FoldingFeature) {
+        val foldTop = FoldPosture.foldOffsetY(playerBinding.root, feature, useFoldBottom = false) ?: return
+        val foldBottom = FoldPosture.foldOffsetY(playerBinding.root, feature, useFoldBottom = true) ?: foldTop
+        val rootHeight = playerBinding.root.height
+        if (foldTop <= 0 || foldTop >= rootHeight) return
+
+        lastFoldingFeature = feature
+        applyTabletopLayout(foldTop, foldBottom.coerceAtLeast(foldTop))
+    }
+
+    private fun applyTabletopLayout(foldTop: Int, foldBottom: Int) {
+        val wasTabletop = isTabletop
+        isTabletop = true
+
+        // Standard flex clears the crease; immersive fills through the hinge band
+        val videoHeight = if (isFlexExpanded) foldBottom else foldTop
+        videoPaneHeight = videoHeight
+        val rootWidth = playerBinding.root.width
+        val bottomHeight = (playerBinding.root.height - videoHeight).coerceAtLeast(0)
+
+        val contentFrame = playerView.findViewById<View>(Media3R.id.exo_content_frame)
+        if (contentFrame is ViewGroup) {
+            contentFrame.clipChildren = true
+            contentFrame.clipToPadding = true
+        }
+
+        setPaneLayoutParams(
+            contentFrame,
+            width = rootWidth,
+            height = videoHeight,
+            gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL,
+        )
+        setPaneLayoutParams(
+            playerControlsView,
+            width = ViewGroup.LayoutParams.MATCH_PARENT,
+            height = bottomHeight,
+            gravity = Gravity.BOTTOM,
+        )
+        setPaneLayoutParams(
+            playerOverlay,
+            width = rootWidth,
+            height = videoHeight,
+            gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL,
+        )
+
+        if (!wasTabletop) {
+            savedControllerTimeoutMs = playerView.controllerShowTimeoutMs
+            savedResizeMode = playerView.resizeMode
+            savedClipChildren = playerView.clipChildren
+            savedClipToPadding = playerView.clipToPadding
+            playerView.setControllerVisibilityListener(controllerVisibilityListener)
+        }
+
+        playerView.clipChildren = true
+        playerView.clipToPadding = true
+        moveTitleOntoVideoOverlay()
+        playerControlsView.isVisible = true
+
+        if (isFlexExpanded) {
+            playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+            playerControlsView.setBackgroundResource(R.color.playback_controls_background_flex_immersive)
+        } else {
+            playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+            playerControlsView.setBackgroundResource(R.color.playback_controls_background)
+        }
+
+        playerView.controllerShowTimeoutMs = Constants.DEFAULT_CONTROLS_TIMEOUT_MS
+        playerView.showController()
+        toolbar.isVisible = true
+
+        if (!wasTabletop) {
+            onTabletopChanged(true)
+        }
+    }
+
+    private fun moveTitleOntoVideoOverlay() {
+        if (titleOnOverlay) return
+        val host = toolbar.parent as? ViewGroup ?: return
+        toolbarHost = host
+        toolbarHostIndex = host.indexOfChild(toolbar)
+        toolbarHostLayoutParams = toolbar.layoutParams
+        host.removeView(toolbar)
+        toolbar.translationY = 0f
+        playerOverlay.addView(
+            toolbar,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.TOP,
+            ),
+        )
+        titleOnOverlay = true
+    }
+
+    private fun restoreTitleToControls() {
+        if (!titleOnOverlay) return
+        val host = toolbarHost
+        val params = toolbarHostLayoutParams
+        val index = toolbarHostIndex
+        (toolbar.parent as? ViewGroup)?.removeView(toolbar)
+        if (host != null && params != null) {
+            val insertAt = index.coerceIn(0, host.childCount)
+            val restoredParams = if (host is ConstraintLayout && params !is ConstraintLayout.LayoutParams) {
+                ConstraintLayout.LayoutParams(params).apply {
+                    topToTop = ConstraintLayout.LayoutParams.PARENT_ID
+                    startToStart = ConstraintLayout.LayoutParams.PARENT_ID
+                    endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
+                    width = 0
+                    height = ViewGroup.LayoutParams.WRAP_CONTENT
+                }
+            } else {
+                params
+            }
+            host.addView(toolbar, insertAt, restoredParams)
+        }
+        toolbar.translationY = 0f
+        toolbar.isVisible = true
+        toolbarHost = null
+        toolbarHostLayoutParams = null
+        toolbarHostIndex = -1
+        titleOnOverlay = false
+    }
+
+    private fun restoreFullBleedLayout() {
+        val wasTabletop = isTabletop
+        isTabletop = false
+        isFlexExpanded = false
+        videoPaneHeight = 0
+        lastFoldingFeature = null
+
+        playerView.setControllerVisibilityListener(null as PlayerView.ControllerVisibilityListener?)
+        restoreTitleToControls()
+
+        val contentFrame = playerView.findViewById<View>(Media3R.id.exo_content_frame)
+        setPaneLayoutParams(
+            contentFrame,
+            width = ViewGroup.LayoutParams.MATCH_PARENT,
+            height = ViewGroup.LayoutParams.MATCH_PARENT,
+            gravity = Gravity.CENTER,
+        )
+        setPaneLayoutParams(
+            playerControlsView,
+            width = ViewGroup.LayoutParams.MATCH_PARENT,
+            height = ViewGroup.LayoutParams.MATCH_PARENT,
+            gravity = Gravity.TOP,
+        )
+        setPaneLayoutParams(
+            playerOverlay,
+            width = ViewGroup.LayoutParams.MATCH_PARENT,
+            height = ViewGroup.LayoutParams.MATCH_PARENT,
+            gravity = Gravity.TOP,
+        )
+
+        playerControlsView.isVisible = true
+        playerControlsView.setBackgroundResource(R.color.playback_controls_background)
+        playerView.resizeMode = savedResizeMode
+        playerView.clipChildren = savedClipChildren
+        playerView.clipToPadding = savedClipToPadding
+        playerView.controllerShowTimeoutMs = savedControllerTimeoutMs
+
+        if (wasTabletop) {
+            onTabletopChanged(false)
+        }
+    }
+
+    private fun setPaneLayoutParams(view: View?, width: Int, height: Int, gravity: Int) {
+        if (view == null) return
+        val params = view.layoutParams
+        if (params is FrameLayout.LayoutParams) {
+            params.width = width
+            params.height = height
+            params.gravity = gravity
+            params.topMargin = 0
+            params.bottomMargin = 0
+            params.leftMargin = 0
+            params.rightMargin = 0
+            view.layoutParams = params
+        } else {
+            view.layoutParams = FrameLayout.LayoutParams(width, height, gravity)
+        }
+    }
+}

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -75,6 +75,17 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     private lateinit var playerFullscreenHelper: PlayerFullscreenHelper
     lateinit var playerLockScreenHelper: PlayerLockScreenHelper
     lateinit var playerGestureHelper: PlayerGestureHelper
+    private var playerFoldHelper: PlayerFoldHelper? = null
+
+    val isTabletopMode: Boolean
+        get() = playerFoldHelper?.isTabletop == true
+
+    val isFlexExpanded: Boolean
+        get() = playerFoldHelper?.isFlexExpanded == true
+
+    /** Height of the video region in tabletop mode; 0 when not in tabletop. */
+    val tabletopVideoPaneHeight: Int
+        get() = playerFoldHelper?.videoPaneHeight ?: 0
 
     private val currentVideoStream: MediaStream?
         get() = viewModel.mediaSourceOrNull?.selectedVideoStream
@@ -119,7 +130,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
             if (mediaSource.selectedVideoStream?.isLandscape == false) {
                 // For portrait videos, immediately enable fullscreen
                 playerFullscreenHelper.enableFullscreen()
-            } else if (appPreferences.exoPlayerStartLandscapeVideoInLandscape) {
+            } else if (appPreferences.exoPlayerStartLandscapeVideoInLandscape && !isTabletopMode) {
                 // Auto-switch to landscape for landscape videos if enabled
                 requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             }
@@ -187,12 +198,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
                 bottom = systemInsets.bottom,
             )
 
-            // Update fullscreen switcher icon
-            val fullscreenDrawable = when {
-                playerFullscreenHelper.isFullscreen -> R.drawable.ic_fullscreen_exit_white_32dp
-                else -> R.drawable.ic_fullscreen_enter_white_32dp
-            }
-            fullscreenSwitcher.setImageResource(fullscreenDrawable)
+            updateFullscreenSwitcherIcon()
 
             insets
         }
@@ -211,11 +217,42 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
 
         playerLockScreenHelper = PlayerLockScreenHelper(this, playerBinding, orientationListener)
         playerGestureHelper = PlayerGestureHelper(this, playerBinding, playerLockScreenHelper)
+        setupPlayerFoldHelper()
 
         // Handle fullscreen switcher
         fullscreenSwitcher.setOnClickListener {
             toggleFullscreen()
         }
+    }
+
+    private fun setupPlayerFoldHelper() {
+        playerFoldHelper = PlayerFoldHelper(
+            fragment = this,
+            playerBinding = playerBinding,
+            playerControlsView = playerControlsView,
+            toolbar = toolbar,
+            onTabletopChanged = { tabletop ->
+                if (tabletop) {
+                    requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                    playerFullscreenHelper.enableFullscreen()
+                    playerGestureHelper.onTabletopChanged(true)
+                } else {
+                    playerGestureHelper.onTabletopChanged(false)
+                    updateFullscreenState(resources.configuration)
+                }
+                updateFullscreenSwitcherIcon()
+            },
+        ).also { it.start(viewLifecycleOwner) }
+    }
+
+    private fun updateFullscreenSwitcherIcon() {
+        val fullscreenDrawable = when {
+            isTabletopMode && isFlexExpanded -> R.drawable.ic_fullscreen_exit_white_32dp
+            isTabletopMode -> R.drawable.ic_fullscreen_enter_white_32dp
+            playerFullscreenHelper.isFullscreen -> R.drawable.ic_fullscreen_exit_white_32dp
+            else -> R.drawable.ic_fullscreen_enter_white_32dp
+        }
+        fullscreenSwitcher.setImageResource(fullscreenDrawable)
     }
 
     override fun onStart() {
@@ -227,7 +264,7 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
         super.onResume()
 
         // When returning from another app, fullscreen mode for landscape orientation has to be set again
-        if (isLandscape()) {
+        if (!isTabletopMode && isLandscape()) {
             playerFullscreenHelper.enableFullscreen()
         }
 
@@ -243,6 +280,12 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
     private fun updateFullscreenState(configuration: Configuration) {
         // Do not handle any orientation changes while being in Picture-in-Picture mode
         if (AndroidVersion.isAtLeastN && activity?.isInPictureInPictureMode == true) {
+            return
+        }
+
+        // Tabletop / Flex Mode manages its own chrome; don't force landscape fullscreen
+        if (isTabletopMode) {
+            playerFullscreenHelper.enableFullscreen()
             return
         }
 
@@ -263,8 +306,15 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
      *
      * If playing a portrait video, this just hides the status and navigation bars.
      * For landscape videos, additionally the screen gets rotated.
+     * In tabletop mode, toggles immersive upper-pane video.
      */
     private fun toggleFullscreen() {
+        if (isTabletopMode) {
+            playerFoldHelper?.toggleFlexExpanded()
+            updateFullscreenSwitcherIcon()
+            return
+        }
+
         val videoTrack = currentVideoStream
         if (videoTrack == null || videoTrack.isLandscape) {
             val current = resources.configuration.orientation
@@ -422,6 +472,8 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        playerFoldHelper?.stop()
+        playerFoldHelper = null
         // Detach player from PlayerView
         playerView.player = null
 

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerGestureHelper.kt
@@ -59,6 +59,11 @@ class PlayerGestureHelper(
     private var isZoomEnabled = false
 
     /**
+     * When true, gestures are limited to the video pane above the hinge (tabletop / Flex Mode).
+     */
+    private var isTabletopMode = false
+
+    /**
      * Tracks a value during a swipe gesture (between multiple onScroll calls).
      * When the gesture starts it's reset to an initial value and gets increased or decreased
      * (depending on the direction) as the gesture progresses.
@@ -137,8 +142,11 @@ class PlayerGestureHelper(
         playerView.context,
         object : GestureDetector.SimpleOnGestureListener() {
             override fun onDoubleTap(e: MotionEvent): Boolean {
+                // Ignore double-taps on the controls pane in tabletop / Flex Mode
+                if (isOutsideVideoPane(e.y)) return false
+
                 val viewWidth = playerView.measuredWidth
-                val viewHeight = playerView.measuredHeight
+                val viewHeight = gestureHeight()
                 val viewCenterX = viewWidth / 2
                 val viewCenterY = viewHeight / 2
                 val isFastForward = e.x.toInt() > viewCenterX
@@ -158,11 +166,11 @@ class PlayerGestureHelper(
                 // Fast-forward/rewind
                 with(fragment) { if (isFastForward) onFastForward() else onRewind() }
 
-                // Cancel previous runnable to not hide controller while seeking
-                playerView.removeCallbacks(hidePlayerViewControllerAction)
-
-                // Ensure controller gets hidden after seeking
-                playerView.postDelayed(hidePlayerViewControllerAction, Constants.DEFAULT_CONTROLS_TIMEOUT_MS.toLong())
+                // Keep controls open in tabletop; otherwise restore normal auto-hide
+                if (!isTabletopMode) {
+                    playerView.removeCallbacks(hidePlayerViewControllerAction)
+                    playerView.postDelayed(hidePlayerViewControllerAction, Constants.DEFAULT_CONTROLS_TIMEOUT_MS.toLong())
+                }
                 return true
             }
 
@@ -192,11 +200,15 @@ class PlayerGestureHelper(
             ): Boolean {
                 if (firstEvent == null) return false
 
+                // Gestures only apply on the video pane in tabletop / Flex Mode
+                if (isOutsideVideoPane(firstEvent.y)) return false
+
                 // Check whether swipe was started in excluded region (vertical)
                 val exclusionSizeVertical = playerView.resources.dip(Constants.SWIPE_GESTURE_EXCLUSION_SIZE_VERTICAL)
+                val paneHeight = gestureHeight()
                 if (
                     firstEvent.y < exclusionSizeVertical ||
-                    firstEvent.y > playerView.height - exclusionSizeVertical
+                    firstEvent.y > paneHeight - exclusionSizeVertical
                 ) {
                     return false
                 }
@@ -314,7 +326,7 @@ class PlayerGestureHelper(
                 val viewCenterX = playerView.measuredWidth / 2
 
                 // Distance to swipe to go from min to max
-                val distanceFull = playerView.measuredHeight * Constants.FULL_SWIPE_RANGE_SCREEN_RATIO
+                val distanceFull = gestureHeight() * Constants.FULL_SWIPE_RANGE_SCREEN_RATIO
                 val ratioChange = distanceY / distanceFull
 
                 if (firstEvent.x.toInt() > viewCenterX) {
@@ -376,7 +388,8 @@ class PlayerGestureHelper(
     private val zoomGestureDetector = ScaleGestureDetector(
         playerView.context,
         object : ScaleGestureDetector.OnScaleGestureListener {
-            override fun onScaleBegin(detector: ScaleGestureDetector): Boolean = fragment.isLandscape()
+            override fun onScaleBegin(detector: ScaleGestureDetector): Boolean =
+                !isTabletopMode && fragment.isLandscape()
 
             override fun onScale(detector: ScaleGestureDetector): Boolean {
                 val scaleFactor = detector.scaleFactor
@@ -444,7 +457,26 @@ class PlayerGestureHelper(
     }
 
     fun handleConfiguration(newConfig: Configuration) {
-        updateZoomMode(fragment.isLandscape(newConfig) && isZoomEnabled)
+        updateZoomMode(!isTabletopMode && fragment.isLandscape(newConfig) && isZoomEnabled)
+    }
+
+    fun onTabletopChanged(enabled: Boolean) {
+        isTabletopMode = enabled
+        if (enabled) {
+            // PlayerFoldHelper owns resizeMode while tabletop
+            isZoomEnabled = false
+        }
+    }
+
+    private fun gestureHeight(): Int {
+        val tabletopHeight = fragment.tabletopVideoPaneHeight
+        return if (isTabletopMode && tabletopHeight > 0) tabletopHeight else playerView.measuredHeight
+    }
+
+    private fun isOutsideVideoPane(y: Float): Boolean {
+        if (!isTabletopMode) return false
+        val paneHeight = fragment.tabletopVideoPaneHeight
+        return paneHeight > 0 && y > paneHeight
     }
 
     private fun updateZoomMode(enabled: Boolean) {

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
@@ -33,8 +33,9 @@ import org.koin.core.component.inject
 import java.util.Locale
 
 /**
- *  Provides a menu UI for audio, subtitle and video stream selection
+ * Provides a menu UI for audio, subtitle and video stream selection
  */
+@Suppress("TooManyFunctions")
 class PlayerMenus(
     private val fragment: PlayerFragment,
     private val playerBinding: FragmentPlayerBinding,
@@ -56,6 +57,7 @@ class PlayerMenus(
     private val qualityButton: View by playerControlsBinding::qualityButton
     private val decoderButton: View by playerControlsBinding::decoderButton
     private val infoButton: View by playerControlsBinding::infoButton
+    private val playbackInfoContainer: View by playerBinding::playbackInfoContainer
     private val playbackInfo: TextView by playerBinding::playbackInfo
     private val audioStreamsMenu: PopupMenu = createAudioStreamsMenu()
     private val subtitlesMenu: PopupMenu = createSubtitlesMenu()
@@ -144,10 +146,15 @@ class PlayerMenus(
             decoderMenu.show()
         }
         infoButton.setOnClickListener {
-            playbackInfo.isVisible = !playbackInfo.isVisible
+            val show = !playbackInfoContainer.isVisible
+            playbackInfoContainer.isVisible = show
+            // Keep controller up while reading/scrolling stream info
+            fragment.suppressControllerAutoHide(show)
         }
-        playbackInfo.setOnClickListener {
-            dismissPlaybackInfo()
+        // Swallow touches so scrolling the info panel doesn't hit player gestures
+        playbackInfoContainer.setOnTouchListener { view, _ ->
+            view.parent?.requestDisallowInterceptTouchEvent(true)
+            false
         }
 
         fragment.setPlayerMenuHelper(playerMenuHelper)
@@ -201,7 +208,6 @@ class PlayerMenus(
         val videoTracksInfo = buildMediaStreamsInfo(
             mediaStreams = listOfNotNull(videoStream),
             prefix = R.string.playback_info_video_streams,
-            maxStreams = MAX_VIDEO_STREAMS_DISPLAY,
             streamSuffix = { stream ->
                 stream.bitRate?.let { bitrate -> " (${formatBitrate(bitrate.toDouble())})" }.orEmpty()
             },
@@ -209,7 +215,6 @@ class PlayerMenus(
         val audioTracksInfo = buildMediaStreamsInfo(
             mediaStreams = audioStreams,
             prefix = R.string.playback_info_audio_streams,
-            maxStreams = MAX_AUDIO_STREAMS_DISPLAY,
             streamSuffix = { stream ->
                 stream.language?.let { lang -> " ($lang)" }.orEmpty()
             },
@@ -257,13 +262,10 @@ class PlayerMenus(
     private fun buildMediaStreamsInfo(
         mediaStreams: List<MediaStream>,
         @StringRes prefix: Int,
-        maxStreams: Int,
         streamSuffix: (MediaStream) -> String,
     ): String = mediaStreams.joinToString(
-        "\n",
-        "${fragment.getString(prefix)}:\n",
-        limit = maxStreams,
-        truncated = fragment.getString(R.string.playback_info_and_x_more, mediaStreams.size - maxStreams),
+        separator = "\n",
+        prefix = "${fragment.getString(prefix)}:\n",
     ) { stream ->
         val title = stream.displayTitle?.takeUnless(String::isEmpty)
             ?: fragment.getString(R.string.playback_info_stream_unknown_title)
@@ -403,7 +405,8 @@ class PlayerMenus(
     }
 
     fun dismissPlaybackInfo() {
-        playbackInfo.isVisible = false
+        playbackInfoContainer.isVisible = false
+        fragment.suppressControllerAutoHide(false)
     }
 
     override fun onDismiss(menu: PopupMenu) {
@@ -429,9 +432,6 @@ class PlayerMenus(
         private const val SPEED_MENU_GROUP = 2
         private const val QUALITY_MENU_GROUP = 3
         private const val DECODER_MENU_GROUP = 4
-
-        private const val MAX_VIDEO_STREAMS_DISPLAY = 3
-        private const val MAX_AUDIO_STREAMS_DISPLAY = 5
 
         private const val BITRATE_MEGA_BIT = 1_000_000
         private const val BITRATE_KILO_BIT = 1_000

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -105,8 +105,8 @@
             android:layout_gravity="center"
             android:visibility="gone" />
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/playback_info"
+        <ScrollView
+            android:id="@+id/playback_info_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|top"
@@ -116,10 +116,20 @@
             android:layout_marginBottom="96dp"
             android:background="@drawable/playback_info_background"
             android:clickable="true"
-            android:padding="16dp"
+            android:fadeScrollbars="false"
+            android:focusable="true"
+            android:maxHeight="360dp"
+            android:scrollbars="vertical"
             android:visibility="gone"
             tools:ignore="KeyboardInaccessibleWidget"
-            tools:visibility="visible" />
+            tools:visibility="visible">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/playback_info"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="16dp" />
+        </ScrollView>
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/unlock_screen_button"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,6 +15,7 @@
     <!-- App colors -->
     <color name="theme_background">#101010</color>
     <color name="playback_controls_background">#60000000</color>
+    <color name="playback_controls_background_flex_immersive">#33000000</color>
     <color name="playback_info_background">#cc000000</color>
     <color name="playback_timebar_unplayed">#333333</color>
 

--- a/app/src/test/java/org/jellyfin/mobile/player/ui/FoldPostureTests.kt
+++ b/app/src/test/java/org/jellyfin/mobile/player/ui/FoldPostureTests.kt
@@ -1,0 +1,18 @@
+package org.jellyfin.mobile.player.ui
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FoldPostureTests {
+    @Test
+    fun foldOffsetYClampsToViewBounds() {
+        assertEquals(1000, FoldPosture.foldOffsetY(viewTopInWindow = 100, viewHeight = 2000, featureBoundsTop = 1100))
+        assertEquals(0, FoldPosture.foldOffsetY(viewTopInWindow = 100, viewHeight = 2000, featureBoundsTop = 50))
+        assertEquals(2000, FoldPosture.foldOffsetY(viewTopInWindow = 100, viewHeight = 2000, featureBoundsTop = 5000))
+    }
+
+    @Test
+    fun foldOffsetYHandlesViewAlignedWithWindow() {
+        assertEquals(540, FoldPosture.foldOffsetY(viewTopInWindow = 0, viewHeight = 1080, featureBoundsTop = 540))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androidx-lifecycle = "2.9.4"
 
 # UI
 androidx-constraintlayout = "2.2.2"
+androidx-window = "1.5.1"
 google-material = "1.13.0"
 androidx-webkit = "1.14.0"
 modernandroidpreferences = "2.4.0-beta2"
@@ -106,6 +107,7 @@ androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-p
 # UI
 google-material = { group = "com.google.android.material", name = "material", version.ref = "google-material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidx-webkit" }
 modernandroidpreferences = { group = "de.maxr1998", name = "modernandroidpreferences", version.ref = "modernandroidpreferences" }
 


### PR DESCRIPTION
## Summary
- Detect Samsung Flex Mode / tabletop posture (`FoldingFeature` HALF_OPENED + horizontal hinge) via Jetpack WindowManager
- Split the native ExoPlayer UI: video above the hinge, controls below (no forced landscape)
- Immersive flex (fullscreen button): fill the upper pane, peek translucent lower controls on tap; title stays on the video corner and controls auto-hide
- Scrollable playback-info panel shows the full stream list without dismissing controls while reading

## Device testing
Tested on a physical **Samsung Galaxy Z Fold5** (`SM-F946B`) with the native ExoPlayer path — a bit older than the latest Fold, but enough to validate real Flex Mode / tabletop posture on device.

Covered on-device:
- Tabletop split (video above crease, controls below)
- Immersive flex toggle + tap-to-peek controls
- Title on the video corner; controls auto-hide
- Scrollable media info panel
- Flat / unfold still behaves as full-bleed

## Test plan
- [x] Tested on Samsung Galaxy Z Fold5 (`SM-F946B`) with native ExoPlayer
- [ ] Closed / cover display: playback unchanged
- [ ] Fully open flat: full-bleed player unchanged
- [ ] Half-open tabletop: video above crease, controls below
- [ ] Immersive flex toggle + tap-to-peek controls
- [ ] Title on video corner; controls auto-hide
- [ ] Info panel scrolls; PiP / lock screen still usable
- [ ] `./gradlew :app:testLibreDebugUnitTest :app:assembleLibreDebug`