### PR TITLE
Fix Live TV playback by not sending item ID as media source ID

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/source/MediaSourceResolver.kt
@@ -42,10 +42,14 @@ class MediaSourceResolver(private val apiClient: ApiClient) {
                 mediaInfoApi.getPostedPlaybackInfo(
                     itemId = itemId,
                     data = PlaybackInfoDto(
-                        // We need to remove the dashes so that the server can find the correct media source.
-                        // And if we didn't pass the mediaSourceId, our stream indices would silently get ignored.
+                        // The server filters media sources by this id and returns none when it matches
+                        // nothing. For most items the media source id equals the item id, but for Live TV
+                        // it is the tuner's stream id, so only substitute the item id when stream indices
+                        // are actually requested - otherwise the response would come back empty.
                         // https://github.com/jellyfin/jellyfin/blob/9a35fd673203cfaf0098138b2768750f4818b3ab/Jellyfin.Api/Helpers/MediaInfoHelper.cs#L196-L201
-                        mediaSourceId = mediaSourceId ?: itemId.toString().replace("-", ""),
+                        mediaSourceId = mediaSourceId ?: itemId.toString().replace("-", "").takeIf {
+                            audioStreamIndex != null || subtitleStreamIndex != null
+                        },
                         deviceProfile = deviceProfile,
                         maxStreamingBitrate = maxStreamingBitrate,
                         startTimeTicks = startTime?.inWholeTicks,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
The app was sending the ID as the media source ID. For Live TV, those tow IDs differ, so the filter matched nothing and PlaybackInfo came back with no media sources. This change only sends that substituted ID when an audio or subtitle stream index is actually requested. 

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
The issue was debugged and the fix written by a LLM. Kotlin is not my language of expertise, so if this violates the rules, feel free to close out the PR and someone else can contribute to write the fix. 

I did however build the APK and test it on my device which I was experiencing the issue and confirmed it work and I confirmed I could still watch Movies and TV shows as well. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #2154 
