### PR TITLE
Fix for chromecast staying wrongly "connected" after the chromecast ends the session

### DIFF
--- a/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastConnection.java
+++ b/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastConnection.java
@@ -69,6 +69,17 @@ public class ChromecastConnection {
     @NonNull
     private String appId;
 
+    // Fires for every session end, whoever caused it - our own endSession() or the chromecast receiver (idle timeout, TV home, etc.)
+    // Status must be "stopped", the only value chrome.cast.js reports as dead,
+    // so jellyfin-web correctly drops the player instead of staying "connected"
+    private final SessionListener sessionListener = new SessionListener() {
+        @Override
+        public void onSessionEnded(@NonNull CastSession castSession, int error) {
+            chromecastSession.setSession(null);
+            listener.onSessionEnd(ChromecastUtilities.createSessionObject(castSession, "stopped"));
+        }
+    };
+
     /**
      * Constructor.
      *
@@ -90,6 +101,7 @@ public class ChromecastConnection {
         // CastContext and prep it for searching for a session to rejoin
         // Also adds the receiver update callback
         getContext().addCastStateListener(listener);
+        getSessionManager().addSessionManagerListener(sessionListener, CastSession.class);
     }
 
     /**
@@ -140,10 +152,14 @@ public class ChromecastConnection {
                             // Since we have a receiver we may also have an active session
                             CastSession session = getSessionManager().getCurrentCastSession();
                             // If we do have a session
-                            if (session != null) {
+                            if (session != null && session.isConnected()) {
                                 // Let the client know
                                 chromecastSession.setSession(session);
                                 listener.onSessionRejoin(ChromecastUtilities.createSessionObject(session));
+                            } else {
+                                // Session object can be stale (e.g. receiver-side timeout while backgrounded)
+                                // Let the client know it's dead explicitly
+                                listener.onSessionEnd(ChromecastUtilities.createSessionObject(session, "stopped"));
                             }
                         }
                     }
@@ -341,7 +357,7 @@ public class ChromecastConnection {
     public void requestSession(RequestSessionCallback callback) {
         activity.runOnUiThread(() -> {
             CastSession session = getSession();
-            if (session == null) {
+            if (session == null || !session.isConnected()) {
                 // show the "choose a connection" dialog
 
                 // Add the connection listener callback
@@ -496,15 +512,14 @@ public class ChromecastConnection {
     void endSession(boolean stopCasting, JavascriptCallback callback) {
         activity.runOnUiThread(new Runnable() {
             public void run() {
+                // sessionListener reports the end to JS, this one just resolves the caller
                 getSessionManager().addSessionManagerListener(new SessionListener() {
                     @Override
                     public void onSessionEnded(@NonNull CastSession castSession, int error) {
                         getSessionManager().removeSessionManagerListener(this, CastSession.class);
-                        chromecastSession.setSession(null);
                         if (callback != null) {
                             callback.success();
                         }
-                        listener.onSessionEnd(ChromecastUtilities.createSessionObject(castSession, stopCasting ? "stopped" : "disconnected"));
                     }
                 }, CastSession.class);
 
@@ -515,6 +530,7 @@ public class ChromecastConnection {
 
     public void destroy() {
         getSessionManager().removeSessionManagerListener(newConnectionListener, CastSession.class);
+        getSessionManager().removeSessionManagerListener(sessionListener, CastSession.class);
         handler.removeCallbacksAndMessages(null);
         activity = null;
     }

--- a/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastSession.java
+++ b/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastSession.java
@@ -81,6 +81,7 @@ public class ChromecastSession {
     public void setSession(CastSession castSession) {
         activity.runOnUiThread(() -> {
             if (castSession == null) {
+                session = null;
                 client = null;
                 return;
             }

--- a/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastUtilities.java
+++ b/app/src/proprietary/java/org/jellyfin/mobile/player/cast/ChromecastUtilities.java
@@ -435,6 +435,7 @@ final class ChromecastUtilities {
                 out.put("media", createMediaArray(session));
                 out.put("receiver", createReceiverObject(session));
                 out.put("sessionId", session.getSessionId());
+                out.put("status", session.isConnected() ? "connected" : "disconnected");
             }
         } catch (JSONException | NullPointerException | IllegalStateException ignored) {
         }


### PR DESCRIPTION
**Changes**
- Added SessionManagerListener to forward Chromecast state (in this case session ends) that was previously silently getting dropped. Chromecasts, when timing out / changing scene (e.g. to another app) were not informing jellyfin-web, which would think that the Chromecast was still casting, require the user to force close -> restart the android app to be able to properly cast again.


**Code assistance**
- Code contributed by mix of models including Opus, Sonnet, Composer 2.5 thru Cursor. Also used to explain Chromecast session flow, identify that receiver-side onSessionEnded was never forwarded to jellyfin-web, draft the listener fix, and help trim the change during review.


Locally tested on my own jellyfin server w/ a locally built debug version of the app with my own chromecast, and I have not been able to repro the bug since.

I had to make some non-commited changes locally, adding `slf4j-android` to gradle build files, otherwise my locally compiled version would crash when trying to log through slf4j - hitting `ClassNotFoundException: org.slf4j.LoggerFactory`

**Issues**
Fixes #1852  
This does NOT fix #1842 which I am still digging into.
