### PR TITLE
Reset playback speed automatically near the live edge

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/PlayerViewModel.kt
@@ -134,6 +134,9 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
     private val _error = MutableLiveData<String>()
     val error: LiveData<String> = _error
 
+    private val _playbackSpeed = MutableLiveData<Float>()
+    val playbackSpeed: LiveData<Float> = _playbackSpeed
+
     private val eventLogger = EventLogger()
     private var analyticsCollector = buildAnalyticsCollector()
     private val initialTracksSelected = AtomicBoolean(false)
@@ -144,6 +147,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
     private var chapterMarkingUpdateJob: Job? = null
     private var skipMediaSegmentUpdateJob: Job? = null
     private var fallbackRetryJob: Job? = null
+    private var liveCatchUpJob: Job? = null
 
     /**
      * Returns the current ExoPlayer instance or null
@@ -365,6 +369,40 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
 
     private fun stopSkipMediaSegmentUpdates() {
         skipMediaSegmentUpdateJob?.cancel()
+    }
+
+    /**
+     * While a live stream is played back faster than normal speed (e.g. to catch up after seeking behind
+     * the live edge), regularly check how far the current position is from the live edge. Once it gets
+     * close enough, reset the speed to normal instead of letting the player run out of buffer and stall,
+     * mirroring the behavior of other live-streaming clients (e.g. YouTube).
+     */
+    private fun startLiveCatchUpUpdates() {
+        liveCatchUpJob = viewModelScope.launch {
+            while (true) {
+                delay(Constants.LIVE_CATCH_UP_CHECK_INTERVAL_MS)
+                playerOrNull?.resetSpeedIfCaughtUpToLiveEdge()
+            }
+        }
+    }
+
+    private fun stopLiveCatchUpUpdates() {
+        liveCatchUpJob?.cancel()
+    }
+
+    private fun Player.resetSpeedIfCaughtUpToLiveEdge() {
+        if (!isCurrentMediaItemLive || playbackParameters.speed <= 1f) return
+        if (duration == C.TIME_UNSET) return
+
+        // The HLS live streams served by Jellyfin don't expose enough info for ExoPlayer to compute
+        // currentLiveOffset, so use the distance to the end of the live window (the encoder's frontier)
+        // as a proxy for the real live edge: at faster than real-time speed, this shrinks as we catch up.
+        val distanceToEdge = duration - currentPosition
+        if (distanceToEdge in 0..Constants.LIVE_CATCH_UP_EDGE_THRESHOLD_MS) {
+            playbackParameters = playbackParameters.withSpeed(1f)
+            playSpeed = 1f
+            _playbackSpeed.postValue(1f)
+        }
     }
 
     /**
@@ -682,6 +720,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
         val parameters = player.playbackParameters
         if (parameters.speed != speed) {
             player.playbackParameters = parameters.withSpeed(speed)
+            _playbackSpeed.value = speed
             return true
         }
         return false
@@ -731,6 +770,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
         // Setup or stop regular progress updates
         if (playbackState == Player.STATE_READY && playWhenReady) {
             startProgressUpdates()
+            startLiveCatchUpUpdates()
             if (!playerMenuHelper?.chapterMarkings?.markings.isNullOrEmpty()) {
                 startChapterMarkingUpdates()
             }
@@ -739,6 +779,7 @@ class PlayerViewModel(application: Application) : AndroidViewModel(application),
             }
         } else {
             stopProgressUpdates()
+            stopLiveCatchUpUpdates()
             stopChapterMarkingUpdates()
             stopSkipMediaSegmentUpdates()
         }

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerFragment.kt
@@ -114,6 +114,9 @@ class PlayerFragment : Fragment(), BackPressInterceptor {
         viewModel.decoderType.observe(this) { type ->
             playerMenus?.updatedSelectedDecoder(type)
         }
+        viewModel.playbackSpeed.observe(this) { speed ->
+            playerMenus?.updateSelectedSpeed(speed)
+        }
         viewModel.error.observe(this) { message ->
             val safeMessage = message.ifEmpty { requireContext().getString(R.string.player_error_unspecific_exception) }
             requireContext().toast(safeMessage)

--- a/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
+++ b/app/src/main/java/org/jellyfin/mobile/player/ui/PlayerMenus.kt
@@ -354,6 +354,11 @@ class PlayerMenus(
         decoderMenu.menu.findItem(type.ordinal).isChecked = true
     }
 
+    fun updateSelectedSpeed(speed: Float) {
+        val step = (speed / SPEED_MENU_STEP_SIZE).toInt()
+        speedMenu.menu.findItem(step)?.isChecked = true
+    }
+
     private fun buildMenuItems(
         menu: Menu,
         groupId: Int,

--- a/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/Constants.kt
@@ -123,6 +123,8 @@ object Constants {
     const val FULL_SWIPE_RANGE_SCREEN_RATIO = 0.66f
     const val SCREEN_BRIGHTNESS_MAX = 255
     const val HOLD_SPEEDUP_MULTIPLIER = 3f
+    const val LIVE_CATCH_UP_CHECK_INTERVAL_MS = 250L
+    const val LIVE_CATCH_UP_EDGE_THRESHOLD_MS = 3000L // lower measured to reliably stall due to bursty segment delivery
     const val ZOOM_SCALE_BASE = 1f
     const val ZOOM_SCALE_THRESHOLD = 0.01f
     val ASPECT_RATIO_16_9 = Rational(16, 9)


### PR DESCRIPTION
**Changes**
When accelerating playback to catch up to a live TV stream, the integrated player kept the increased speed until it ran out of buffer and stalled, then resumed at the same speed once buffered again, repeating indefinitely. This monitors the remaining distance to the live edge while playing faster than normal and resets the speed to 1x once close, similar to how other live-streaming clients (e.g. YouTube) behave.

**Code assistance**
Code assistance (LLM) was used to investigate and implement this change, including on-device log analysis to tune the catch-up threshold. All changes were reviewed and tested on-device by me before submitting.

**Issues**
Fixes #2178
