### PR TITLE
Add setting to automatically play next part in multi-part media

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
+++ b/app/src/main/java/org/jellyfin/mobile/app/AppPreferences.kt
@@ -128,6 +128,9 @@ class AppPreferences(context: Context) {
     val exoPlayerNetworkBuffer: String
         get() = sharedPreferences.getString(Constants.PREF_EXOPLAYER_NETWORK_BUFFER, Constants.NETWORK_BUFFER_AUTO)!!
 
+    val autoPlayNextPart: Boolean
+        get() = sharedPreferences.getBoolean(Constants.PREF_AUTO_PLAY_NEXT_PART, true)
+
     @ExternalPlayerPackage
     var externalPlayerApp: String
         get() = sharedPreferences.getString(Constants.PREF_EXTERNAL_PLAYER_APP, ExternalPlayerPackage.SYSTEM_DEFAULT)!!

--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -761,7 +761,8 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
                 }
                 Player.STATE_ENDED -> {
                     reportPlaybackStop()
-                    if (!autoPlayNextEpisodeEnabled || !queueManager.next()) {
+                    val shouldAutoPlayNext = autoPlayNextEpisodeEnabled || (appPreferences.autoPlayNextPart && queueManager.isNextItemSameEpisode())
+                    if (!shouldAutoPlayNext || !queueManager.next()) {
                         releasePlayer()
                     }
                 }

--- a/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/queue/QueueManager.kt
@@ -12,6 +12,7 @@ import androidx.media3.exoplayer.source.MergingMediaSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jellyfin.mobile.data.dao.DownloadDao
+import org.jellyfin.mobile.data.dao.UserDao
 import org.jellyfin.mobile.downloads.DownloadFileType
 import org.jellyfin.mobile.player.PlayerException
 import org.jellyfin.mobile.player.PlayerViewModel
@@ -23,9 +24,13 @@ import org.jellyfin.mobile.player.source.LocalJellyfinMediaSource
 import org.jellyfin.mobile.player.source.MediaSourceResolver
 import org.jellyfin.mobile.player.source.PlaybackDetails
 import org.jellyfin.mobile.player.source.RemoteJellyfinMediaSource
+import org.jellyfin.mobile.app.AppPreferences
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
+import org.jellyfin.sdk.api.operations.UserLibraryApi
 import org.jellyfin.sdk.api.operations.VideosApi
+import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.MediaProtocol
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamProtocol
@@ -44,6 +49,9 @@ class QueueManager(
 ) : KoinComponent {
     private val apiClient: ApiClient = get()
     private val videosApi: VideosApi = apiClient.videosApi
+    private val userLibraryApi: UserLibraryApi = apiClient.userLibraryApi
+    private val appPreferences: AppPreferences by inject()
+    private val userDao: UserDao by inject()
     private val mediaSourceResolver: MediaSourceResolver by inject()
     private val deviceProfileBuilder: DeviceProfileBuilder by inject()
     private val downloadDao: DownloadDao by inject()
@@ -51,6 +59,8 @@ class QueueManager(
 
     private var currentQueue: List<UUID> = emptyList()
     private var currentQueueIndex: Int = 0
+
+    private val currentSiblingIds = mutableSetOf<UUID>()
 
     private var playbackRetries = 0
     private var lastPlaybackError = 0L
@@ -68,14 +78,23 @@ class QueueManager(
      * @return an error of type [PlayerException] or null on success.
      */
     suspend fun initializePlaybackQueue(playOptions: PlayOptions): PlayerException? {
-        currentQueue = playOptions.ids
-        currentQueueIndex = playOptions.startIndex
-        resetPlaybackFallback()
-
         val itemId = when {
-            currentQueue.isNotEmpty() -> currentQueue[currentQueueIndex]
+            playOptions.ids.isNotEmpty() -> playOptions.ids[playOptions.startIndex]
             else -> playOptions.mediaSourceId?.toUUIDOrNull()
         } ?: return PlayerException.InvalidPlayOptions()
+
+        // Initialize queue and siblings
+        val initialIds = playOptions.ids.toMutableList()
+        if (initialIds.isEmpty()) initialIds.add(itemId)
+
+        currentQueue = initialIds
+        currentQueueIndex = if (playOptions.ids.isNotEmpty()) playOptions.startIndex else 0
+        resetPlaybackFallback()
+
+        // Populate siblings and expand queue if it's a multi-part
+        if (appPreferences.autoPlayNextPart) {
+            refreshSiblingIds(itemId)
+        }
 
         when (playOptions.playFromDownloads) {
             true -> playOptions.mediaSourceId?.let {
@@ -151,6 +170,10 @@ class QueueManager(
         enableDirectPlay: Boolean? = null,
         enableDirectStream: Boolean? = null,
     ): PlayerException? {
+        if (appPreferences.autoPlayNextPart) {
+            refreshSiblingIds(itemId)
+        }
+
         mediaSourceResolver.resolveMediaSource(
             itemId = itemId,
             mediaSourceId = mediaSourceId,
@@ -301,6 +324,74 @@ class QueueManager(
             null -> return false
         }
         return true
+    }
+
+    /**
+     * Checks if the next item in the queue is a part of the same episode or movie as the current item.
+     */
+    fun isNextItemSameEpisode(): Boolean {
+        if (!hasNext()) return false
+        val nextId = currentQueue[currentQueueIndex + 1]
+
+        val isSibling = currentSiblingIds.contains(nextId)
+        Timber.d("Checking if next item %s is a sibling: %b", nextId, isSibling)
+        return isSibling
+    }
+
+    private suspend fun refreshSiblingIds(itemId: UUID) {
+        // If the item is already a known sibling, we don't need to refresh
+        if (currentSiblingIds.contains(itemId)) return
+
+        currentSiblingIds.clear()
+        currentSiblingIds.add(itemId)
+
+        val siblings = getAdditionalParts(itemId)
+        if (siblings.isNotEmpty()) {
+            val siblingIds = siblings.map { it.id }
+            currentSiblingIds.addAll(siblingIds)
+            Timber.d("Found %d siblings for item %s: %s", siblings.size, itemId, siblingIds)
+
+            // Expand the current queue with missing siblings if we are in a single-item or small queue
+            // and the next items aren't already the siblings.
+            // This ensures Part 2, 3 etc are available in the queue.
+            expandQueueWithSiblings(siblingIds)
+        }
+    }
+
+    private fun expandQueueWithSiblings(siblingIds: List<UUID>) {
+        val newQueue = currentQueue.toMutableList()
+        var changed = false
+
+        // Find where to insert siblings (immediately after current item)
+        var insertIndex = currentQueueIndex + 1
+
+        siblingIds.forEach { id ->
+            if (!newQueue.contains(id)) {
+                newQueue.add(insertIndex++, id)
+                changed = true
+            }
+        }
+
+        if (changed) {
+            currentQueue = newQueue
+            Timber.d("Expanded queue with siblings. New size: %d", currentQueue.size)
+        }
+    }
+
+    private suspend fun getAdditionalParts(itemId: UUID): List<BaseItemDto> {
+        val userId = appPreferences.currentUserId?.let {
+            withContext(Dispatchers.IO) {
+                userDao.getUser(it)?.userId
+            }
+        }
+        return try {
+            withContext(Dispatchers.IO) {
+                videosApi.getAdditionalPart(itemId, userId).content.items.orEmpty()
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to fetch additional parts for $itemId")
+            emptyList()
+        }
     }
 
     /**

--- a/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/settings/SettingsFragment.kt
@@ -157,6 +157,12 @@ class SettingsFragment : Fragment(), BackPressInterceptor {
             enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
             defaultValue = true
         }
+        checkBox(Constants.PREF_AUTO_PLAY_NEXT_PART) {
+            titleRes = R.string.pref_exoplayer_auto_play_next_part
+            summaryRes = R.string.pref_exoplayer_auto_play_next_part_summary
+            enabled = appPreferences.videoPlayerType == VideoPlayerType.EXO_PLAYER
+            defaultValue = true
+        }
         backgroundAudioPreference = checkBox(Constants.PREF_EXOPLAYER_ALLOW_BACKGROUND_AUDIO) {
             titleRes = R.string.pref_exoplayer_allow_background_audio
             summaryRes = R.string.pref_exoplayer_allow_background_audio_summary

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -41,6 +41,7 @@ object Constants {
     const val PREF_EXOPLAYER_ALLOW_HORIZONTAL_GESTURE = "pref_exoplayer_allow_horizontal_gesture"
     const val PREF_EXOPLAYER_DIRECT_PLAY_ASS = "pref_exoplayer_direct_play_ass"
     const val PREF_EXOPLAYER_NETWORK_BUFFER = "pref_exoplayer_network_buffer"
+    const val PREF_AUTO_PLAY_NEXT_PART = "pref_auto_play_next_part"
     const val NETWORK_BUFFER_AUTO = "auto"
     const val NETWORK_BUFFER_LARGE = "large"
     const val NETWORK_BUFFER_EXTRA_LARGE = "extra_large"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,8 @@
     <string name="pref_exoplayer_remember_brightness">Remember display brightness</string>
     <string name="pref_exoplayer_allow_press_speed_up">Hold to speed up</string>
     <string name="pref_exoplayer_allow_press_speed_up_summary">Touch and hold the screen to temporarily speed up playback</string>
+    <string name="pref_exoplayer_auto_play_next_part">Automatically play next part</string>
+    <string name="pref_exoplayer_auto_play_next_part_summary">Automatically play the next part of a multi-part episode or movie</string>
     <string name="pref_exoplayer_allow_background_audio">Background audio</string>
     <string name="pref_exoplayer_allow_background_audio_summary">Allow playing videos in the background with audio-only</string>
     <string name="pref_exoplayer_allow_horizontal_gesture">Horizontal gestures</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ android-minSdk = "23"
 android-targetSdk = "36"
 
 # Plugins
-android-plugin = "9.4.0"
+android-plugin = "9.3.0"
 kotlin = "2.4.10"
 kotlin-ksp = "2.3.11"
 detekt = "1.23.8"


### PR DESCRIPTION
**Add setting to automatically play next part in multi-part media**

**Changes**
Added a new client-side setting to automatically play the next part in a multi-part episode or movie, even when general auto-play is disabled. The implementation integrates with the Jellyfin "Additional Parts" API to proactively identify and queue all related segments of a media item. Playback logic was updated to use a sibling-tracking mechanism to ensure seamless transitions through all parts of a file group.

**Code assistance**
This feature was implemented with the help of Android Studio's AI assistant. The AI contributed to the design of the sibling-tracking cache, the integration with the SDK's VideosApi for part discovery, and provided debugging guidance to ensure that playback expands and advances through the entire queue correctly.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
