### PR TITLE
Fix SDK logging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,6 +178,7 @@ dependencies {
     ksp(libs.androidx.room.compiler)
 
     // Monitoring
+    implementation(libs.slf4j.timber)
     implementation(libs.timber)
 
     // Testing

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ playservices = "22.3.1"
 androidx-room = "2.8.4"
 
 # Monitoring
+slf4j-timber = "0.0.4"
 timber = "5.0.1"
 
 # Testing
@@ -143,6 +144,7 @@ androidx-room-runtime = { group = "androidx.room", name = "room-runtime", versio
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidx-room" }
 
 # Monitoring
+slf4j-timber = { module = "io.github.unveloper:slf4j-timber", version.ref = "slf4j-timber" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
 # Testing


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

Our Kotlin SDK uses slf4j for logging, due to recent dependency updates we no longer had any slf4j dependency in our runtime anymore. This caused the app to crash when the SKD tried to log something.

Introduce the timber-slf4j binding as a dependency to fix this, and route the Kotlin SDK logs to Timber via slf4j. This matches jf-androidtv behavior. I also matched the same (older) version.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
