### PR TITLE
Require Android 6 at minimum (API 23)

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
+++ b/app/src/main/java/org/jellyfin/mobile/bridge/NativeInterface.kt
@@ -57,7 +57,7 @@ class NativeInterface(private val context: Context) : KoinComponent {
         val clientInfo = apiClient.clientInfo
 
         buildJsonObject {
-            put("deviceId", deviceInfo.id.toString())
+            put("deviceId", deviceInfo.id)
             // normalize the name by removing special characters
             // and making sure it's at least 1 character long
             // otherwise the webui will fail to send it to the server

--- a/app/src/main/java/org/jellyfin/mobile/downloads/DownloadNotificationManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/downloads/DownloadNotificationManager.kt
@@ -4,12 +4,12 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.ServiceInfo
-import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
 import androidx.work.ForegroundInfo
 import org.jellyfin.mobile.R
+import org.jellyfin.mobile.utils.AndroidVersion
 
 class DownloadNotificationManager(
     val context: Context,
@@ -22,7 +22,7 @@ class DownloadNotificationManager(
     private val notificationManager = requireNotNull(context.getSystemService<NotificationManager>())
 
     init {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (AndroidVersion.isAtLeastO) {
             val channel = NotificationChannel(
                 CHANNEL_ID,
                 context.getString(R.string.downloads),
@@ -40,7 +40,7 @@ class DownloadNotificationManager(
             setContentTitle(context.getString(R.string.downloads))
             setSmallIcon(android.R.drawable.stat_sys_download)
         }.build(),
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC else 0,
+        if (AndroidVersion.isAtLeastQ) ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC else 0,
     )
 
     fun downloadFile(id: Long, name: String) = NotificationProgressCallback(context, notificationManager, id, name)

--- a/app/src/main/java/org/jellyfin/mobile/utils/AndroidVersion.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/AndroidVersion.kt
@@ -11,14 +11,6 @@ import android.os.Build
  */
 object AndroidVersion {
     /**
-     * Checks whether the current Android version is at least Android 6 Marshmallow, API 23.
-     *
-     * @see Build.VERSION_CODES.M
-     */
-    inline val isAtLeastM: Boolean
-        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-
-    /**
      * Checks whether the current Android version is at least Android 7 Nougat, API 24.
      *
      * @see Build.VERSION_CODES.N

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -62,10 +62,7 @@ object Constants {
     const val PLAYBACK_MANAGER_COMMAND_VOL_DOWN = "volumeDown"
 
     // Notification
-    val PENDING_INTENT_FLAGS = PendingIntent.FLAG_UPDATE_CURRENT or when {
-        AndroidVersion.isAtLeastM -> PendingIntent.FLAG_IMMUTABLE
-        else -> 0
-    }
+    const val PENDING_INTENT_FLAGS = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     const val MEDIA_NOTIFICATION_CHANNEL_ID = "org.jellyfin.mobile.media.NOW_PLAYING"
     const val DOWNLOAD_NOTIFICATION_CHANNEL_ID = "org.jellyfin.mobile.download.DOWNLOAD_PROGRESS"
 

--- a/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/SystemUtils.kt
@@ -33,26 +33,24 @@ import java.util.UUID
 import kotlin.coroutines.resume
 
 fun WebViewFragment.requestNoBatteryOptimizations(rootView: CoordinatorLayout) {
-    if (AndroidVersion.isAtLeastM) {
-        val powerManager = requireContext().getSystemService(Activity.POWER_SERVICE) as PowerManager
-        if (
-            !appPreferences.ignoreBatteryOptimizations &&
-            !powerManager.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID)
-        ) {
-            Snackbar.make(rootView, R.string.battery_optimizations_message, Snackbar.LENGTH_INDEFINITE).apply {
-                setAction(android.R.string.ok) {
-                    try {
-                        val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
-                        startActivity(intent)
-                    } catch (e: ActivityNotFoundException) {
-                        Timber.e(e)
-                    }
-
-                    // Ignore after the user interacted with the snackbar at least once
-                    appPreferences.ignoreBatteryOptimizations = true
+    val powerManager = requireContext().getSystemService(Activity.POWER_SERVICE) as PowerManager
+    if (
+        !appPreferences.ignoreBatteryOptimizations &&
+        !powerManager.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID)
+    ) {
+        Snackbar.make(rootView, R.string.battery_optimizations_message, Snackbar.LENGTH_INDEFINITE).apply {
+            setAction(android.R.string.ok) {
+                try {
+                    val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                    startActivity(intent)
+                } catch (e: ActivityNotFoundException) {
+                    Timber.e(e)
                 }
-                show()
+
+                // Ignore after the user interacted with the snackbar at least once
+                appPreferences.ignoreBatteryOptimizations = true
             }
+            show()
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Android
 android-compileSdk = "36"
-android-minSdk = "21"
+android-minSdk = "23"
 android-targetSdk = "36"
 
 # Plugins


### PR DESCRIPTION
Starting a months ago Google dropped support for API level 21 and 22 (Android 5 and Android 5.1) in androidx libraries. We'll have to mirror this to be able to update our libraries, including media3.

On Google Play this affects very little users and this chance was announced in the 2.7 blog post.

**Changes**
- Require Android 6 at minimum (API 23)
- Remove code branches for Android 5 <=
- Fix some places not using the AndroidVersion class

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Relates to https://github.com/jellyfin/jellyfin-androidtv/pull/4836