### PR TITLE
Remove custom device profile for web player

### DIFF
--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -104,10 +104,6 @@ function getDeviceProfile(profileBuilder, item) {
         enableMkvProgressive: false
     });
 
-    profile.CodecProfiles = profile.CodecProfiles.filter(function (i) {
-        return i.Type === "Audio";
-    });
-
     profile.CodecProfiles.push({
         Type: "Video",
         Container: "avi",

--- a/app/src/main/assets/native/nativeshell.js
+++ b/app/src/main/assets/native/nativeshell.js
@@ -100,47 +100,7 @@ window.NativeShell = {
 };
 
 function getDeviceProfile(profileBuilder, item) {
-    const profile = profileBuilder({
-        enableMkvProgressive: false
-    });
-
-    profile.CodecProfiles.push({
-        Type: "Video",
-        Container: "avi",
-        Conditions: [
-            {
-                Condition: "NotEquals",
-                Property: "VideoCodecTag",
-                Value: "xvid"
-            }
-        ]
-    });
-
-    profile.CodecProfiles.push({
-        Type: "Video",
-        Codec: "h264",
-        Conditions: [
-            {
-                Condition: "EqualsAny",
-                Property: "VideoProfile",
-                Value: "high|main|baseline|constrained baseline"
-            },
-            {
-                Condition: "LessThanEqual",
-                Property: "VideoLevel",
-                Value: codecCaps.h264MaxLevel
-            }]
-    });
-
-    profile.TranscodingProfiles.reduce(function (profiles, p) {
-        if (p.Type === "Video" && p.CopyTimestamps === true && p.VideoCodec === "h264") {
-            p.AudioCodec += ",ac3";
-            profiles.push(p);
-        }
-        return profiles;
-    }, []);
-
-    return profile;
+    return profileBuilder();
 }
 
 window.NativeShell.AppHost = {
@@ -156,7 +116,6 @@ window.NativeShell.AppHost = {
         return features.includes(command);
     },
     getDeviceProfile,
-    getSyncProfile: getDeviceProfile,
     deviceName() {
         return deviceName;
     },


### PR DESCRIPTION
Whenever a piece of media with multiple audio tracks is directly played in the app using the web player, only the predetermined audio track works. Switching to others updates the selection in the UI, but does nothing.

From my understanding, the web player inside the app should mimic the behavior of the web player in a browser. But right now, media that would switch tracks normally in a browser by getting remuxed, keeps playing in `Stream type: Video` and `Play method: Direct play` modes which depend on the, not supported by WebView, [AudioTrack api](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack).

**Changes**
The proposed fix stops the client from stripping useful CodecProfiles that'd tell the server when remuxing would be appropiate and stop the client from using an unsupported api.

**Code assistance**
LLMs were used to navigate and find some key logic faster in multiple Jellyfin repos.

**Issues**
Would resolve #1502 

