### PR TITLE
Bump compile SDK to 37 (Android 17)

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceCodec.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/deviceprofile/DeviceCodec.kt
@@ -78,7 +78,7 @@ sealed class DeviceCodec(
                         mimeType = mimeType,
                         profiles = profiles,
                         levels = levels,
-                        maxBitrate = codecCapabilities.videoCapabilities.bitrateRange.upper,
+                        maxBitrate = codecCapabilities.videoCapabilities!!.bitrateRange.upper,
                     )
                 }
                 audioCodec != null -> {
@@ -91,9 +91,9 @@ sealed class DeviceCodec(
                         name = audioCodec,
                         mimeType = mimeType,
                         profiles = profiles,
-                        maxBitrate = codecCapabilities.audioCapabilities.bitrateRange.upper,
-                        maxChannels = codecCapabilities.audioCapabilities.maxInputChannelCount,
-                        maxSampleRate = codecCapabilities.audioCapabilities.supportedSampleRateRanges
+                        maxBitrate = codecCapabilities.audioCapabilities!!.bitrateRange.upper,
+                        maxChannels = codecCapabilities.audioCapabilities!!.maxInputChannelCount,
+                        maxSampleRate = codecCapabilities.audioCapabilities!!.supportedSampleRateRanges
                             .maxOfOrNull(Range<Int>::getUpper),
                     )
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Android
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-minSdk = "23"
 android-targetSdk = "36"
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
Bump the compile SDK to 37 (Android 17) while keeping the target SDK at 36 (Android 16). We need some additional changes before we switch the target too, I'm working on those.

Needed to unblock new androidx updates.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
