### PR TITLE
Support external URLs

### DIFF
--- a/app/src/main/java/org/jellyfin/mobile/utils/WebViewUtils.kt
+++ b/app/src/main/java/org/jellyfin/mobile/utils/WebViewUtils.kt
@@ -72,6 +72,7 @@ private fun WebView.getDefaultUserAgentString(): String {
 fun WebSettings.applyDefault() {
     javaScriptEnabled = true
     domStorageEnabled = true
+    setSupportMultipleWindows(true)
 }
 
 /**

--- a/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebChromeClient.kt
+++ b/app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebChromeClient.kt
@@ -1,12 +1,17 @@
 package org.jellyfin.mobile.webapp
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Message
 import android.util.Log
 import android.webkit.ConsoleMessage
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import androidx.core.net.toUri
+import androidx.webkit.WebViewClientCompat
 import timber.log.Timber
 
 class JellyfinWebChromeClient(
@@ -29,6 +34,35 @@ class JellyfinWebChromeClient(
             consoleMessage.lineNumber(),
         )
 
+        return true
+    }
+
+    override fun onCreateWindow(view: WebView, isDialog: Boolean, isUserGesture: Boolean, resultMsg: Message): Boolean {
+        val transport = resultMsg.obj as? WebView.WebViewTransport ?: return false
+
+        val windowWebView = WebView(view.context)
+        windowWebView.webViewClient = object : WebViewClientCompat() {
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                return openExternalUrl(view.context, request.url.toString())
+            }
+
+            @Deprecated("Deprecated in Android")
+            override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+                return openExternalUrl(view.context, url)
+            }
+        }
+        transport.webView = windowWebView
+        resultMsg.sendToTarget()
+
+        return true
+    }
+
+    private fun openExternalUrl(context: Context, url: String): Boolean {
+        // Some web views can try to open empty popups, we cannot infer an URL from those easily so ignore them
+        if (url == "about:blank") return false
+
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+        context.startActivity(intent)
         return true
     }
 


### PR DESCRIPTION
**Changes**

Enable multiple window support in the webview and create intents to open them externally. This allows any `<a target="_blank" />` element or `window.open()` JavaScript calls to open a page outside of the app.

The method to get the URL is a bit hacky, but this is the only real solution as the `onCreateWindow` function does not receive the URL itself, it's hidden in a transport.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**

Fixes #984